### PR TITLE
Fixes for integration test issue on product-apim 2.x

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/header/CORSHeadersTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/header/CORSHeadersTestCase.java
@@ -218,7 +218,7 @@ public class CORSHeadersTestCase extends APIManagerLifecycleBaseTest {
         this.userMode = userMode;
     }
 
-  @AfterClass(alwaysRun = true)
+    @AfterClass(alwaysRun = true)
     public void destroy() throws Exception {
         apiStore.removeAPISubscriptionByName(API_NAME,API_VERSION,providerNameApi,APPLICATION_NAME);
         apiStore.removeApplication(APPLICATION_NAME);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/header/CORSHeadersTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/header/CORSHeadersTestCase.java
@@ -81,6 +81,7 @@ public class CORSHeadersTestCase extends APIManagerLifecycleBaseTest {
     private APIIdentifier apiIdentifier;
     private String accessToken;
 
+    private String providerNameApi = "admin";
     Log log = LogFactory.getLog(CORSHeadersTestCase.class);
 
     @BeforeClass(alwaysRun = true)
@@ -126,7 +127,8 @@ public class CORSHeadersTestCase extends APIManagerLifecycleBaseTest {
         createPublishAndSubscribeToAPI(apiIdentifier, apiCreationRequestBean, apiPublisherClientUser1,
                                        apiStoreClientUser1, APPLICATION_NAME);
         waitForAPIDeploymentSync(user.getUserName(), API_NAME, API_VERSION, APIMIntegrationConstants.IS_API_EXISTS);
-    }
+        providerNameApi = publisherContext.getContextTenant().getContextUser().getUserName();
+      }
 
     @Test(groups = {"wso2.am"}, description = "Checking CORS headers in pre-flight response")
     public void CheckCORSHeadersInPreFlightResponse() throws Exception {
@@ -204,10 +206,6 @@ public class CORSHeadersTestCase extends APIManagerLifecycleBaseTest {
                    "but it should not be.");
     }
 
-    @AfterClass(alwaysRun = true)
-    public void destroy() throws Exception {
-        super.cleanUp();
-    }
 
     @DataProvider
     public static Object[][] userModeDataProvider() {
@@ -219,4 +217,18 @@ public class CORSHeadersTestCase extends APIManagerLifecycleBaseTest {
     public CORSHeadersTestCase(TestUserMode userMode) {
         this.userMode = userMode;
     }
+
+  @AfterClass(alwaysRun = true)
+    public void destroy() throws Exception {
+        apiStore.removeAPISubscriptionByName(API_NAME,API_VERSION,providerNameApi,APPLICATION_NAME);
+        apiStore.removeApplication(APPLICATION_NAME);
+        apiStoreClientUser1.removeAPISubscriptionByName(API_NAME,API_VERSION,providerNameApi,APPLICATION_NAME);
+        apiStoreClientUser1.removeApplication(APPLICATION_NAME);
+        apiPublisher.deleteAPI(API_NAME,API_VERSION,providerNameApi);
+        apiPublisherClientUser1.deleteAPI(API_NAME,API_VERSION,providerNameApi);
+        super.cleanUp();
+    }
+
+
+
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/publisher/APIM614AddDocumentationToAnAPIWithDocTypeSampleAndSDKThroughPublisherRestAPITest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/publisher/APIM614AddDocumentationToAnAPIWithDocTypeSampleAndSDKThroughPublisherRestAPITest.java
@@ -1,0 +1,407 @@
+/*
+ *
+ *   Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *   WSO2 Inc. licenses this file to you under the Apache License,
+ *   Version 2.0 (the "License"); you may not use this file except
+ *   in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing,
+ *   software distributed under the License is distributed on an
+ *   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *   KIND, either express or implied.  See the License for the
+ *   specific language governing permissions and limitations
+ *   under the License.
+ *
+ */
+
+package org.wso2.am.integration.tests.publisher;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.mime.MultipartEntity;
+import org.apache.http.entity.mime.content.FileBody;
+import org.apache.http.entity.mime.content.StringBody;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.util.EntityUtils;
+import org.json.JSONObject;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+import org.wso2.am.integration.test.utils.base.APIMIntegrationBaseTest;
+import org.wso2.am.integration.test.utils.bean.APICreationRequestBean;
+import org.wso2.am.integration.test.utils.clients.APIPublisherRestClient;
+import org.wso2.am.integration.test.utils.generic.TestConfigurationProvider;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+
+import java.io.File;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Add Documentation To An API using source type File Through Publisher Rest API
+ * APIM2 -614 / APIM2 -622 /APIM2 -624 /APIM2 -626 /APIM2 -629
+ */
+public class APIM614AddDocumentationToAnAPIWithDocTypeSampleAndSDKThroughPublisherRestAPITestCase
+        extends APIMIntegrationBaseTest{
+
+    private final String apiName = "APIM614PublisherTest";
+    private final String apiVersion = "1.0.0";
+    private APIPublisherRestClient apiPublisher;
+    private String apiProvider;
+    private String apiEndPointUrl;
+    private HttpClient httpClient;
+    private HttpPost httpPostLogin;
+
+    @Factory(dataProvider = "userModeDataProvider")
+    public APIM614AddDocumentationToAnAPIWithDocTypeSampleAndSDKThroughPublisherRestAPITestCase
+            (TestUserMode userMode) {
+        this.userMode = userMode;
+    }
+
+    @DataProvider
+    public static Object[][] userModeDataProvider() {
+        return new Object[][]{
+                new Object[]{TestUserMode.SUPER_TENANT_ADMIN},
+                new Object[]{TestUserMode.TENANT_ADMIN},
+        };
+    }
+
+    @BeforeClass(alwaysRun = true)
+    public void setEnvironment() throws Exception {
+        super.init(userMode);
+
+        String apiProductionEndpointPostfixUrl = "jaxrs_basic/services/customers/" +
+                "customerservice/customers/123";
+        String loginUrl = publisherUrls.getWebAppURLHttp()+"publisher/site/blocks/user/login/ajax/login.jag";
+
+        String publisherURLHttp = publisherUrls.getWebAppURLHttp();
+
+        apiPublisher = new APIPublisherRestClient(publisherURLHttp);
+        apiPublisher.login(publisherContext.getContextTenant().getContextUser().getUserName(),
+                publisherContext.getContextTenant().getContextUser().getPassword());
+
+        apiEndPointUrl = gatewayUrlsWrk.getWebAppURLHttp() + apiProductionEndpointPostfixUrl;
+        apiProvider = publisherContext.getContextTenant().getContextUser().getUserName();
+
+        httpClient = HttpClients.createDefault();
+        httpPostLogin = new HttpPost(loginUrl);
+
+        List<NameValuePair> loginValue = new ArrayList<NameValuePair>();
+        loginValue.add(new BasicNameValuePair("action", "login"));
+        loginValue.add(new BasicNameValuePair("username", "admin"));
+        loginValue.add(new BasicNameValuePair("password", "admin"));
+
+        httpPostLogin.setEntity(new UrlEncodedFormEntity(loginValue));
+
+        //Validate whether the newly created client can login to the API publisher
+        HttpResponse loginResponse = httpClient.execute(httpPostLogin);
+        HttpEntity loginEntity = loginResponse.getEntity();
+        JSONObject jsonObjectLogin = new JSONObject(EntityUtils.toString(loginEntity));
+        //assertFalse(jsonObjectLogin.getBoolean("error"),"Error when login to the Publisher Rest API using new client");
+         assertTrue(jsonObjectLogin.has("{\"error\":false}"));
+    }
+
+    @Test(groups = {"wso2.am"}, description = "Create an API to update the documents with " +
+            "source type file  through the publisher rest API ")
+    public void testApiCreation() throws Exception {
+
+        String apiContext = "apim614PublisherTestAPI";
+        String apiDescription = "This is Test API Created by API Manager Integration Test";
+        String apiTags = "tag614-1, tag622-2, tag624-3";
+
+        //Create an API and validate it
+        APICreationRequestBean apiCreationRequestBean =
+                new APICreationRequestBean(apiName, apiContext, apiVersion, apiProvider,
+                        new URL(apiEndPointUrl));
+        apiCreationRequestBean.setTags(apiTags);
+        apiCreationRequestBean.setDescription(apiDescription);
+        apiCreationRequestBean.setTiersCollection("Gold,Bronze");
+        apiCreationRequestBean.setDefaultVersion("default_version");
+        apiCreationRequestBean.setDefaultVersionChecked("default_version");
+        apiCreationRequestBean.setBizOwner("api620b");
+        apiCreationRequestBean.setBizOwnerMail("api620b@ee.com");
+        apiCreationRequestBean.setTechOwner("api620t");
+        apiCreationRequestBean.setTechOwnerMail("api620t@ww.com");
+
+        JSONObject jsonObject = new JSONObject(apiPublisher.
+                addAPI(apiCreationRequestBean).getData());
+        assertFalse(jsonObject.getBoolean("error"), apiName + " is not created ");
+
+    }
+
+    @Test(groups = {"wso2.am"}, description = "Add Documentation To An API With Type HowTo And" +
+            " Source File through the publisher rest API ",
+            dependsOnMethods = "testApiCreation")
+    public void testAddDocumentToAnAPIHowToFile() throws Exception {
+
+        String fileNameAPIM614 = "APIM614.txt";
+        String docName = "APIM614PublisherTestHowTo-File-summary";
+        String docType = "How To";
+        String sourceType = "file";
+        String summary = "Testing";
+        String mimeType = "text/plain";
+        String docUrl = "http://";
+        String filePathAPIM614 =TestConfigurationProvider.getResourceLocation() + File.separator +
+                "artifacts" + File.separator + "AM" + File.separator + "lifecycletest" +
+                File.separator + fileNameAPIM614;;
+        String addDocUrl = publisherUrls.getWebAppURLHttp()+"publisher/site/blocks/documentation/ajax/docs.jag";
+
+
+        //Send Http Post request to add a new file
+        HttpPost httppost = new HttpPost(addDocUrl);
+        File file = new File(filePathAPIM614);
+        FileBody fileBody = new FileBody(file,"text/plain");
+
+        //Create multipart entity to upload file as multipart file
+        MultipartEntity multipartEntity = new MultipartEntity();
+        multipartEntity.addPart("docLocation", fileBody);
+        multipartEntity.addPart("mode",new StringBody(""));
+        multipartEntity.addPart("docName",new StringBody(docName));
+        multipartEntity.addPart("docUrl",new StringBody(docUrl));
+        multipartEntity.addPart("sourceType",new StringBody(sourceType));
+        multipartEntity.addPart("summary",new StringBody(summary));
+        multipartEntity.addPart("docType",new StringBody(docType));
+        multipartEntity.addPart("version",new StringBody(apiVersion));
+        multipartEntity.addPart("apiName",new StringBody(apiName));
+        multipartEntity.addPart("action",new StringBody("addDocumentation"));
+        multipartEntity.addPart("provider",new StringBody(apiProvider));
+        multipartEntity.addPart("mimeType",new StringBody(mimeType));
+        multipartEntity.addPart("optionsRadios",new StringBody(docType));
+        multipartEntity.addPart("optionsRadios1",new StringBody(sourceType));
+        multipartEntity.addPart("optionsRadios1",new StringBody(sourceType));
+
+        httppost.setEntity(multipartEntity);
+
+        //Upload created file and validate
+        HttpResponse response = httpClient.execute(httppost);
+        HttpEntity entity = response.getEntity();
+        JSONObject jsonObject1 = new JSONObject(EntityUtils.toString(entity));
+        assertFalse(jsonObject1.getBoolean("error"), "Error when adding files to the API ");
+
+}
+
+    @Test(groups = {"wso2.am"}, description = "Add Documentation To An API With Type Sample SDK And" +
+            " Source File through the publisher rest API ",
+            dependsOnMethods = "testAddDocumentToAnAPIHowToFile")
+    public void testAddDocumentToAnAPISDKToFile() throws Exception {
+
+        String fileNameAPIM622 = "APIM622.txt";
+        String docName = "APIM622PublisherTestHowTo-File-summary";
+        String docType = "samples";
+        String sourceType = "file";
+        String summary = "Testing";
+        String mimeType = "text/plain";
+        String docUrl = "http://";
+        String filePathAPIM622 = TestConfigurationProvider.getResourceLocation() + File.separator +
+                "artifacts" + File.separator + "AM" + File.separator + "lifecycletest" +
+                File.separator + fileNameAPIM622;
+        String addDocUrl = publisherUrls.getWebAppURLHttp() +"publisher/site/blocks/documentation/ajax/docs.jag";
+
+        //Send Http Post request to add a new file
+        HttpPost httppost = new HttpPost(addDocUrl);
+        File file = new File(filePathAPIM622);
+        FileBody fileBody = new FileBody(file,"text/plain");
+
+        //Create multipart entity to upload file as multipart file
+        MultipartEntity multipartEntity = new MultipartEntity();
+        multipartEntity.addPart("docLocation", fileBody);
+        multipartEntity.addPart("mode",new StringBody(""));
+        multipartEntity.addPart("docName",new StringBody(docName));
+        multipartEntity.addPart("docUrl",new StringBody(docUrl));
+        multipartEntity.addPart("sourceType",new StringBody(sourceType));
+        multipartEntity.addPart("summary",new StringBody(summary));
+        multipartEntity.addPart("docType",new StringBody(docType));
+        multipartEntity.addPart("version",new StringBody(apiVersion));
+        multipartEntity.addPart("apiName",new StringBody(apiName));
+        multipartEntity.addPart("action",new StringBody("addDocumentation"));
+        multipartEntity.addPart("provider",new StringBody(apiProvider));
+        multipartEntity.addPart("mimeType",new StringBody(mimeType));
+        multipartEntity.addPart("optionsRadios",new StringBody(docType));
+        multipartEntity.addPart("optionsRadios1",new StringBody(sourceType));
+        multipartEntity.addPart("optionsRadios1",new StringBody(sourceType));
+
+        httppost.setEntity(multipartEntity);
+
+        //Upload created file and validate
+        HttpResponse response = httpClient.execute(httppost);
+        HttpEntity entity = response.getEntity();
+        JSONObject jsonObject1 = new JSONObject(EntityUtils.toString(entity));
+        assertFalse(jsonObject1.getBoolean("error"), "Error when adding files to the API ");
+    }
+
+
+    @Test(groups = {"wso2.am"}, description = "Add Documentation To An API With Type  public forum And" +
+            " Source File through the publisher rest API ",
+            dependsOnMethods = "testAddDocumentToAnAPISDKToFile")
+    public void testAddDocumentToAnAPIPublicToFile() throws Exception {
+
+        String fileNameAPIM624 = "APIM624.txt";
+        String docName = "APIM624PublisherTestHowTo-File-summary";
+        String docType = "public forum";
+        String sourceType = "file";
+        String summary = "Testing";
+        String mimeType = "text/plain";
+        String docUrl = "http://";
+        String filePathAPIM624 = TestConfigurationProvider.getResourceLocation() + File.separator +
+                "artifacts" + File.separator + "AM" + File.separator + "lifecycletest" +
+                File.separator + fileNameAPIM624;
+        String addDocUrl = publisherUrls.getWebAppURLHttp()+"publisher/site/blocks/documentation/ajax/docs.jag";
+
+        //Send Http Post request to add a new file
+        HttpPost httppost = new HttpPost(addDocUrl);
+        File file = new File(filePathAPIM624);
+        FileBody fileBody = new FileBody(file,"text/plain");
+
+        //Create multipart entity to upload file as multipart file
+        MultipartEntity multipartEntity = new MultipartEntity();
+        multipartEntity.addPart("docLocation", fileBody);
+        multipartEntity.addPart("mode",new StringBody(""));
+        multipartEntity.addPart("docName",new StringBody(docName));
+        multipartEntity.addPart("docUrl",new StringBody(docUrl));
+        multipartEntity.addPart("sourceType",new StringBody(sourceType));
+        multipartEntity.addPart("summary",new StringBody(summary));
+        multipartEntity.addPart("docType",new StringBody(docType));
+        multipartEntity.addPart("version",new StringBody(apiVersion));
+        multipartEntity.addPart("apiName",new StringBody(apiName));
+        multipartEntity.addPart("action",new StringBody("addDocumentation"));
+        multipartEntity.addPart("provider",new StringBody(apiProvider));
+        multipartEntity.addPart("mimeType",new StringBody(mimeType));
+        multipartEntity.addPart("optionsRadios",new StringBody(docType));
+        multipartEntity.addPart("optionsRadios1",new StringBody(sourceType));
+        multipartEntity.addPart("optionsRadios1",new StringBody(sourceType));
+
+        httppost.setEntity(multipartEntity);
+
+        //Upload created file and validate
+        HttpResponse response = httpClient.execute(httppost);
+        HttpEntity entity = response.getEntity();
+        JSONObject jsonObject1 = new JSONObject(EntityUtils.toString(entity));
+        assertFalse(jsonObject1.getBoolean("error"), "Error when adding files to the API ");
+    }
+
+    @Test(groups = {"wso2.am"}, description = "Add Documentation To An API With Type  support forum And" +
+            " Source File through the publisher rest API ",
+            dependsOnMethods = "testAddDocumentToAnAPIPublicToFile")
+    public void testAddDocumentToAnAPISupportToFile() throws Exception {
+
+        String fileNameAPIM626 = "APIM626.txt";
+        String docName = "APIM626PublisherTestHowTo-File-summary";
+        String docType = "support forum";
+        String sourceType = "file";
+        String summary = "Testing";
+        String mimeType = "text/plain";
+        String docUrl = "http://";
+        String filePathAPIM626 = TestConfigurationProvider.getResourceLocation() + File.separator +
+                "artifacts" + File.separator + "AM" + File.separator + "lifecycletest" +
+                File.separator + fileNameAPIM626;
+        String addDocUrl = publisherUrls.getWebAppURLHttp()+"publisher/site/blocks/documentation/ajax/docs.jag";
+
+        //Send Http Post request to add a new file
+        HttpPost httppost = new HttpPost(addDocUrl);
+        File file = new File(filePathAPIM626);
+        FileBody fileBody = new FileBody(file,"text/plain");
+
+        //Create multipart entity to upload file as multipart file
+        MultipartEntity multipartEntity = new MultipartEntity();
+        multipartEntity.addPart("docLocation", fileBody);
+        multipartEntity.addPart("mode",new StringBody(""));
+        multipartEntity.addPart("docName",new StringBody(docName));
+        multipartEntity.addPart("docUrl",new StringBody(docUrl));
+        multipartEntity.addPart("sourceType",new StringBody(sourceType));
+        multipartEntity.addPart("summary",new StringBody(summary));
+        multipartEntity.addPart("docType",new StringBody(docType));
+        multipartEntity.addPart("version",new StringBody(apiVersion));
+        multipartEntity.addPart("apiName",new StringBody(apiName));
+        multipartEntity.addPart("action",new StringBody("addDocumentation"));
+        multipartEntity.addPart("provider",new StringBody(apiProvider));
+        multipartEntity.addPart("mimeType",new StringBody(mimeType));
+        multipartEntity.addPart("optionsRadios",new StringBody(docType));
+        multipartEntity.addPart("optionsRadios1",new StringBody(sourceType));
+        multipartEntity.addPart("optionsRadios1",new StringBody(sourceType));
+
+        httppost.setEntity(multipartEntity);
+
+        //Upload created file and validate
+        HttpResponse response = httpClient.execute(httppost);
+        HttpEntity entity = response.getEntity();
+        JSONObject jsonObject1 = new JSONObject(EntityUtils.toString(entity));
+        assertFalse(jsonObject1.getBoolean("error"), "Error when adding files to the API ");
+    }
+
+    @Test(groups = {"wso2.am"}, description = "Add Documentation To An API With Type Other And" +
+            " Source File through the publisher rest API ",
+            dependsOnMethods = "testAddDocumentToAnAPISupportToFile")
+    public void testAddDocumentToAnAPIOtherFile() throws Exception {
+
+        String fileNameAPIM629 = "APIM629.txt";
+        String docName = "APIM629PublisherTestHowTo-File-summary";
+        String docType = "Other";
+        String sourceType = "file";
+        String newType = "Type APIM629";
+        String summary = "Testing";
+        String mimeType = "text/plain";
+        String docUrl = "http://";
+        String filePathAPIM629 = TestConfigurationProvider.getResourceLocation() + File.separator +
+                "artifacts" + File.separator + "AM" + File.separator + "lifecycletest" +
+                File.separator + fileNameAPIM629;
+        String addDocUrl = publisherUrls.getWebAppURLHttp()+"publisher/site/blocks/documentation/ajax/docs.jag";
+
+        //Send Http Post request to add a new file
+        HttpPost httppost = new HttpPost(addDocUrl);
+        File file = new File(filePathAPIM629);
+        FileBody fileBody = new FileBody(file,"text/plain");
+
+        //Create multipart entity to upload file as multipart file
+        MultipartEntity multipartEntity = new MultipartEntity();
+        multipartEntity.addPart("docLocation", fileBody);
+        multipartEntity.addPart("mode",new StringBody(""));
+        multipartEntity.addPart("docName",new StringBody(docName));
+        multipartEntity.addPart("docUrl",new StringBody(docUrl));
+        multipartEntity.addPart("sourceType",new StringBody(sourceType));
+        multipartEntity.addPart("summary",new StringBody(summary));
+        multipartEntity.addPart("docType",new StringBody(docType));
+        multipartEntity.addPart("version",new StringBody(apiVersion));
+        multipartEntity.addPart("apiName",new StringBody(apiName));
+        multipartEntity.addPart("action",new StringBody("addDocumentation"));
+        multipartEntity.addPart("provider",new StringBody(apiProvider));
+        multipartEntity.addPart("mimeType",new StringBody(mimeType));
+        multipartEntity.addPart("newType",new StringBody(newType));
+        multipartEntity.addPart("optionsRadios",new StringBody(docType));
+        multipartEntity.addPart("optionsRadios1",new StringBody(sourceType));
+        multipartEntity.addPart("optionsRadios1",new StringBody(sourceType));
+
+        httppost.setEntity(multipartEntity);
+
+        //Upload created file and validate
+        HttpResponse response = httpClient.execute(httppost);
+        HttpEntity entity = response.getEntity();
+        JSONObject jsonObject1 = new JSONObject(EntityUtils.toString(entity));
+        assertFalse(jsonObject1.getBoolean("error"), "Error when adding files to the API ");
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void destroyAPIs() throws Exception {
+        apiPublisher.deleteAPI(apiName, apiVersion, apiProvider);
+        super.cleanUp();
+    }
+
+
+
+
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/publisher/APIResourceWithTemplateTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/publisher/APIResourceWithTemplateTestCase.java
@@ -172,7 +172,7 @@ public class APIResourceWithTemplateTestCase extends APIManagerLifecycleBaseTest
 
         //add test api
         HttpResponse serviceResponse = apiPublisher.addAPI(apiCreationRequestBean);
-       //verifyResponse(serviceResponse);
+        verifyResponse(serviceResponse);
 
         //add a application
         serviceResponse = apiStore

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/publisher/APIResourceWithTemplateTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/publisher/APIResourceWithTemplateTestCase.java
@@ -60,6 +60,7 @@ public class APIResourceWithTemplateTestCase extends APIManagerLifecycleBaseTest
     private final String API_END_POINT_POSTFIX_URL = "jaxrs_basic/services/customers/customerservice/";
     private String apiEndPointUrl;
     private APIIdentifier apiIdentifier;
+    private String providerNameApi = "";
 
     @Factory(dataProvider = "userModeDataProvider")
     public APIResourceWithTemplateTestCase(TestUserMode userMode) {
@@ -93,6 +94,7 @@ public class APIResourceWithTemplateTestCase extends APIManagerLifecycleBaseTest
                             File.separator + "APIResourceWithTemplateTestCaseAPI.xml", gatewayContextMgt,
                     gatewaySessionCookie);
         }
+        providerNameApi = publisherContext.getContextTenant().getContextUser().getUserName();
     }
 
     @Test(groups = { "wso2.am" }, description = "Test API with resouce containing url template for default api")
@@ -170,7 +172,7 @@ public class APIResourceWithTemplateTestCase extends APIManagerLifecycleBaseTest
 
         //add test api
         HttpResponse serviceResponse = apiPublisher.addAPI(apiCreationRequestBean);
-        verifyResponse(serviceResponse);
+       //verifyResponse(serviceResponse);
 
         //add a application
         serviceResponse = apiStore
@@ -224,6 +226,9 @@ public class APIResourceWithTemplateTestCase extends APIManagerLifecycleBaseTest
 
     @AfterClass(alwaysRun = true)
     public void cleanUpArtifacts() throws Exception {
+        apiStore.removeAPISubscriptionByName(TEMPLATE_API_NAME, API_VERSION_1_0_0,providerNameApi,TEMPLATE_APP_NAME );
+        apiStore.removeApplication(TEMPLATE_APP_NAME);
+        apiPublisher.deleteAPI(API_NAME, API_VERSION_1_0_0,providerNameApi);
         super.cleanUp();
     }
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/websocket/APIMANAGER5869WSGayewatURLTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/websocket/APIMANAGER5869WSGayewatURLTestCase.java
@@ -48,8 +48,9 @@ import static org.testng.Assert.*;
  */
 @SetEnvironment(executionEnvironments = { ExecutionEnvironment.STANDALONE })
 public class APIMANAGER5869WSGayewatURLTestCase extends APIMIntegrationBaseTest {
+//    private  double apiNameExt = Math.random();
     private final Log log = LogFactory.getLog(APIMANAGER5869WSGayewatURLTestCase.class);
-    private final String API_NAME = "WSGayewatURLAPIName";
+    private  String API_NAME = "WSGayewatURLAPIName";
     private final String API_CONTEXT = "WSGayewatURLContext";
     private final String WS_API_NAME = "WSGayewatURLWSAPIName";
     private final String WS_API_CONTEXT = "WSGayewatURLWSContext";
@@ -64,6 +65,9 @@ public class APIMANAGER5869WSGayewatURLTestCase extends APIMIntegrationBaseTest 
     private APIPublisherRestClient apiPublisher;
     private APIStoreRestClient apiStore;
     private ServerConfigurationManager serverConfigurationManager;
+    private final String applicationName = "WebSocketApplication";
+    private String providerNameApi = "";
+
 
     @Factory(dataProvider = "userModeDataProvider")
     public APIMANAGER5869WSGayewatURLTestCase(TestUserMode userMode) {
@@ -80,6 +84,7 @@ public class APIMANAGER5869WSGayewatURLTestCase extends APIMIntegrationBaseTest 
         apiStore = new APIStoreRestClient(storeURLHttp);
         apiPublisher.login(user.getUserName(), user.getPassword());
         apiStore.login(user.getUserName(), user.getPassword());
+        providerNameApi = publisherContext.getContextTenant().getContextUser().getUserName();
     }
 
     @Test(groups = { "wso2.am" }, description = "Sample API creation")
@@ -108,7 +113,7 @@ public class APIMANAGER5869WSGayewatURLTestCase extends APIMIntegrationBaseTest 
         APILifeCycleStateRequest updateRequest = new APILifeCycleStateRequest(API_NAME, user.getUserName(),
                 APILifeCycleState.PUBLISHED);
         serviceResponse = apiPublisher.changeAPILifeCycleStatus(updateRequest);
-        verifyResponse(serviceResponse);
+        //verifyResponse(serviceResponse);
         waitForAPIDeploymentSync(user.getUserName(), API_NAME, API_VERSION, APIMIntegrationConstants.IS_API_EXISTS);
     }
 
@@ -239,10 +244,14 @@ public class APIMANAGER5869WSGayewatURLTestCase extends APIMIntegrationBaseTest 
 
     @AfterClass(alwaysRun = true)
     public void destroy() throws Exception {
+        apiStore.removeAPISubscriptionByName(API_NAME,API_VERSION,providerNameApi,applicationName);
+        apiStore.removeApplication(applicationName);
+        apiPublisher.deleteAPI(API_NAME,API_VERSION,providerNameApi);
         super.cleanUp();
         if (TestUserMode.SUPER_TENANT_ADMIN == userMode) {
             serverConfigurationManager.restoreToLastConfiguration(true);
-        }
+          
+           }
     }
 
     @DataProvider

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/websocket/APIMANAGER5869WSGayewatURLTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/websocket/APIMANAGER5869WSGayewatURLTestCase.java
@@ -113,7 +113,7 @@ public class APIMANAGER5869WSGayewatURLTestCase extends APIMIntegrationBaseTest 
         APILifeCycleStateRequest updateRequest = new APILifeCycleStateRequest(API_NAME, user.getUserName(),
                 APILifeCycleState.PUBLISHED);
         serviceResponse = apiPublisher.changeAPILifeCycleStatus(updateRequest);
-        //verifyResponse(serviceResponse);
+        verifyResponse(serviceResponse);
         waitForAPIDeploymentSync(user.getUserName(), API_NAME, API_VERSION, APIMIntegrationConstants.IS_API_EXISTS);
     }
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/websocket/WebSocketAPITestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/websocket/WebSocketAPITestCase.java
@@ -250,7 +250,6 @@ public class WebSocketAPITestCase extends APIMIntegrationBaseTest {
         InputStream inputStream = new FileInputStream(getAMResourceLocation() + File.separator +
                 "configFiles" + File.separator + "webSocketTest" + File.separator + "policy.json");
         HttpResponse addPolicyResponse = adminDashboardRestClient.addThrottlingPolicy(IOUtils.toString(inputStream));
-       // verifyResponse(addPolicyResponse);
 
         //Update Throttling policy of the API
         apiRequest.setApiTier("WebSocketTestThrottlingPolicy");

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/websocket/WebSocketAPITestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/websocket/WebSocketAPITestCase.java
@@ -250,6 +250,7 @@ public class WebSocketAPITestCase extends APIMIntegrationBaseTest {
         InputStream inputStream = new FileInputStream(getAMResourceLocation() + File.separator +
                 "configFiles" + File.separator + "webSocketTest" + File.separator + "policy.json");
         HttpResponse addPolicyResponse = adminDashboardRestClient.addThrottlingPolicy(IOUtils.toString(inputStream));
+        verifyResponse(addPolicyResponse);
 
         //Update Throttling policy of the API
         apiRequest.setApiTier("WebSocketTestThrottlingPolicy");
@@ -288,7 +289,7 @@ public class WebSocketAPITestCase extends APIMIntegrationBaseTest {
         String userAccessToken = accessTokenGenerationResponse.getString("access_token");
 
         Assert.assertNotNull("Access Token not found " + accessTokenGenerationResponse, userAccessToken);
-       // testThrottling(userAccessToken);
+        testThrottling(userAccessToken);
     }
 
     @Test(description = "Invoke API using invalid token", dependsOnMethods = "testWebSocketAPIThrottling")


### PR DESCRIPTION
## Purpose
> Fixes for integration test issue on product-apim 2.x

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above
The three test cases below only created the API/Application and the Subscription and when  the test ran more than once the test had failed with duplicate error. With this changes on the destroy method we remove the subscription/application and the api
## Approach
Publisher :APIResourceWithTemplateTestCase.java  
          
WebSocket :APIMANAGER5869WSGayewatURLTestCase.java
           WebSocketAPITestCase.java  

Header :CORSHeadersTestCase.java 

The below test case had an assertion that was always successful but the assertion on line 116 was looking for a failure and was failing 
APIM614AddDocumentationToAnAPIWithDocTypeSampleAndSDKThroughPublisherRestAPITestCase  







## Test environment
> Oracle Jdk :jdk1.8.0_171
> Open Jdk java-1.8.0-openjdk-1.8.0.171-8.b10.el7_5.x86_64
> CentOS
>Mysql5.7
 
