### PR TITLE
fix docker integration test fauilure on Mac

### DIFF
--- a/modules/integration-tests/pom.xml
+++ b/modules/integration-tests/pom.xml
@@ -129,9 +129,9 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <environmentVariables>
+                    <!--<environmentVariables>
                         <SERVER_HOST>${docker.container.product-apim.ip}:9443</SERVER_HOST>
-                    </environmentVariables>
+                    </environmentVariables>-->
                     <suiteXmlFiles>
                         <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
                     </suiteXmlFiles>
@@ -168,12 +168,20 @@
                                 <namingStrategy>alias</namingStrategy>
                                 <wait>
                                     <tcp>
+                                        <mode>mapped</mode>
                                         <ports>
                                             <port>9443</port>
                                         </ports>
                                     </tcp>
                                     <time>60000</time>
                                 </wait>
+                                <wait>
+                                    <log>WSO2 Carbon Kernel started</log>
+                                    <time>20000</time>
+                                </wait>
+                                <ports>
+                                    <port>+bind.host.name:9443:9443</port>
+                                </ports>
                             </run>
                         </image>
                     </images>
@@ -286,5 +294,6 @@
         <jackson-version>2.8.9</jackson-version>
         <jackson-threetenbp-version>2.6.4</jackson-threetenbp-version>
         <oltu-version>1.0.1</oltu-version>
+        <bind.host.name>localhost</bind.host.name>
     </properties>
 </project>

--- a/modules/integration-tests/pom.xml
+++ b/modules/integration-tests/pom.xml
@@ -177,7 +177,6 @@
                                 </wait>
                                 <wait>
                                     <log>WSO2 Carbon Kernel started</log>
-                                    <time>20000</time>
                                 </wait>
                                 <ports>
                                     <port>+bind.host.name:9443:9443</port>


### PR DESCRIPTION
## Purpose
> This PR fixes Docker integration test failure on Mac.

 Failed to execute goal io.fabric8:docker-maven-plugin:0.26.1:start (start-docker) on project api-manager-test: Execution start-docker of goal io.fabric8:docker-maven-plugin:0.26.1:start failed: Start-Job failed with unexpected exception: [wso2am:3.0.0-SNAPSHOT] "product-apim": Timeout after 20271 ms while waiting on log out 'WSO2 Carbon Kernel started'