### PR TITLE
added xacml mediation

### DIFF
--- a/modules/p2-profile/product/pom.xml
+++ b/modules/p2-profile/product/pom.xml
@@ -588,6 +588,9 @@
                                 <featureArtifactDef>
                                     org.wso2.carbon.mediation:org.wso2.carbon.mediator.cache.server.feature:${carbon.mediation.version}
                                 </featureArtifactDef>
+                                <featureArtifactDef>
+                                    org.wso2.carbon.mediation:org.wso2.carbon.identity.xacml.mediator.feature:${carbon.mediation.version}
+                                </featureArtifactDef>
 
                             </featureArtifacts>
                         </configuration>
@@ -988,6 +991,10 @@
                                 <feature>
                                     <id>org.wso2.carbon.registry.ws.feature.group</id>
                                     <version>${carbon.registry.version}</version>
+                                </feature>
+                                <feature>
+                                    <id>org.wso2.carbon.identity.xacml.mediator.feature.group</id>
+                                    <version>${carbon.mediation.version}</version>
                                 </feature>
                                 <!--API Management related feature-->
                                 <feature>
@@ -1579,6 +1586,10 @@
                                     <id>org.wso2.carbon.websocket.feature.group</id>
                                     <version>${carbon.mediation.version}</version>
                                 </feature>
+                                <feature>
+                                    <id>org.wso2.carbon.identity.xacml.mediator.feature.group</id>
+                                    <version>${carbon.mediation.version}</version>
+                                </feature>
                             </features>
                         </configuration>
                     </execution>
@@ -1921,6 +1932,10 @@
                                 </feature>
                                 <feature>
                                     <id>org.wso2.carbon.mediator.cache.server.feature.group</id>
+                                    <version>${carbon.mediation.version}</version>
+                                </feature>
+                                <feature>
+                                    <id>org.wso2.carbon.identity.xacml.mediator.feature.group</id>
                                     <version>${carbon.mediation.version}</version>
                                 </feature>
                             </features>


### PR DESCRIPTION
This is the fix for the APIMANAGER-5473. API Manager now comes with the XACML and XACML Mediation in-built with this fix and there is no need to add these features explicitly