### PR TITLE
Change SOAP namespace to match with the soap version(1.2)

### DIFF
--- a/modules/distribution/resources/api_templates/soap_to_rest_in_seq_template.xml
+++ b/modules/distribution/resources/api_templates/soap_to_rest_in_seq_template.xml
@@ -22,7 +22,7 @@ $mapping.get('properties')
 #end
 <payloadFactory description="transform" media-type="xml">
   <format>
-  <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:web="${namespace}">
+  <soapenv:Envelope xmlns:soapenv="http://www.w3.org/2003/05/soap-envelope" xmlns:web="${namespace}">
   <soapenv:Header/>
   <soapenv:Body>
   	$mapping.get('sequence')


### PR DESCRIPTION
## Purpose

- Fix the SOAP API invocation issue, by changing SOAP namespace to match with the soap version(i.e.1.2) which is related to the current content-type(i.e.application/soap+xml)