### PR TITLE
added xacml mediation

### DIFF
--- a/modules/p2-profile/product/pom.xml
+++ b/modules/p2-profile/product/pom.xml
@@ -590,6 +590,9 @@
                                 <featureArtifactDef>
                                     org.wso2.carbon.mediation:org.wso2.carbon.mediator.cache.server.feature:${carbon.mediation.version}
                                 </featureArtifactDef>
+                                <featureArtifactDef>
+                                    org.wso2.carbon.mediation:org.wso2.carbon.identity.xacml.mediator.feature:${carbon.mediation.version}
+                                </featureArtifactDef>
 
                             </featureArtifacts>
                         </configuration>
@@ -992,6 +995,10 @@
                                 <feature>
                                     <id>org.wso2.carbon.registry.ws.feature.group</id>
                                     <version>${carbon.registry.version}</version>
+                                </feature>
+                                <feature>
+                                    <id>org.wso2.carbon.identity.xacml.mediator.feature.group</id>
+                                    <version>${carbon.mediation.version}</version>
                                 </feature>
                                 <!--API Management related feature-->
                                 <feature>
@@ -1583,6 +1590,10 @@
                                     <id>org.wso2.carbon.websocket.feature.group</id>
                                     <version>${carbon.mediation.version}</version>
                                 </feature>
+                                <feature>
+                                    <id>org.wso2.carbon.identity.xacml.mediator.feature.group</id>
+                                    <version>${carbon.mediation.version}</version>
+                                </feature>
                             </features>
                         </configuration>
                     </execution>
@@ -1925,6 +1936,10 @@
                                 </feature>
                                 <feature>
                                     <id>org.wso2.carbon.websocket.feature.group</id>
+                                    <version>${carbon.mediation.version}</version>
+                                </feature>
+                                <feature>
+                                    <id>org.wso2.carbon.identity.xacml.mediator.feature.group</id>
                                     <version>${carbon.mediation.version}</version>
                                 </feature>
                             </features>

--- a/modules/p2-profile/product/pom.xml
+++ b/modules/p2-profile/product/pom.xml
@@ -592,8 +592,8 @@
                                 </featureArtifactDef>
                                 <featureArtifactDef>
                                     org.wso2.carbon.mediation:org.wso2.carbon.identity.xacml.mediator.feature:${carbon.mediation.version}
-				</featureArtifactDef>
-				<featureArtifactDef>
+                                </featureArtifactDef>
+                                <featureArtifactDef>
                                     org.wso2.carbon.mediation:org.wso2.carbon.mediator.publishevent.feature:${carbon.mediation.version}
                                 </featureArtifactDef>
 
@@ -1599,8 +1599,9 @@
                                 </feature>
                                 <feature>
                                     <id>org.wso2.carbon.identity.xacml.mediator.feature.group</id>
-				    <version>${carbon.mediation.version}</version>
-				<feature>
+				                    <version>${carbon.mediation.version}</version>
+                                </feature>
+                                <feature>
                                     <id>org.wso2.carbon.mediator.publishevent.feature.group</id>
                                     <version>${carbon.mediation.version}</version>
                                 </feature>


### PR DESCRIPTION
This is the fix for the APIMANAGER-5473. API Manager now comes with the XACML and XACML Mediation in-built with this fix and there is no need to add these features explicitly