### PR TITLE
Fix for APIMANAGER5869WSGayewatURLTestCase.testApiGatewayUrlsAfterConfigChangeTest failure.

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/websocket/APIMANAGER5869WSGayewatURLTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/websocket/APIMANAGER5869WSGayewatURLTestCase.java
@@ -229,10 +229,10 @@ public class APIMANAGER5869WSGayewatURLTestCase extends APIMIntegrationBaseTest 
         assertEquals(serviceResponse.getResponseCode(), 200, "HTTP status code mismatched");
         if (TestUserMode.SUPER_TENANT_ADMIN == userMode) {
             assertTrue(
-                    serviceResponse.getData().contains("ws://wsserverhost:9797/" + WS_API_CONTEXT + "/" + API_VERSION));
+                    serviceResponse.getData().contains("ws://localhost:9099/" + WS_API_CONTEXT + "/" + API_VERSION));
         } else {
             assertTrue(serviceResponse.getData()
-                    .contains("ws://wsserverhost:9797/t/wso2.com/" + WS_API_CONTEXT + "/" + API_VERSION));
+                    .contains("ws://localhost:9099/t/wso2.com/" + WS_API_CONTEXT + "/" + API_VERSION));
         }
 
     }

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/webSocketTest/policy.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/webSocketTest/policy.json
@@ -5,7 +5,7 @@
   "defaultQuotaPolicy": {
     "type": "requestCount",
     "limit": {
-      "requestCount": "8",
+      "requestCount": "2",
       "timeUnit": "min",
       "dataAmount": 0,
       "dataUnit": "",


### PR DESCRIPTION
## Purpose

This PR includes the fix for org.wso2.am.integration.tests.websocket.APIMANAGER5869WSGayewatURLTestCase.testApiGatewayUrlsAfterConfigChangeTest failure.