### PR TITLE
Inherit maven assembly plugin from carbon-parent

### DIFF
--- a/analyzer/pom.xml
+++ b/analyzer/pom.xml
@@ -1043,7 +1043,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.5.2</version>
                 <executions>
                     <execution>
                         <id>distribution</id>

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -258,7 +258,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.5.2</version>
                 <executions>
                     <execution>
                         <id>distribution1</id>

--- a/product/pom.xml
+++ b/product/pom.xml
@@ -587,7 +587,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.5.2</version>
                 <executions>
                     <execution>
                         <id>distribution</id>


### PR DESCRIPTION
Products shouldn't re-define or override what is available in carbon-parent without a proper reason.
This has done in compliance with recent build efficiency effort.
Please check if you have used this assembly plugin version for specific reason.
If not you can inherit from the carbon-parent.
