### PR TITLE
fix file path and resource path separator for all the env including windows

### DIFF
--- a/modules/integration/tests-common/admin-clients/src/main/java/org/wso2/am/admin/clients/webapp/WebAppAdminClient.java
+++ b/modules/integration/tests-common/admin-clients/src/main/java/org/wso2/am/admin/clients/webapp/WebAppAdminClient.java
@@ -60,7 +60,7 @@ public class WebAppAdminClient {
     public boolean uploadWarFile(String filePath) throws RemoteException, MalformedURLException {
         File file = new File(filePath);
         String fileName = file.getName();
-        URL url = new URL("file://" + filePath);
+        URL url = new URL("file:///" + filePath);
         DataHandler dh = new DataHandler(url);
         WebappUploadData webApp;
         webApp = new WebappUploadData();

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/sequence/DefaultEndpointTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/sequence/DefaultEndpointTestCase.java
@@ -32,6 +32,7 @@ public class DefaultEndpointTestCase extends APIManagerLifecycleBaseTest {
     private final String API_DESCRIPTION = "This is test API create by API manager integration test";
     private final String API_VERSION_1_0_0 = "1.0.0";
     private final String APPLICATION_NAME = "AddDynamicEndpointAndInvokeAPI";
+    private final String RESOURCE_PATH_SEPARATOR = "/";
     private APIPublisherRestClient apiPublisherClientUser1;
     private APIStoreRestClient apiStoreClientUser1;
     private APICreationRequestBean apiCreationRequestBean;
@@ -74,13 +75,13 @@ public class DefaultEndpointTestCase extends APIManagerLifecycleBaseTest {
 
         boolean isResourceAdded = resourceAdminServiceStub.addResource(
                 "/_system/governance/apimgt/applicationdata/provider" +
-                File.separator + apiUser + File.separator + API_NAME + File.separator + API_VERSION_1_0_0 + File.separator +
+                        RESOURCE_PATH_SEPARATOR + apiUser + RESOURCE_PATH_SEPARATOR + API_NAME + RESOURCE_PATH_SEPARATOR + API_VERSION_1_0_0 + RESOURCE_PATH_SEPARATOR +
                 //"/admin/AddNewMediationAndInvokeAPITest/1.0.0/" +
                 "in/default_endpoint.xml",
                 "application/xml",
                 "xml files",
-                new DataHandler(new URL("file:///" + getAMResourceLocation() + File.separator + "sequence"
-                                        + File.separator + "default_endpoint.xml")));
+                new DataHandler(new URL("file:///" + getAMResourceLocation() + RESOURCE_PATH_SEPARATOR + "sequence"
+                                        + RESOURCE_PATH_SEPARATOR + "default_endpoint.xml")));
 
         assertTrue(isResourceAdded, "Adding Mediation Sequence File failed");
 


### PR DESCRIPTION
## Purpose
This will fix the integration test failures occurred on Windows platform.  

## Approach
corrected file url prefix in WebAppAdminClient#uploadWarFile as "File:///"
previous value "File://" doesn't work on Windows environments

corrected resource path separater as "/" in DefaultEndpointTestCase#testAPIInvocationAfterAddingDynamicEndpoint
previous value was the File.separator which led the url to be malformed in Windows.

## Test environment
Tested on Centos, Ubuntu, Windows
