### PR TITLE
fixing customLifecycle test case

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/CustomLifeCycleTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/CustomLifeCycleTestCase.java
@@ -36,7 +36,7 @@ import java.net.URL;
 
 public class CustomLifeCycleTestCase extends APIManagerLifecycleBaseTest {
 
-    private static final String API_NAME = "APILifecycleTestApi";
+    private static final String API_NAME = "APICustomLifecycleTestApi";
     String publisherURLHttp;
     private LifeCycleAdminClient lifeCycleAdminClient;
     private String customizedAPILifecyclePath =


### PR DESCRIPTION
## Purpose

Another test case was having another API with the same name. This resulted in an error when creating the API via this test case. Therefore changing the name of the customLifeCycleTestCase.