### PR TITLE
Revert "Removed Calculator API webapp getting packaged in the product"

### DIFF
--- a/modules/distribution/product/src/main/assembly/bin.xml
+++ b/modules/distribution/product/src/main/assembly/bin.xml
@@ -479,6 +479,18 @@
             </includes>
         </fileSet>
 
+
+        <!-- Copy sample calculator api webapp-->
+        <fileSet>
+            <directory>
+                ../../p2-profile/product/target/wso2carbon-core-${carbon.platform.version}/repository/deployment/server/webapps
+            </directory>
+            <outputDirectory>${pom.artifactId}-${pom.version}/repository/deployment/server/webapps</outputDirectory>
+            <includes>
+                <include>am#sample#calculator#v1.war</include>
+            </includes>
+        </fileSet>
+
         <!-- Copy sample pizzashack api webapp-->
         <fileSet>
             <directory>


### PR DESCRIPTION
Reverts wso2/product-apim#798 since Calculator API war is required for tests.