### PR TITLE
The location of Java JDK was changed on Mac OS X Mountain Lion.

### DIFF
--- a/modules/distribution/product/src/main/startup-scripts/wso2server.sh
+++ b/modules/distribution/product/src/main/startup-scripts/wso2server.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # ----------------------------------------------------------------------------
-#  Copyright 2005-2012 WSO2, Inc. http://www.wso2.org
+#  Copyright 2005-2016 WSO2, Inc. http://www.wso2.org
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -48,7 +48,11 @@ Darwin*) darwin=true
              echo "Using Java version: $JAVA_VERSION"
            fi
            if [ -z "$JAVA_HOME" ] ; then
-             JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Versions/${JAVA_VERSION}/Home
+               if [ -x '/usr/libexec/java_home' ] ; then
+                   JAVA_HOME=`/usr/libexec/java_home`
+               elif [ -d "/System/Library/Frameworks/JavaVM.framework/Versions/$JAVA_VERSION/Home" ]; then
+                   JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Versions/$JAVA_VERSION/Home
+               fi
            fi
            ;;
 esac


### PR DESCRIPTION
Updated the resolving procedure, by employing changes from ant startup scripts at
https://svn.apache.org/viewvc/ant/core/trunk/src/script/ant?view=markup&pathrev=1434680