### PR TITLE
APIMANAGER-5357 issue fixed.

### DIFF
--- a/modules/p2-profile/product/pom.xml
+++ b/modules/p2-profile/product/pom.xml
@@ -2437,8 +2437,11 @@
                                     <id>org.wso2.carbon.module.mgt.server.feature.group</id>
                                     <version>${carbon.deployment.version}</version>
                                 </feature>
+                                <feature>
+                                    <id>org.wso2.carbon.databridge.datapublisher.feature.group</id>
+                                    <version>${carbon.analytics.common.version}</version>
+                                </feature>
 
-                               
                                 <feature>
                                     <id>org.apache.synapse.wso2.feature.group</id>
                                     <version>${carbon.mediation.version}</version>


### PR DESCRIPTION
- Public JIRA URL https://wso2.org/jira/browse/APIMANAGER-5357. The issue was data publisher feature missing in the api-publisher profile, hence throw NoClassDefFoundError at server startup. The missing feature added to the profile generation.