### PR TITLE
Fix related to APIMANAGER-3941

### DIFF
--- a/modules/distribution/product/src/main/conf/axis2.xml
+++ b/modules/distribution/product/src/main/conf/axis2.xml
@@ -166,10 +166,10 @@
                          class="org.apache.axis2.format.PlainTextFormatter"/>
 
         <!--JSON Message Formatters-->
-	<messageFormatter contentType="application/json"
-                          class="org.apache.synapse.commons.json.JsonFormatter"/>
-        <!--messageFormatter contentType="application/json"
-                          class="org.apache.synapse.commons.json.JsonStreamFormatter"/-->
+	    <!--messageFormatter contentType="application/json"
+                          class="org.apache.synapse.commons.json.JsonFormatter"/-->
+        <messageFormatter contentType="application/json"
+                          class="org.apache.synapse.commons.json.JsonStreamFormatter"/>
         <messageFormatter contentType="application/json/badgerfish"
                           class="org.apache.axis2.json.JSONBadgerfishMessageFormatter"/>
         <messageFormatter contentType="text/javascript"
@@ -228,10 +228,10 @@
                         class="org.apache.axis2.format.PlainTextBuilder"/>
 
         <!--JSON Message Builders-->
-	<messageBuilder contentType="application/json"
-                        class="org.apache.synapse.commons.json.JsonBuilder"/>
-        <!--messageBuilder contentType="application/json"
-                        class="org.apache.synapse.commons.json.JsonStreamBuilder"/-->
+	    <!--messageBuilder contentType="application/json"
+                        class="org.apache.synapse.commons.json.JsonBuilder"/-->
+        <messageBuilder contentType="application/json"
+                        class="org.apache.synapse.commons.json.JsonStreamBuilder"/>
         <messageBuilder contentType="application/json/badgerfish"
                         class="org.apache.axis2.json.JSONBadgerfishOMBuilder"/>
         <messageBuilder contentType="text/javascript"

--- a/modules/distribution/product/src/main/conf/synapse-configs/default/proxy-services/WorkflowCallbackService.xml
+++ b/modules/distribution/product/src/main/conf/synapse-configs/default/proxy-services/WorkflowCallbackService.xml
@@ -19,7 +19,7 @@
          </send>
       </inSequence>
       <outSequence>
-         <property name="messageType" value="text/xml" scope="axis2" type="STRING"/>
+         <property name="messageType" value="application/json" scope="axis2" type="STRING"/>
          <send/>
       </outSequence>
    </target>


### PR DESCRIPTION
The above issue was fixed by switching the JSON builder and formatter to **org.apache.synapse.commons.json.JsonStreamFormatter** and **org.apache.synapse.commons.json.JsonStreamBuilder** respectively. As a consequence of doing this, the WorkflowCallbackService.xml proxy services messageType property in its outSequence was changed to **application/json** which was required in order to be compatible with the new JSON formatter and builder that was enabled, since the outSequence actually receives a JSON.