### PR TITLE
Upgrade uuf core version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -209,7 +209,7 @@
         <carbon.jndi.version>1.0.1</carbon.jndi.version>
         <carbon.metrics.version>2.0.0</carbon.metrics.version>
         <wso2.msf4j.version>2.1.0</wso2.msf4j.version>
-        <carbon.uuf.version>1.0.0-m9</carbon.uuf.version>
+        <carbon.uuf.version>1.0.0-SNAPSHOT</carbon.uuf.version>
         <carbon.security.caas.version>1.0.0-m2</carbon.security.caas.version>
         <carbon.cache.version>1.0.0</carbon.cache.version>
         <javax.cache-api.version>1.0.0</javax.cache-api.version>


### PR DESCRIPTION
In this PR:

- Change UUF Core version to its SNAPSHOT because of version compatibility issue with UUF-Commons

This PR depends on #[3584](https://github.com/wso2/carbon-apimgt/pull/3584)