### PR TITLE
update product and carbon version in filter properties

### DIFF
--- a/modules/distribution/product/src/main/assembly/filter.properties
+++ b/modules/distribution/product/src/main/assembly/filter.properties
@@ -1,8 +1,8 @@
 product.name=WSO2 API Manager
 product.key=AM
-product.version=2.0.0
+product.version=2.0.1
 
-carbon.version=4.4.5
-am.version=2.0.0
+carbon.version=4.4.9
+am.version=2.0.1
 default.server.role=APIManager
 bundle.creators=org.wso2.carbon.mediator.bridge.MediatorBundleCreator


### PR DESCRIPTION
- Server startup logs still print as WSO2 API Manager-2.0.0 and updating above properties would change it to WSO2 API Manager-2.0.1