### PR TITLE
Update the test execution environment

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/throttling/AdvancedThrottlingConfig.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/throttling/AdvancedThrottlingConfig.java
@@ -30,11 +30,14 @@ import org.wso2.am.integration.test.utils.webapp.WebAppDeploymentUtil;
 import org.wso2.carbon.automation.engine.context.AutomationContext;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
 import org.wso2.carbon.integration.common.utils.mgt.ServerConfigurationManager;
+import org.wso2.carbon.automation.engine.annotations.SetEnvironment;
+import org.wso2.carbon.automation.engine.annotations.ExecutionEnvironment;
 
 import java.io.File;
 
 import static org.testng.Assert.assertTrue;
 
+@SetEnvironment(executionEnvironments = {ExecutionEnvironment.STANDALONE})
 public class AdvancedThrottlingConfig extends APIMIntegrationBaseTest {
     private ServerConfigurationManager serverConfigurationManager;
     private AutomationContext superTenantKeyManagerContext;


### PR DESCRIPTION
## Purpose
> This will fix the platform test failures occurred due to 'null' value set to the 'serverConfigurationManager' parameter

## Approach
> To fix the platform test failures, test execution environment is set as 'Standalone' so that the tests will not be considered for the platform integration tests.

## Test environment
> JDK 1.8, Centos, MySQL database
 