### PR TITLE
WIP - Upgrade OSGi, P2, C4, metrics and apimgt dependencies to support Java 10

### DIFF
--- a/modules/distribution/product/pom.xml
+++ b/modules/distribution/product/pom.xml
@@ -51,7 +51,7 @@
             <artifactId>h2-database-engine</artifactId>
             <exclusions>
                 <exclusion>
-                    <groupId>org.eclipse.osgi</groupId>
+                    <groupId>org.wso2.eclipse.osgi</groupId>
                     <artifactId>org.eclipse.osgi</artifactId>
                 </exclusion>
                 <exclusion>

--- a/modules/distribution/product/src/main/startup-scripts/wso2server.sh
+++ b/modules/distribution/product/src/main/startup-scripts/wso2server.sh
@@ -222,10 +222,11 @@ elif [ "$CMD" = "version" ]; then
 fi
 
 # ---------- Handle the SSL Issue with proper JDK version --------------------
-jdk_17=`$JAVA_HOME/bin/java -version 2>&1 | grep "1.[7|8]"`
-if [ "$jdk_17" = "" ]; then
+java_version=$("$JAVACMD" -version 2>&1 | awk -F '"' '/version/ {print $2}')
+java_version_formatted=$(echo "$java_version" | awk -F. '{printf("%02d%02d",$1,$2);}')
+if [ $java_version_formatted -lt 0107 ] || [ $java_version_formatted -gt 1000 ]; then
    echo " Starting WSO2 Carbon (in unsupported JDK)"
-   echo " [ERROR] CARBON is supported only on JDK 1.7 and 1.8"
+   echo " [ERROR] CARBON is supported only on JDK 1.7, 1.8, 9 and 10"
 fi
 
 CARBON_XBOOTCLASSPATH=""
@@ -252,13 +253,25 @@ for t in "$CARBON_HOME"/lib/commons-lang*.jar
 do
     CARBON_CLASSPATH="$CARBON_CLASSPATH":$t
 done
+
+if [ $java_version_formatted -ge 0900 ]; then
+    for f in "$CARBON_HOME"/lib/endorsed/*.jar
+    do
+       if [ "$f" != "$CARBON_HOME/lib/endorsed/*.jar" ];then
+           CARBON_CLASSPATH="$CARBON_CLASSPATH":$f
+       fi
+    done
+fi
+
 # For Cygwin, switch paths to Windows format before running java
 if $cygwin; then
   JAVA_HOME=`cygpath --absolute --windows "$JAVA_HOME"`
   CARBON_HOME=`cygpath --absolute --windows "$CARBON_HOME"`
   AXIS2_HOME=`cygpath --absolute --windows "$CARBON_HOME"`
   CLASSPATH=`cygpath --path --windows "$CLASSPATH"`
-  JAVA_ENDORSED_DIRS=`cygpath --path --windows "$JAVA_ENDORSED_DIRS"`
+  if [ $java_version_formatted -le 0108 ]; then
+    JAVA_ENDORSED_DIRS=`cygpath --path --windows "$JAVA_ENDORSED_DIRS"`
+  fi
   CARBON_CLASSPATH=`cygpath --path --windows "$CARBON_CLASSPATH"`
   CARBON_XBOOTCLASSPATH=`cygpath --path --windows "$CARBON_XBOOTCLASSPATH"`
 fi
@@ -290,6 +303,14 @@ echo "Using Java memory options: $JVM_MEM_OPTS"
 #To monitor a Carbon server in remote JMX mode on linux host machines, set the below system property.
 #   -Djava.rmi.server.hostname="your.IP.goes.here"
 
+JAVA_VER_BASED_OPTS=""
+if [ $java_version_formatted -le 0108 ]; then
+    JAVA_VER_BASED_OPTS="-Djava.endorsed.dirs=$JAVA_ENDORSED_DIRS"
+fi
+if [ $java_version_formatted -ge 0900 ]; then
+    JAVA_VER_BASED_OPTS="--add-modules=java.activation,java.xml.bind"
+fi
+
 while [ "$status" = "$START_EXIT_STATUS" ]
 do
     $JAVACMD \
@@ -300,7 +321,7 @@ do
     $JAVA_OPTS \
     -Dcom.sun.management.jmxremote \
     -classpath "$CARBON_CLASSPATH" \
-    -Djava.endorsed.dirs="$JAVA_ENDORSED_DIRS" \
+    $JAVA_VER_BASED_OPTS \
     -Djava.io.tmpdir="$CARBON_HOME/tmp" \
     -Dcatalina.base="$CARBON_HOME/lib/tomcat" \
     -Dwso2.server.standalone=true \

--- a/modules/distribution/resources/migration/wso2-api-migration-client/pom.xml
+++ b/modules/distribution/resources/migration/wso2-api-migration-client/pom.xml
@@ -204,7 +204,7 @@
     <properties>
         <carbon.apimgt.version>6.3.124</carbon.apimgt.version>
         <carbon.governance.version>4.7.27</carbon.governance.version>
-        <carbon.kernel.version>4.4.35</carbon.kernel.version>
+        <carbon.kernel.version>4.4.37-SNAPSHOT</carbon.kernel.version> <!-- carbon-kernel branch: 4.4.x_java10 -->
         <maven.build.timestamp.format>yyyy-MM-dd HH:mm:ss</maven.build.timestamp.format>
     </properties>
 </project>

--- a/modules/p2-profile/product/carbon.product
+++ b/modules/p2-profile/product/carbon.product
@@ -2,7 +2,7 @@
 <?pde version="3.5"?>
 
 <product name="Carbon Product" uid="carbon.product.id" id="carbon.product" application="carbon.application"
-version="4.4.35" useFeatures="true" includeLaunchers="true">
+version="4.4.37.SNAPSHOT" useFeatures="true" includeLaunchers="true">
 
    <configIni use="default">
    </configIni>
@@ -14,7 +14,7 @@ version="4.4.35" useFeatures="true" includeLaunchers="true">
    </plugins>
 
    <features>
-      <feature id="org.wso2.carbon.core.runtime" version="4.4.35"/>
+      <feature id="org.wso2.carbon.core.runtime" version="4.4.37.SNAPSHOT"/>
    </features>
 
   <configurations>

--- a/modules/p2-profile/product/pom.xml
+++ b/modules/p2-profile/product/pom.xml
@@ -1042,10 +1042,10 @@
                                     <version>${jaggery.modules.i18n.feature.version}</version>
                                 </feature>
                                 
-                                <feature>
-                                    <id>org.wso2.carbon.apimgt.feature.group</id>
-                                    <version>${carbon.apimgt.version}</version>
-                                </feature>
+                                <!--<feature>-->
+                                    <!--<id>org.wso2.carbon.apimgt.feature.group</id>-->
+                                    <!--<version>${carbon.apimgt.version}</version>-->
+                                <!--</feature>-->
                                 
                                 <!--Registry Feature-->
                                 <feature>
@@ -1991,14 +1991,14 @@
                                     <id>org.wso2.carbon.apimgt.core.feature.group</id>
                                     <version>${carbon.apimgt.version}</version>
                                 </feature>
-                                <feature>
-                                    <id>org.wso2.carbon.apimgt.store.feature.group</id>
-                                    <version>${carbon.apimgt.version}</version>
-                                </feature>
-                                <feature>
-                                    <id>org.wso2.carbon.apimgt.keymanager.feature.group</id>
-                                    <version>${carbon.apimgt.version}</version>
-                                </feature>
+                                <!--<feature>-->
+                                    <!--<id>org.wso2.carbon.apimgt.store.feature.group</id>-->
+                                    <!--<version>${carbon.apimgt.version}</version>-->
+                                <!--</feature>-->
+                                <!--<feature>-->
+                                    <!--<id>org.wso2.carbon.apimgt.keymanager.feature.group</id>-->
+                                    <!--<version>${carbon.apimgt.version}</version>-->
+                                <!--</feature>-->
                                 <feature>
                                     <id>org.wso2.carbon.registry.extensions.feature.group</id>
                                     <version>${carbon.governance.version}</version>
@@ -2465,10 +2465,10 @@
                                     <id>org.wso2.carbon.apimgt.gateway.feature.group</id>
                                     <version>${carbon.apimgt.version}</version>
                                 </feature>
-                                <feature>
-                                    <id>org.wso2.carbon.apimgt.keymanager.feature.group</id>
-                                    <version>${carbon.apimgt.version}</version>
-                                </feature>
+                                <!--<feature>-->
+                                    <!--<id>org.wso2.carbon.apimgt.keymanager.feature.group</id>-->
+                                    <!--<version>${carbon.apimgt.version}</version>-->
+                                <!--</feature>-->
                                 <feature>
                                     <id>org.wso2.carbon.apimgt.core.feature.group</id>
                                     <version>${carbon.apimgt.version}</version>
@@ -2949,10 +2949,10 @@
                                     <id>org.wso2.carbon.apimgt.core.feature.group</id>
                                     <version>${carbon.apimgt.version}</version>
                                 </feature>
-                                <feature>
-                                    <id>org.wso2.carbon.apimgt.keymanager.feature.group</id>
-                                    <version>${carbon.apimgt.version}</version>
-                                </feature>
+                                <!--<feature>-->
+                                    <!--<id>org.wso2.carbon.apimgt.keymanager.feature.group</id>-->
+                                    <!--<version>${carbon.apimgt.version}</version>-->
+                                <!--</feature>-->
                                 <feature>
                                     <id>org.wso2.carbon.registry.extensions.feature.group</id>
                                     <version>${carbon.governance.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -230,7 +230,7 @@
                 <version>${carbon.kernel.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.eclipse.osgi</groupId>
+                <groupId>org.wso2.eclipse.osgi</groupId>
                 <artifactId>org.eclipse.osgi</artifactId>
                 <version>${version.equinox.osgi}</version>
             </dependency>
@@ -245,7 +245,7 @@
                 <version>${version.equinox.http.helper}</version>
             </dependency>
             <dependency>
-                <groupId>org.eclipse.osgi</groupId>
+                <groupId>org.wso2.eclipse.osgi</groupId>
                 <artifactId>org.eclipse.osgi.services</artifactId>
                 <version>${version.equinox.osgi.services}</version>
             </dependency>
@@ -1035,7 +1035,7 @@
         <carbon.analytics.common.version>5.1.42</carbon.analytics.common.version>
 
         <!-- APIM Component Version -->
-        <carbon.apimgt.version>6.4.60</carbon.apimgt.version>
+        <carbon.apimgt.version>6.4.73-SNAPSHOT</carbon.apimgt.version> <!-- carbon-apimgt branch: 6.x_java10 -->
         <carbon.apimgt.imp.pkg.version>[6.4.0, 7.0.0)</carbon.apimgt.imp.pkg.version>
 
         <!-- Carbon Registry -->
@@ -1047,7 +1047,7 @@
         <carbon.governance.version>4.7.27</carbon.governance.version>
 
         <!--carbon versions-->
-        <carbon.kernel.version>4.4.35</carbon.kernel.version>
+        <carbon.kernel.version>4.4.37-SNAPSHOT</carbon.kernel.version> <!-- carbon-kernel branch: 4.4.x_java10 -->
         <apimserver.version>2.6.1-SNAPSHOT</apimserver.version>
         <ws.feature.version>1.4.2</ws.feature.version>
 
@@ -1117,12 +1117,12 @@
         <bcprov.jdk13.version>140</bcprov.jdk13.version>
         <bcprov.jdk15.version>132</bcprov.jdk15.version>
         <version.javax.servlet.jsp>2.2.0.v201112011158</version.javax.servlet.jsp>
-        <version.equinox.osgi>3.8.1.v20120830-144521</version.equinox.osgi>
+        <version.equinox.osgi>3.11.0.v20160603-1336</version.equinox.osgi>
         <version.equinox.jsp.jasper>1.0.400.v20120522-2049</version.equinox.jsp.jasper>
         <version.equinox.http.helper>1.1.0.wso2v1</version.equinox.http.helper>
-        <version.equinox.osgi.services>3.3.100.v20120522-1822</version.equinox.osgi.services>
+        <version.equinox.osgi.services>3.5.100.v20160504-1419</version.equinox.osgi.services>
         <version.equinox.http.servlet>1.1.300.v20120522-1841</version.equinox.http.servlet>
-        <carbon.p2.plugin.version>1.5.4</carbon.p2.plugin.version>
+        <carbon.p2.plugin.version>1.6.1-SNAPSHOT</carbon.p2.plugin.version> <!-- maven-tools branch: master_java10 -->
         <orbit.version.jettison>1.3.4.wso2v1</orbit.version.jettison>
         <emma.version>2.1.5320</emma.version>
         <javax.ws.rs-api.version>2.0.1</javax.ws.rs-api.version>
@@ -1165,7 +1165,7 @@
         <jacoco.agent.version>0.7.5.201505241946</jacoco.agent.version>
         <google.guava.version>18.0</google.guava.version>
 
-        <carbon.metrics.version>1.2.3</carbon.metrics.version>
+        <carbon.metrics.version>1.2.4-SNAPSHOT</carbon.metrics.version> <!-- carbon-metrics branch: 1.x.x_java10 -->
         <!-- MB Features -->
         <carbon.messaging.version>3.2.44</carbon.messaging.version>
         <carbon.event-processing.version>2.1.23</carbon.event-processing.version>


### PR DESCRIPTION
## Purpose
To support APIM to be able to run on Java 10. 
Its WIP and not achieved yet. 

## Approach
Upgraded OSGi, P2 Plugin, Carbon Kernel, Carbon Metrics and Carbon Apimgt dependencies

## Prerequisites
Please checkout and locally build following branches:
    master_java10 branch in maven-tools repo
    4.4.x_java10 branch in carbon-kernel repo
    1.x.x_java10 branch in carbon-metrics repo
    6.x_java10 branch in carbon-apimgt repo

## Note
This is a work in progress commit. Following feature groups have been temporarily commented out in am-p2-profile pom to avoid build errors. IS dependencies should be upgraded to uncomment those feature groups.
org.wso2.carbon.apimgt.feature.group
org.wso2.carbon.apimgt.store.feature.group
org.wso2.carbon.apimgt.keymanager.feature.group
