### PR TITLE
Fixing the issue in test execution environment

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/AdvancedConfigDeploymentConfig.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/AdvancedConfigDeploymentConfig.java
@@ -33,10 +33,13 @@ import org.wso2.carbon.automation.engine.context.TestUserMode;
 import org.wso2.carbon.automation.test.utils.common.TestConfigurationProvider;
 import org.wso2.carbon.integration.common.utils.mgt.ServerConfigurationManager;
 import org.wso2.carbon.utils.ServerConstants;
+import org.wso2.carbon.automation.engine.annotations.SetEnvironment;
+import org.wso2.carbon.automation.engine.annotations.ExecutionEnvironment;
 
 import java.io.File;
 import java.io.FileInputStream;
 
+@SetEnvironment(executionEnvironments = {ExecutionEnvironment.STANDALONE})
 public class AdvancedConfigDeploymentConfig extends APIMIntegrationBaseTest {
     private static final Log log = LogFactory.getLog(AdvancedConfigDeploymentConfig.class);
     private final String TENANT_CONFIG_LOCATION = "/_system/config/apimgt/applicationdata/tenant-conf.json";

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/websocket/WebSocketAPITestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/websocket/WebSocketAPITestCase.java
@@ -55,6 +55,8 @@ import org.wso2.carbon.automation.test.utils.common.TestConfigurationProvider;
 import org.wso2.carbon.automation.test.utils.http.client.HttpResponse;
 import org.wso2.carbon.integration.common.utils.mgt.ServerConfigurationManager;
 import org.wso2.carbon.utils.xml.StringUtils;
+import org.wso2.carbon.automation.engine.annotations.SetEnvironment;
+import org.wso2.carbon.automation.engine.annotations.ExecutionEnvironment;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -74,6 +76,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
+@SetEnvironment(executionEnvironments = {ExecutionEnvironment.STANDALONE})
 public class WebSocketAPITestCase extends APIMIntegrationBaseTest {
     private final Log log = LogFactory.getLog(WebSocketAPITestCase.class);
     private final ExecutorService executorService = Executors.newSingleThreadExecutor();


### PR DESCRIPTION
## Purpose
> This will fix the platform test failures occurred due to 'null' value set to the 'carbon.home' variable. 

## Approach
> To fix the platform test failures test execution environment is set as 'Standalone' so that the tests will not be considered for the platform integration tests.

## Test environment
> JDK 1.8, Centos, MySQL database
