### PR TITLE
downgrading registry version by 1 to fix osgi issue causing build failure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -909,7 +909,7 @@
         <carbon.apimgt.imp.pkg.version>[6.2.0, 7.0.0)</carbon.apimgt.imp.pkg.version>
 
         <!-- Carbon Registry -->
-        <carbon.registry.version>4.6.25</carbon.registry.version>
+        <carbon.registry.version>4.6.24</carbon.registry.version>
         <carbon.registry.package.import.version.range>[4.5.4, 5.0.0)</carbon.registry.package.import.version.range>
 
 


### PR DESCRIPTION

## Purpose
These is an intermittent build failure issue as there are two dependency versions of httpclient lib.
httpclient_4.3.1.wso2v2 and httpclient_4.3.6.wso2v1
Since, httpclient_4.3.6.wso2v1 has introduced in [1] downgrading registry version to fix the issue.
[1] https://github.com/wso2/carbon-registry/pull/271