### PR TITLE
Removing API creation duplicated test methods

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/APIPublishingAndVisibilityInStoreTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/APIPublishingAndVisibilityInStoreTestCase.java
@@ -83,7 +83,7 @@ public class APIPublishingAndVisibilityInStoreTestCase extends APIManagerLifecyc
 
 
     @Test(groups = {"wso2.am"}, description = "Create a API and  check its availability in Publisher.")
-    public void testAPICreation() throws APIManagerIntegrationTestException {
+    public void testAvailabilityOfAPIInPublisher() throws APIManagerIntegrationTestException {
         //Create APi
         HttpResponse createAPIResponse = apiPublisherClientUser1.addAPI(apiCreationRequestBean);
         assertEquals(createAPIResponse.getResponseCode(), HTTP_RESPONSE_CODE_OK,
@@ -101,7 +101,7 @@ public class APIPublishingAndVisibilityInStoreTestCase extends APIManagerLifecyc
 
 
     @Test(groups = {"wso2.am"}, description = "Check the visibility of API in Store before the API publish. " +
-            "it should not be available in store.", dependsOnMethods = "testAPICreation")
+            "it should not be available in store.", dependsOnMethods = "testAvailabilityOfAPIInPublisher")
     public void testVisibilityOfAPIInStoreBeforePublishing() throws APIManagerIntegrationTestException {
         //Verify the API in API Store : API should not be available in the store.
         List<APIIdentifier> apiStoreAPIIdentifierList =

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/APITagVisibilityByRoleTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/APITagVisibilityByRoleTestCase.java
@@ -101,7 +101,7 @@ public class APITagVisibilityByRoleTestCase extends APIMIntegrationBaseTest {
     }
 
     @Test(groups = { "wso2.am" }, description = "Create and publish two apis with public and role based visibility")
-    public void testAPICreation() throws Exception {
+    public void testAPICreationWithVisibility() throws Exception {
         String providerName = user.getUserName();
 
         //API request for public visible API
@@ -140,7 +140,7 @@ public class APITagVisibilityByRoleTestCase extends APIMIntegrationBaseTest {
     }
 
     @Test(groups = { "wso2.am" }, description = "Test the API tag visibility as a anonymous user",
-            dependsOnMethods = "testAPICreation")
+            dependsOnMethods = "testAPICreationWithVisibility")
     public void testAPITagVisibilityAnonymousUser() throws Exception {
         requestHeaders.clear();
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/APIVisibilityWithDirectURLTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/APIVisibilityWithDirectURLTestCase.java
@@ -105,8 +105,9 @@ public class APIVisibilityWithDirectURLTestCase extends APIManagerLifecycleBaseT
                         new String[] { INTERNAL_ROLE_SUBSCRIBER_1 }, null);
     }
 
-    @Test(groups = { "wso2.am" }, description = "Sample API creation and publishing")
-    public void testAPICreation() throws Exception {
+    @Test(groups = { "wso2.am" }, description = "Test availability of the api without login")
+    public void testDirectLinkAnonymous() throws Exception {
+
         String providerName = user.getUserName();
 
         apiRequest = new APIRequest(apiName, APIContext, new URL(endpointUrl));
@@ -126,11 +127,7 @@ public class APIVisibilityWithDirectURLTestCase extends APIManagerLifecycleBaseT
         serviceResponse = apiPublisher.changeAPILifeCycleStatus(updateRequest);
         verifyResponse(serviceResponse);
 
-    }
 
-    @Test(groups = { "wso2.am" }, description = "Test availability of the api without login",
-            dependsOnMethods = "testAPICreation")
-    public void testDirectLinkAnonymous() throws Exception {
         HttpResponse a = HttpRequestUtil
                 .doGet(getStoreURLHttps() + "/store/apis/info?name=" + apiName + "&version=" + APIVersion + "&provider="
                         + SUPER_ADMIN_USERNAME + "&tenant=" + SUPER_ADMIN_DOMAIN, requestHeaders);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/NewVersionUpdateTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/NewVersionUpdateTestCase.java
@@ -77,8 +77,9 @@ public class NewVersionUpdateTestCase extends APIMIntegrationBaseTest {
 
     }
 
-    @Test(groups = { "wso2.am" }, description = "Create sample API and set the state as Prototype")
-    public void testAPICreation() throws Exception {
+    @Test(groups = { "wso2.am" }, description = "Create new version and publish")
+
+    public void testAPINewVersionCreation() throws Exception {
         String providerName = user.getUserName();
 
         apiRequest = new APIRequest(apiName, APIContext, new URL(endpointUrl));
@@ -97,13 +98,8 @@ public class NewVersionUpdateTestCase extends APIMIntegrationBaseTest {
         serviceResponse = apiPublisher.changeAPILifeCycleStatus(updateRequest);
         verifyResponse(serviceResponse);
 
-    }
-
-    @Test(groups = { "wso2.am" }, description = "Create new version and publish",
-            dependsOnMethods = "testAPICreation")
-    public void testAPINewVersionCreation() throws Exception {
-        //add test api
-        HttpResponse serviceResponse = apiPublisher
+        //copy test api
+        serviceResponse = apiPublisher
                 .copyAPI(apiRequest.getProvider(), apiRequest.getName(), apiRequest.getVersion(), APIVersionNew, null);
         verifyResponse(serviceResponse);
 
@@ -115,7 +111,7 @@ public class NewVersionUpdateTestCase extends APIMIntegrationBaseTest {
         Assert.assertEquals(version, APIVersionNew);
 
         //publish the api
-        APILifeCycleStateRequest updateRequest = new APILifeCycleStateRequest(apiName, user.getUserName(),
+        updateRequest = new APILifeCycleStateRequest(apiName, user.getUserName(),
                 APILifeCycleState.PUBLISHED);
         serviceResponse = apiPublisher.changeAPILifeCycleStatus(updateRequest);
         verifyResponse(serviceResponse);


### PR DESCRIPTION

1. Removed API Creation test methods within package "org.wso2.am.integration.tests.api.lifecycle" , API creation functionality should not test in each and every test class since that functionality is already tested in package org.wso2.am.integration.tests.api.creation. 
2. Renamed two test method names to reflect actual scenario 