### PR TITLE
Fixing File Path Issue With Escape Character

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/json/ESBJAVA3380TestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/json/ESBJAVA3380TestCase.java
@@ -88,10 +88,9 @@ public class ESBJAVA3380TestCase extends APIMIntegrationBaseTest {
         gatewaySessionCookie = createSession(gatewayContextMgt);
 
         String apiMngrSynapseConfigPath = "/artifacts/AM/synapseconfigs/property/json_to_xml.xml";
-        String relativeFilePath = apiMngrSynapseConfigPath.replaceAll(
-                "[\\\\]", File.separator);
+                
         if(userMode == TestUserMode.SUPER_TENANT_USER || userMode == TestUserMode.SUPER_TENANT_ADMIN) {
-            loadSynapseConfigurationFromClasspath(relativeFilePath, gatewayContextMgt, gatewaySessionCookie);
+            loadSynapseConfigurationFromClasspath(apiMngrSynapseConfigPath, gatewayContextMgt, gatewaySessionCookie);
         } else {
             //changing the context when the user is tenant
             String apiConfiguration = FileManager.readFile(TestConfigurationProvider.getResourceLocation() + apiMngrSynapseConfigPath);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/json/ESBJAVA3380TestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/json/ESBJAVA3380TestCase.java
@@ -89,7 +89,7 @@ public class ESBJAVA3380TestCase extends APIMIntegrationBaseTest {
 
         String apiMngrSynapseConfigPath = "/artifacts/AM/synapseconfigs/property/json_to_xml.xml";
         String relativeFilePath = apiMngrSynapseConfigPath.replaceAll(
-                "[\\\\/]", File.separator);
+                "[\\\\]", File.separator);
         if(userMode == TestUserMode.SUPER_TENANT_USER || userMode == TestUserMode.SUPER_TENANT_ADMIN) {
             loadSynapseConfigurationFromClasspath(relativeFilePath, gatewayContextMgt, gatewaySessionCookie);
         } else {

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/APIM4312NPEAfterRequestTimeoutTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/APIM4312NPEAfterRequestTimeoutTestCase.java
@@ -80,7 +80,7 @@ public class APIM4312NPEAfterRequestTimeoutTestCase extends APIMIntegrationBaseT
         } else {
             apiMngrSynapseConfigPath = "/artifacts/AM/synapseconfigs/rest/dummy_api_APIMANAGER-4312_tenant.xml";
         }
-        String relativeFilePath = apiMngrSynapseConfigPath.replaceAll("[\\\\/]", File.separator);
+        String relativeFilePath = apiMngrSynapseConfigPath.replaceAll("[\\\\]", File.separator);
         loadSynapseConfigurationFromClasspath(relativeFilePath, gatewayContextMgt, gatewaySessionCookie);
     }
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/APIM4312NPEAfterRequestTimeoutTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/APIM4312NPEAfterRequestTimeoutTestCase.java
@@ -80,8 +80,7 @@ public class APIM4312NPEAfterRequestTimeoutTestCase extends APIMIntegrationBaseT
         } else {
             apiMngrSynapseConfigPath = "/artifacts/AM/synapseconfigs/rest/dummy_api_APIMANAGER-4312_tenant.xml";
         }
-        String relativeFilePath = apiMngrSynapseConfigPath.replaceAll("[\\\\]", File.separator);
-        loadSynapseConfigurationFromClasspath(relativeFilePath, gatewayContextMgt, gatewaySessionCookie);
+        loadSynapseConfigurationFromClasspath(apiMngrSynapseConfigPath, gatewayContextMgt, gatewaySessionCookie);
     }
 
     @Test(groups = { "noRestart" },


### PR DESCRIPTION
## Purpose
> This will fix the integration test failures occurred on Windows platform with escape character for File Path.

## Approach
> Corrected relativeFilePath in APIM4312NPEAfterRequestTimeoutTestCase#setEnvironment as "[\\\\]".
Previous value "[\\\\/]" doesn't work on Windows environments.

> Corrected relativeFilePath in ESBJAVA3380TestCase#setEnvironment as "[\\\\]".
Previous value "[\\\\/]" doesn't work on Windows environments.

## Test environment
> Tested on Centos, Ubuntu, Windows and Mac OSs.
