### PR TITLE
Updating maven-assembly-plugin version to 2.5.3

### DIFF
--- a/modules/distribution/product/pom.xml
+++ b/modules/distribution/product/pom.xml
@@ -213,6 +213,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
+                <version>2.4</version>
                 <executions>
                     <execution>
                         <id>pre_dist</id>

--- a/modules/distribution/product/pom.xml
+++ b/modules/distribution/product/pom.xml
@@ -213,7 +213,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.4</version>
+                <version>2.5.3</version>
                 <executions>
                     <execution>
                         <id>pre_dist</id>


### PR DESCRIPTION
Updating maven-assembly-plugin to latest version to 2.5.3 in the pom to prevent issue in packs created using plugin version 2.5.1.

When attempting to unzip product packs create using maven-assembly-plugin 2.5.1 following error is thrown, 
'unpack failed: file mode must be 3 or 4 characters'.