### PR TITLE
removing microgateway usage publisher related files from distribution

### DIFF
--- a/modules/distribution/product/src/main/assembly/bin.xml
+++ b/modules/distribution/product/src/main/assembly/bin.xml
@@ -725,25 +725,6 @@
             </includes>
         </fileSet>
 
-        <!-- On-Premise Gateway related files -->
-        <fileSet>
-            <directory>../../p2-profile/product/target/wso2carbon-core-${carbon.kernel.version}/repository/stream-definitions/</directory>
-            <outputDirectory>wso2am-${pom.version}/repository/conf/stream-definitions/</outputDirectory>
-            <includes>
-                <include>*</include>
-            </includes>
-        </fileSet>
-        <fileSet>
-            <directory>
-                ../../p2-profile/product/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps
-            </directory>
-            <outputDirectory>${pom.artifactId}-${pom.version}/repository/deployment/server/webapps
-            </outputDirectory>
-            <includes>
-                <include>micro-gateway#v0.10.war</include>
-            </includes>
-        </fileSet>
-
         <!-- Copying forget me tool -->
         <fileSet>
             <directory>target/forget-me/identity-anonymization-tool-${forgetme.tool.version}</directory>
@@ -974,14 +955,6 @@
             <source>src/main/conf/carbon.properties</source>
             <outputDirectory>wso2am-${pom.version}/repository/conf</outputDirectory>
             <destName>carbon.properties</destName>
-            <filtered>true</filtered>
-        </file>
-
-        <!-- On-Premise Gateway related properties -->
-        <file>
-            <source>../../p2-profile/product/target/wso2carbon-core-${carbon.kernel.version}/repository/conf/on-premise-gateway.properties</source>
-            <outputDirectory>wso2am-${pom.version}/repository/conf</outputDirectory>
-            <destName>on-premise-gateway.properties</destName>
             <filtered>true</filtered>
         </file>
 

--- a/modules/p2-profile/product/pom.xml
+++ b/modules/p2-profile/product/pom.xml
@@ -615,11 +615,6 @@
                                 <featureArtifactDef>
                                     org.wso2.carbon.identity.auth.rest:org.wso2.carbon.identity.context.rewrite.server.feature:${carbon.identity.auth.version}
                                 </featureArtifactDef>
-
-                                <!-- On-Premise Gateway Features -->
-                                <featureArtifactDef>
-                                    org.wso2.carbon.apimgt:org.wso2.carbon.apimgt.micro.gateway.default.feature:${carbon.apimgt.version}
-                                </featureArtifactDef>
                                 <featureArtifactDef>
                                     org.wso2.carbon.utils:org.wso2.carbon.database.utils.feature:${carbon.database.utils.version}
                                 </featureArtifactDef>
@@ -1304,10 +1299,6 @@
                                 <feature>
                                     <id>org.wso2.carbon.identity.context.rewrite.server.feature.group</id>
                                     <version>${carbon.identity.auth.version}</version>
-                                </feature>
-                                <feature>
-                                    <id>org.wso2.carbon.apimgt.micro.gateway.default.feature.group</id>
-                                    <version>${carbon.apimgt.version}</version>
                                 </feature>
                             </features>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -1035,7 +1035,7 @@
         <carbon.analytics.common.version>5.1.42</carbon.analytics.common.version>
 
         <!-- APIM Component Version -->
-        <carbon.apimgt.version>6.3.103</carbon.apimgt.version>
+        <carbon.apimgt.version>6.3.109</carbon.apimgt.version>
         <carbon.apimgt.imp.pkg.version>[6.3.0, 7.0.0)</carbon.apimgt.imp.pkg.version>
 
         <!-- Carbon Registry -->


### PR DESCRIPTION
## Purpose

Removing some files from the distribution because the feature has been moved to Analytics Server.