### PR TITLE
Fix issue in import/export tool for secondary user store users

### DIFF
--- a/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/APIImportExportConstants.java
+++ b/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/APIImportExportConstants.java
@@ -89,4 +89,6 @@ public final class APIImportExportConstants {
 
     public static final String CHARSET = "UTF-8";
 
+    public static final String AUTHENTICATION_ADMIN_SERVICE_ENDPOINT = "AuthenticationAdmin";
+
 }

--- a/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/APIService.java
+++ b/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/APIService.java
@@ -28,6 +28,7 @@ import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.apimgt.importexport.utils.APIExportUtil;
 import org.wso2.carbon.apimgt.importexport.utils.APIImportUtil;
 import org.wso2.carbon.apimgt.importexport.utils.ArchiveGeneratorUtil;
+import org.wso2.carbon.apimgt.importexport.utils.AuthenticationContext;
 import org.wso2.carbon.apimgt.importexport.utils.AuthenticatorUtil;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
@@ -73,7 +74,6 @@ public class APIService {
     public Response exportAPI(@QueryParam("name") String name, @QueryParam("version") String version,
             @QueryParam("provider") String providerName, @Context HttpHeaders httpHeaders) {
 
-        String userName;
         if (name == null || version == null || providerName == null) {
             log.error("Invalid API Information ");
 
@@ -91,7 +91,8 @@ public class APIService {
                 return authorizationResponse;
             }
 
-            userName = AuthenticatorUtil.getAuthenticatedUserName();
+            AuthenticationContext authenticationContext = (AuthenticationContext) authorizationResponse.getEntity();
+            String userName = authenticationContext.getUsername();
             //provider names with @ signs are only accepted
             String apiDomain = MultitenantUtils.getTenantDomain(providerName);
             String apiRequesterDomain = MultitenantUtils.getTenantDomain(userName);
@@ -185,7 +186,10 @@ public class APIService {
                 return authorizationResponse;
             }
 
-            String currentUser = AuthenticatorUtil.getAuthenticatedUserName();
+            AuthenticationContext authenticationContext = (AuthenticationContext) authorizationResponse.getEntity();
+            String tenantDomain = MultitenantUtils.getTenantDomain(authenticationContext.getUsername());
+            String currentUser = APIUtil.appendDomainWithUser(authenticationContext.getDomainAwareUsername(),
+                    tenantDomain);
             APIImportUtil.initializeProvider(currentUser);
 
             //Temporary directory is used to create the required folders
@@ -210,7 +214,6 @@ public class APIService {
                     return Response.status(Status.BAD_REQUEST).entity(e.getMessage()).build();
                 }
 
-                String tenantDomain = MultitenantUtils.getTenantDomain(currentUser);
                 if (tenantDomain != null &&
                         !org.wso2.carbon.utils.multitenancy.MultitenantConstants.SUPER_TENANT_DOMAIN_NAME
                                 .equals(tenantDomain)) {


### PR DESCRIPTION
## Purpose
This PR contains changes for the API import/export tool to be used by the users of from the secondary user store having specific permissions. With this fix they can use the tool without explicitly indicating the user store name. Resolves #3262 

## Goals
Allow users from secondary user stores to use API import/export tool without explicitly indicating the user store name.

## Approach
The authentication is done via the us, the Authentication admin service and via which the domain aware user name can be inferred to grant the users with corresponding permissions.

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N?A

## Automation tests
Manually tested the tool.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
JDK 1.8.0_121-b13
OS Ubuntu 16.04.2 LTS

## Learning
N/A