### PR TITLE
Enable APIM4312NPEAfterRequestTimeoutTestCase

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -197,8 +197,7 @@
             CARBON-15759 and ESBJAVA-4386 fixed -->
             <!--<class name="org.wso2.am.integration.tests.other.APIMANAGER4464BackendReturningStatusCode204TestCase"/>-->
             <!--<class name="org.wso2.am.integration.tests.other.APIMANAGER4533BackendReturningStatusCode200TestCase"/>-->
-            <!--Should be uncommented only after upgrading synapse version to 2.1.7-wso2v9 or later-->
-            <!--<class name="org.wso2.am.integration.tests.other.APIM4312NPEAfterRequestTimeoutTestCase"/>-->
+            <class name="org.wso2.am.integration.tests.other.APIM4312NPEAfterRequestTimeoutTestCase"/>
             <class name="org.wso2.am.integration.tests.restapi.testcases.TierTestCase"/>
             <class name="org.wso2.am.integration.tests.restapi.testcases.APITestCase"/>
             <class name="org.wso2.am.integration.tests.restapi.testcases.EnvironmentTestCase"/>


### PR DESCRIPTION
Enabled APIM4312NPEAfterRequestTimeoutTestCase since we have updated the synapse version : https://github.com/wso2/carbon-apimgt/commit/a7ef1ff

Please see : https://github.com/Manuri/product-apim-1/blob/acfe85164839de75061495ab34d2257226d46027/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml#L200 and https://github.com/wso2/product-apim/pull/1195