### PR TITLE
Fix for : APIMANAGER-4238

### DIFF
--- a/modules/distribution/resources/default-tiers/default-app-tiers.xml
+++ b/modules/distribution/resources/default-tiers/default-app-tiers.xml
@@ -21,11 +21,6 @@
                         </throttle:Attributes>
                         </wsp:Policy>
                         -->
-                        <wsp:Policy>
-                        <throttle:Attributes>
-                            <throttle:IsPaid>false</throttle:IsPaid>
-                        </throttle:Attributes>
-                        </wsp:Policy>
                     </wsp:Policy>
                 </throttle:Control>
             </wsp:Policy>
@@ -50,11 +45,6 @@
                         </throttle:Attributes>
                         </wsp:Policy>
                         -->
-                        <wsp:Policy>
-                            <throttle:Attributes>
-                                <throttle:IsPaid>false</throttle:IsPaid>
-                            </throttle:Attributes>
-                        </wsp:Policy>
                     </wsp:Policy>
                 </throttle:Control>
             </wsp:Policy>
@@ -79,11 +69,6 @@
                         </throttle:Attributes>
                         </wsp:Policy>
                         -->
-                        <wsp:Policy>
-                            <throttle:Attributes>
-                                <throttle:IsPaid>false</throttle:IsPaid>
-                            </throttle:Attributes>
-                        </wsp:Policy>
                     </wsp:Policy>
                 </throttle:Control>
             </wsp:Policy>
@@ -108,11 +93,6 @@
                         </throttle:Attributes>
                         </wsp:Policy>
                         -->
-                        <wsp:Policy>
-                            <throttle:Attributes>
-                                <throttle:IsPaid>false</throttle:IsPaid>
-                            </throttle:Attributes>
-                        </wsp:Policy>
                     </wsp:Policy>
                 </throttle:Control>
             </wsp:Policy>

--- a/modules/distribution/resources/default-tiers/default-res-tiers.xml
+++ b/modules/distribution/resources/default-tiers/default-res-tiers.xml
@@ -21,11 +21,6 @@
                         </throttle:Attributes>
                         </wsp:Policy>
                         -->
-                        <wsp:Policy>
-                        <throttle:Attributes>
-                            <throttle:IsPaid>false</throttle:IsPaid>
-                        </throttle:Attributes>
-                        </wsp:Policy>
                     </wsp:Policy>
                 </throttle:Control>
             </wsp:Policy>
@@ -50,11 +45,6 @@
                         </throttle:Attributes>
                         </wsp:Policy>
                         -->
-                        <wsp:Policy>
-                            <throttle:Attributes>
-                                <throttle:IsPaid>false</throttle:IsPaid>
-                            </throttle:Attributes>
-                        </wsp:Policy>
                     </wsp:Policy>
                 </throttle:Control>
             </wsp:Policy>
@@ -79,11 +69,6 @@
                         </throttle:Attributes>
                         </wsp:Policy>
                         -->
-                        <wsp:Policy>
-                            <throttle:Attributes>
-                                <throttle:IsPaid>false</throttle:IsPaid>
-                            </throttle:Attributes>
-                        </wsp:Policy>
                     </wsp:Policy>
                 </throttle:Control>
             </wsp:Policy>

--- a/modules/distribution/resources/default-tiers/default-tiers.xml
+++ b/modules/distribution/resources/default-tiers/default-tiers.xml
@@ -21,11 +21,6 @@
                         </throttle:Attributes>
                         </wsp:Policy>
                         -->
-                        <wsp:Policy>
-                        <throttle:Attributes>
-                            <throttle:IsPaid>false</throttle:IsPaid>
-                        </throttle:Attributes>
-                        </wsp:Policy>
                     </wsp:Policy>
                 </throttle:Control>
             </wsp:Policy>
@@ -50,11 +45,6 @@
                         </throttle:Attributes>
                         </wsp:Policy>
                         -->
-                        <wsp:Policy>
-                            <throttle:Attributes>
-                                <throttle:IsPaid>false</throttle:IsPaid>
-                            </throttle:Attributes>
-                        </wsp:Policy>
                     </wsp:Policy>
                 </throttle:Control>
             </wsp:Policy>
@@ -79,11 +69,6 @@
                         </throttle:Attributes>
                         </wsp:Policy>
                         -->
-                        <wsp:Policy>
-                            <throttle:Attributes>
-                                <throttle:IsPaid>false</throttle:IsPaid>
-                            </throttle:Attributes>
-                        </wsp:Policy>
                     </wsp:Policy>
                 </throttle:Control>
             </wsp:Policy>
@@ -108,11 +93,6 @@
                         </throttle:Attributes>
                         </wsp:Policy>
                         -->
-                        <wsp:Policy>
-                            <throttle:Attributes>
-                                <throttle:IsPaid>false</throttle:IsPaid>
-                            </throttle:Attributes>
-                        </wsp:Policy>
                     </wsp:Policy>
                 </throttle:Control>
             </wsp:Policy>


### PR DESCRIPTION
This will fix : isPaid attribute is being shown on the UI of the Subscribe page.
Please refer : https://github.com/wso2/carbon-apimgt/pull/1315 as well.