### PR TITLE
Adding on-premise-gateway.properties file to the distribution.

### DIFF
--- a/modules/distribution/product/src/main/assembly/bin.xml
+++ b/modules/distribution/product/src/main/assembly/bin.xml
@@ -978,6 +978,14 @@
             <filtered>true</filtered>
         </file>
 
+        <!-- On-Premise Gateway related properties -->
+        <file>
+            <source>../../p2-profile/product/target/wso2carbon-core-${carbon.kernel.version}/repository/conf/on-premise-gateway.properties</source>
+            <outputDirectory>wso2am-${pom.version}/repository/conf</outputDirectory>
+            <destName>on-premise-gateway.properties</destName>
+            <filtered>true</filtered>
+        </file>
+
         <!--file>
             <source>../../p2-profile/product/target/wso2carbon-core-${carbon.kernel.version}/repository/conf/rule-engine-config.xml</source>
             <outputDirectory>wso2am-${pom.version}/repository/conf</outputDirectory>


### PR DESCRIPTION
## Purpose
Adding on-premise-gateway.properties file to the APIM pack

## Goals
To activate usage publisher.
