### PR TITLE
Fix for APIMANAGER-5529

### DIFF
--- a/modules/distribution/product/src/main/conf/axis2.xml
+++ b/modules/distribution/product/src/main/conf/axis2.xml
@@ -168,10 +168,10 @@
                          class="org.apache.axis2.format.PlainTextFormatter"/>
 
         <!--JSON Message Formatters-->
-	<messageFormatter contentType="application/json"
-                          class="org.apache.synapse.commons.json.JsonFormatter"/>
+        <messageFormatter contentType="application/json"
+                          class="org.apache.synapse.commons.json.JsonStreamFormatter"/>
         <!--messageFormatter contentType="application/json"
-                          class="org.apache.synapse.commons.json.JsonStreamFormatter"/-->
+                          class="org.apache.synapse.commons.json.JsonFormatter"/-->
         <messageFormatter contentType="application/json/badgerfish"
                           class="org.apache.axis2.json.JSONBadgerfishMessageFormatter"/>
         <messageFormatter contentType="text/javascript"
@@ -232,10 +232,10 @@
                         class="org.apache.axis2.format.PlainTextBuilder"/>
 
         <!--JSON Message Builders-->
-	<messageBuilder contentType="application/json"
-                        class="org.apache.synapse.commons.json.JsonBuilder"/>
+        <messageBuilder contentType="application/json"
+                        class="org.apache.synapse.commons.json.JsonStreamBuilder"/>
         <!--messageBuilder contentType="application/json"
-                        class="org.apache.synapse.commons.json.JsonStreamBuilder"/-->
+                        class="org.apache.synapse.commons.json.JsonBuilder"/-->
         <messageBuilder contentType="application/json/badgerfish"
                         class="org.apache.axis2.json.JSONBadgerfishOMBuilder"/>
         <messageBuilder contentType="text/javascript"

--- a/modules/distribution/product/src/main/conf/synapse-configs/default/proxy-services/WorkflowCallbackService.xml
+++ b/modules/distribution/product/src/main/conf/synapse-configs/default/proxy-services/WorkflowCallbackService.xml
@@ -19,8 +19,24 @@
          </send>
       </inSequence>
       <outSequence>
-         <property name="messageType" value="text/xml" scope="axis2" type="STRING"/>
-         <send/>
+         <outSequence>
+            <property name="messageType" scope="axis2" type="STRING" value="text/xml"/>
+            <filter xpath="//jsonObject">
+               <then>
+                  <enrich>
+                     <source clone="true" xpath="//jsonObject/*"/>
+                     <target property="BPS_PAYLOAD" type="property"/>
+                  </enrich>
+                  <enrich>
+                     <source clone="true" property="BPS_PAYLOAD" type="property"/>
+                     <target type="body"/>
+                  </enrich>
+               </then>
+               <else/>
+            </filter>
+            <send/>
+         </outSequence>
+
       </outSequence>
    </target>
    <publishWSDL>

--- a/modules/distribution/product/src/main/conf/synapse-configs/default/proxy-services/WorkflowCallbackService.xml
+++ b/modules/distribution/product/src/main/conf/synapse-configs/default/proxy-services/WorkflowCallbackService.xml
@@ -19,24 +19,21 @@
          </send>
       </inSequence>
       <outSequence>
-         <outSequence>
-            <property name="messageType" scope="axis2" type="STRING" value="text/xml"/>
-            <filter xpath="//jsonObject">
-               <then>
-                  <enrich>
-                     <source clone="true" xpath="//jsonObject/*"/>
-                     <target property="BPS_PAYLOAD" type="property"/>
-                  </enrich>
-                  <enrich>
-                     <source clone="true" property="BPS_PAYLOAD" type="property"/>
-                     <target type="body"/>
-                  </enrich>
-               </then>
-               <else/>
-            </filter>
-            <send/>
-         </outSequence>
-
+         <property name="messageType" scope="axis2" type="STRING" value="text/xml"/>
+         <filter xpath="//jsonObject">
+            <then>
+               <enrich>
+                  <source clone="true" xpath="//jsonObject/*"/>
+                  <target property="BPS_PAYLOAD" type="property"/>
+               </enrich>
+               <enrich>
+                  <source clone="true" property="BPS_PAYLOAD" type="property"/>
+                  <target type="body"/>
+               </enrich>
+            </then>
+            <else/>
+         </filter>
+         <send/>
       </outSequence>
    </target>
    <publishWSDL>


### PR DESCRIPTION
## Purpose
Changes the default message builder and formatter for application/json as org.apache.synapse.commons.json.JsonStreamBuilder/JsonStreamFormatter. 

## Goals
Fixes https://wso2.org/jira/browse/APIMANAGER-5529


## Migrations (if applicable)
Migration required for axis2.xml file and WorkflowCallbackService.xml proxy service

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.