### PR TITLE
Fix tests cases and update master-ds.xml

### DIFF
--- a/modules/distribution/product/src/main/conf/master-datasources.xml
+++ b/modules/distribution/product/src/main/conf/master-datasources.xml
@@ -23,6 +23,7 @@
                     <testOnBorrow>true</testOnBorrow>
                     <validationQuery>SELECT 1</validationQuery>
                     <validationInterval>30000</validationInterval>
+                    <defaultAutoCommit>true</defaultAutoCommit>
                 </configuration>
             </definition>
         </datasource>
@@ -38,7 +39,7 @@
                     <url>jdbc:h2:repository/database/WSO2AM_DB;DB_CLOSE_ON_EXIT=FALSE</url>
                     <username>wso2carbon</username>
                     <password>wso2carbon</password>
-                    <defaultAutoCommit>false</defaultAutoCommit>
+                    <defaultAutoCommit>true</defaultAutoCommit>
                     <driverClassName>org.h2.Driver</driverClassName>
                     <maxActive>50</maxActive>
                     <maxWait>60000</maxWait>
@@ -60,7 +61,7 @@
                     <url>jdbc:h2:../tmpStatDB/WSO2AM_STATS_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000;AUTO_SERVER=TRUE</url>
                     <username>wso2carbon</username>
                     <password>wso2carbon</password>
-                    <defaultAutoCommit>false</defaultAutoCommit>
+                    <defaultAutoCommit>true</defaultAutoCommit>
                     <driverClassName>org.h2.Driver</driverClassName>
                     <maxActive>50</maxActive>
                     <maxWait>60000</maxWait>

--- a/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/utils/clients/APIPublisherRestClient.java
+++ b/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/utils/clients/APIPublisherRestClient.java
@@ -187,6 +187,7 @@ public class APIPublisherRestClient {
     public HttpResponse changeAPILifeCycleStatus(APILifeCycleStateRequest updateRequest)
             throws APIManagerIntegrationTestException {
         try {
+            Thread.sleep(1000); // this is to make sure timestamps of current and next lifecycle states are different
             checkAuthentication();
             return HTTPSClientUtils.doPost(
                     new URL(backendURL + "publisher/site/blocks/life-cycles/ajax/life-cycles.jag"),
@@ -424,6 +425,7 @@ public class APIPublisherRestClient {
     public HttpResponse changeAPILifeCycleStatusToPublish(APIIdentifier apiIdentifier, boolean isRequireReSubscription)
             throws APIManagerIntegrationTestException {
         try {
+            Thread.sleep(1000); // this is to make sure timestamps of current and next lifecycle states are different
             checkAuthentication();
             APILifeCycleStateRequest publishUpdateRequest =
                     new APILifeCycleStateRequest(apiIdentifier.getApiName(), apiIdentifier.getProviderName(),

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/APIAccessibilityOfPublishedOldAPIAndPublishedCopyAPITestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/APIAccessibilityOfPublishedOldAPIAndPublishedCopyAPITestCase.java
@@ -34,13 +34,12 @@ import org.wso2.carbon.apimgt.api.model.APIIdentifier;
 import org.wso2.carbon.automation.test.utils.http.client.HttpRequestUtil;
 import org.wso2.carbon.automation.test.utils.http.client.HttpResponse;
 
-import javax.xml.xpath.XPathExpressionException;
-import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.xml.xpath.XPathExpressionException;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -113,8 +112,6 @@ public class APIAccessibilityOfPublishedOldAPIAndPublishedCopyAPITestCase
         assertEquals(getValueFromJSON(httpResponseCopyAPI, "error"), "false",
                      "Copy  API response data is invalid" + getAPIIdentifierString(apiIdentifierAPI1Version1) +
                      "Response Data:" + httpResponseCopyAPI.getData());
-
-        Thread.sleep(1000); //This is required to set a time difference between timestamps of current state and next
     }
 
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/APIMANAGER5337SubscriptionRetainTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/APIMANAGER5337SubscriptionRetainTestCase.java
@@ -107,8 +107,6 @@ public class APIMANAGER5337SubscriptionRetainTestCase extends APIManagerLifecycl
             response = apiStore.subscribe(subscriptionRequest);
             verifyResponse(response);
 
-            Thread.sleep(1000);
-
             //Demote the API to the Created State
             APILifeCycleStateRequest updateRequest2 = new APILifeCycleStateRequest(apiName,
                     user.getUserName(), APILifeCycleState.CREATED);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/APIManagerLifecycleBaseTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/APIManagerLifecycleBaseTest.java
@@ -23,23 +23,26 @@ import org.apache.commons.logging.LogFactory;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.testng.annotations.BeforeClass;
 import org.wso2.am.integration.test.utils.APIManagerIntegrationTestException;
 import org.wso2.am.integration.test.utils.base.APIMIntegrationBaseTest;
 import org.wso2.am.integration.test.utils.base.APIMIntegrationConstants;
-import org.wso2.am.integration.test.utils.bean.*;
+import org.wso2.am.integration.test.utils.bean.APICreationRequestBean;
+import org.wso2.am.integration.test.utils.bean.APILifeCycleState;
+import org.wso2.am.integration.test.utils.bean.APILifeCycleStateRequest;
+import org.wso2.am.integration.test.utils.bean.APPKeyRequestGenerator;
+import org.wso2.am.integration.test.utils.bean.ApplicationKeyBean;
+import org.wso2.am.integration.test.utils.bean.SubscriptionRequest;
 import org.wso2.am.integration.test.utils.clients.APIPublisherRestClient;
 import org.wso2.am.integration.test.utils.clients.APIStoreRestClient;
 import org.wso2.carbon.apimgt.api.model.APIIdentifier;
 import org.wso2.carbon.automation.engine.frameworkutils.FrameworkPathUtil;
 import org.wso2.carbon.automation.test.utils.http.client.HttpResponse;
 
-import javax.ws.rs.core.Response;
-import javax.xml.xpath.XPathExpressionException;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import javax.ws.rs.core.Response;
 
 /**
  * Base test class for all API Manager lifecycle test cases. This class contents the all the
@@ -273,11 +276,6 @@ public class APIManagerLifecycleBaseTest extends APIMIntegrationBaseTest {
         if (createAPIResponse.getResponseCode() == HTTP_RESPONSE_CODE_OK &&
                 getValueFromJSON(createAPIResponse, "error").equals("false")) {
             log.info("API Created :" + getAPIIdentifierString(apiIdentifier));
-            try {
-                Thread.sleep(1000); //This is required to set a time difference between timestamps of current state and next
-            } catch (InterruptedException e) {
-                throw new APIManagerIntegrationTestException(e.getMessage(), e);
-            }
             //Publish the API
             HttpResponse publishAPIResponse = publishAPI(apiIdentifier, publisherRestClient, isRequireReSubscription);
             if (!(publishAPIResponse.getResponseCode() == HTTP_RESPONSE_CODE_OK &&

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/APIPublishingAndVisibilityInStoreTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/APIPublishingAndVisibilityInStoreTestCase.java
@@ -25,19 +25,20 @@ import org.wso2.am.integration.test.utils.APIManagerIntegrationTestException;
 import org.wso2.am.integration.test.utils.base.APIMIntegrationConstants;
 import org.wso2.am.integration.test.utils.bean.APICreationRequestBean;
 import org.wso2.am.integration.test.utils.bean.APILifeCycleState;
-import org.wso2.am.integration.test.utils.bean.APILifeCycleStateRequest;
 import org.wso2.am.integration.test.utils.clients.APIPublisherRestClient;
 import org.wso2.am.integration.test.utils.clients.APIStoreRestClient;
 import org.wso2.am.integration.test.utils.generic.APIMTestCaseUtils;
 import org.wso2.carbon.apimgt.api.model.APIIdentifier;
 import org.wso2.carbon.automation.test.utils.http.client.HttpResponse;
 
-import javax.xml.xpath.XPathExpressionException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
+import javax.xml.xpath.XPathExpressionException;
 
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 /**
  * Publish a API and check its visibility in the API Store.
@@ -114,7 +115,7 @@ public class APIPublishingAndVisibilityInStoreTestCase extends APIManagerLifecyc
     @Test(groups = {"wso2.am"}, description = "Test the API publishing action. " +
             "Response HTTP message should contains API status change from  CREATED to PUBLISHED",
             dependsOnMethods = "testVisibilityOfAPIInStoreBeforePublishing")
-    public void testAPIPublishing() throws APIManagerIntegrationTestException, XPathExpressionException {
+    public void testAPIPublishing() throws Exception {
         //Publish the API
         HttpResponse publishAPIResponse =
                 apiPublisherClientUser1.changeAPILifeCycleStatusToPublish(apiIdentifier, false);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/AccessibilityOfBlockAPITestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/AccessibilityOfBlockAPITestCase.java
@@ -32,12 +32,11 @@ import org.wso2.carbon.apimgt.api.model.APIIdentifier;
 import org.wso2.carbon.automation.test.utils.http.client.HttpRequestUtil;
 import org.wso2.carbon.automation.test.utils.http.client.HttpResponse;
 
-import javax.xml.xpath.XPathExpressionException;
-import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
+import javax.xml.xpath.XPathExpressionException;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -121,7 +120,6 @@ public class AccessibilityOfBlockAPITestCase extends APIManagerLifecycleBaseTest
                 new APILifeCycleStateRequest(API_NAME, providerName, APILifeCycleState.BLOCKED);
         blockUpdateRequest.setVersion(API_VERSION_1_0_0);
         //Change API lifecycle  to Block
-        Thread.sleep(1000); // this is to make sure published and blocked timestamps are different
         HttpResponse blockAPIActionResponse =
                 apiPublisherClientUser1.changeAPILifeCycleStatus(blockUpdateRequest);
         assertEquals(blockAPIActionResponse.getResponseCode(), HTTP_RESPONSE_CODE_OK, "Response code mismatched");

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/AccessibilityOfOldAPIAndCopyAPIWithOutReSubscriptionTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/AccessibilityOfOldAPIAndCopyAPIWithOutReSubscriptionTestCase.java
@@ -25,19 +25,18 @@ import org.wso2.am.integration.test.utils.APIManagerIntegrationTestException;
 import org.wso2.am.integration.test.utils.base.APIMIntegrationConstants;
 import org.wso2.am.integration.test.utils.bean.APICreationRequestBean;
 import org.wso2.am.integration.test.utils.bean.APILifeCycleState;
-import org.wso2.am.integration.test.utils.bean.APILifeCycleStateRequest;
 import org.wso2.am.integration.test.utils.clients.APIPublisherRestClient;
 import org.wso2.am.integration.test.utils.clients.APIStoreRestClient;
 import org.wso2.carbon.apimgt.api.model.APIIdentifier;
 import org.wso2.carbon.automation.test.utils.http.client.HttpRequestUtil;
 import org.wso2.carbon.automation.test.utils.http.client.HttpResponse;
 
-import javax.xml.xpath.XPathExpressionException;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
+import javax.xml.xpath.XPathExpressionException;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -124,7 +123,6 @@ public class AccessibilityOfOldAPIAndCopyAPIWithOutReSubscriptionTestCase extend
         //Copy  API
         copyAPI(apiIdentifierAPI1Version1, API_VERSION_2_0_0, apiPublisherClientUser1);
         //Publish  version 2.0.0 without re-subscription required
-        Thread.sleep(1000); // this is to make sure created and published timestamps are different
         HttpResponse publishAPIResponse =
                 apiPublisherClientUser1.changeAPILifeCycleStatusToPublish(apiIdentifierAPI1Version2, false);
         assertEquals(publishAPIResponse.getResponseCode(), HTTP_RESPONSE_CODE_OK,

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/AccessibilityOfRetireAPITestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/AccessibilityOfRetireAPITestCase.java
@@ -33,12 +33,12 @@ import org.wso2.carbon.apimgt.api.model.APIIdentifier;
 import org.wso2.carbon.automation.test.utils.http.client.HttpRequestUtil;
 import org.wso2.carbon.automation.test.utils.http.client.HttpResponse;
 
-import javax.xml.xpath.XPathExpressionException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.xml.xpath.XPathExpressionException;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -112,7 +112,6 @@ public class AccessibilityOfRetireAPITestCase extends APIManagerLifecycleBaseTes
         assertTrue(oldVersionInvokeResponse.getData().contains(API_RESPONSE_DATA),
                 "Response data mismatched when invoke  API  before Retire" +
                         " Response Data:" + oldVersionInvokeResponse.getData());
-        Thread.sleep(1000); //This is required to set a time difference between timestamps of current state and next
     }
 
     @Test(groups = {"wso2.am"}, description = "Change API lifecycle to Retired",
@@ -130,7 +129,6 @@ public class AccessibilityOfRetireAPITestCase extends APIManagerLifecycleBaseTes
                 APILifeCycleState.DEPRECATED), "API status Change is invalid when retire an API :" +
                 getAPIIdentifierString(apiIdentifier) +
                 " Response Code:" + blockAPIActionResponse.getData());
-        Thread.sleep(1000); //This is required to set a time difference between timestamps of current state and next
     }
 
     @Test(groups = {"wso2.am"}, description = "Change API lifecycle to Retired",

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/CustomLifeCycleTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/CustomLifeCycleTestCase.java
@@ -20,7 +20,6 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.am.admin.clients.lifecycle.LifeCycleAdminClient;
-import org.wso2.am.integration.test.utils.APIManagerIntegrationTestException;
 import org.wso2.am.integration.test.utils.bean.APICreationRequestBean;
 import org.wso2.am.integration.test.utils.bean.APILifeCycleState;
 import org.wso2.am.integration.test.utils.bean.APILifeCycleStateRequest;
@@ -80,7 +79,6 @@ public class CustomLifeCycleTestCase extends APIManagerLifecycleBaseTest {
         apiLifeCycleStatusChangeRequest.setVersion(apiIdentifier.getVersion());
 
         //Change api status to custom state
-        Thread.sleep(1000); // this is to make sure published and promoted timestamps are different
         HttpResponse publishAPIResponse = apiPublisherClient.changeAPILifeCycleStatus(apiLifeCycleStatusChangeRequest);
         Boolean statusChangeSuccess = verifyAPIStatusChange(publishAPIResponse, APILifeCycleState.PUBLISHED,
                 APILifeCycleState.PROMOTED);


### PR DESCRIPTION
## Purpose

- Take all Thread.sleeps, which were added to make sure 2 lifecycle states have 2 different timestamps, to a single place
- Set default autocommit true in master ds