### PR TITLE
Fix NPE when adding property to production endpoint

### DIFF
--- a/modules/distribution/resources/migration/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/_200Specific/ResourceModifier200.java
+++ b/modules/distribution/resources/migration/wso2-api-migration-client/src/main/java/org/wso2/carbon/apimgt/migration/client/_200Specific/ResourceModifier200.java
@@ -173,26 +173,29 @@ public class ResourceModifier200 {
                 Element endpointElement = (Element) sendElement
                         .getElementsByTagNameNS(Constants.SYNAPSE_API_XMLNS, Constants.SYNAPSE_ENDPOINT_XML_ELEMENT)
                         .item(0);
-                NodeList failOverElements = endpointElement
-                        .getElementsByTagName(Constants.SYNAPSE_FAIL_OVER_XML_ELEMENT);
-                NodeList loadBalanceElements = endpointElement
-                        .getElementsByTagName(Constants.SYNAPSE_LOAD_BALANCE_XML_ELEMENT);
-                if (failOverElements.getLength() > 0) {
-                    Element failOverElement = (Element) failOverElements.item(0);
-                    NodeList endpointElements = failOverElement
-                            .getElementsByTagName(Constants.SYNAPSE_ENDPOINT_XML_ELEMENT);
-                    for (int i = 0; i < endpointElements.getLength(); i++) {
-                        addingAddressPropertyToEndpoint((Element) endpointElements.item(i), doc);
+                
+                if (endpointElement != null) {
+                    NodeList failOverElements = endpointElement
+                            .getElementsByTagName(Constants.SYNAPSE_FAIL_OVER_XML_ELEMENT);
+                    NodeList loadBalanceElements = endpointElement
+                            .getElementsByTagName(Constants.SYNAPSE_LOAD_BALANCE_XML_ELEMENT);
+                    if (failOverElements.getLength() > 0) {
+                        Element failOverElement = (Element) failOverElements.item(0);
+                        NodeList endpointElements = failOverElement
+                                .getElementsByTagName(Constants.SYNAPSE_ENDPOINT_XML_ELEMENT);
+                        for (int i = 0; i < endpointElements.getLength(); i++) {
+                            addingAddressPropertyToEndpoint((Element) endpointElements.item(i), doc);
+                        }
+                    } else if (loadBalanceElements.getLength() > 0) {
+                        Element loadBalanceElement = (Element) loadBalanceElements.item(0);
+                        NodeList endpointElements = loadBalanceElement
+                                .getElementsByTagName(Constants.SYNAPSE_ENDPOINT_XML_ELEMENT);
+                        for (int i = 0; i < endpointElements.getLength(); i++) {
+                            addingAddressPropertyToEndpoint((Element) endpointElements.item(i), doc);
+                        }
+                    } else {
+                        addingAddressPropertyToEndpoint(endpointElement, doc);
                     }
-                } else if (loadBalanceElements.getLength() > 0) {
-                    Element loadBalanceElement = (Element) loadBalanceElements.item(0);
-                    NodeList endpointElements = loadBalanceElement
-                            .getElementsByTagName(Constants.SYNAPSE_ENDPOINT_XML_ELEMENT);
-                    for (int i = 0; i < endpointElements.getLength(); i++) {
-                        addingAddressPropertyToEndpoint((Element) endpointElements.item(i), doc);
-                    }
-                } else {
-                    addingAddressPropertyToEndpoint(endpointElement, doc);
                 }
             }
         }


### PR DESCRIPTION
Migration script add property( ENDPOINT_ADDRESS) to production endpoint.When send mediator does not have endpoint element,migration script throws NPE.
e.g when sending back the response from inSequence,send mediator will not have endpoint.
&lt;property name="RESPONSE" value="true"/&gt;
 &lt;header name="To" expression="get-property('ReplyTo')"/&gt;
 &lt;send/&gt;