### PR TITLE
Update the backend endpoint URL and make it configurable

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/APIAccessibilityOfPublishedOldAPIAndPublishedCopyAPITestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/APIAccessibilityOfPublishedOldAPIAndPublishedCopyAPITestCase.java
@@ -74,7 +74,7 @@ public class APIAccessibilityOfPublishedOldAPIAndPublishedCopyAPITestCase
     public void initialize() throws APIManagerIntegrationTestException, XPathExpressionException,
                                     MalformedURLException {
         super.init();
-        apiEndPointUrl = getGatewayURLHttp() + API_END_POINT_POSTFIX_URL;
+        apiEndPointUrl = backEndServerUrl.getWebAppURLHttp() + API_END_POINT_POSTFIX_URL;
         providerName = user.getUserName();
         apiCreationRequestBean =
                 new APICreationRequestBean(API_NAME, API_CONTEXT, API_VERSION_1_0_0, providerName,

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/APIPublishingAndVisibilityInStoreTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/APIPublishingAndVisibilityInStoreTestCase.java
@@ -62,7 +62,7 @@ public class APIPublishingAndVisibilityInStoreTestCase extends APIManagerLifecyc
     @BeforeClass(alwaysRun = true)
     public void initialize() throws APIManagerIntegrationTestException, XPathExpressionException, MalformedURLException {
         super.init();
-        apiEndPointUrl = getGatewayURLHttp() + API_END_POINT_POSTFIX_URL;
+        apiEndPointUrl = backEndServerUrl.getWebAppURLHttp() + API_END_POINT_POSTFIX_URL;
         providerName = user.getUserName();
         apiCreationRequestBean =
                 new APICreationRequestBean(API_NAME, API_CONTEXT, API_VERSION_1_0_0, providerName,

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/APIVisibilityByDomainTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/APIVisibilityByDomainTestCase.java
@@ -75,7 +75,7 @@ public class APIVisibilityByDomainTestCase extends APIManagerLifecycleBaseTest {
     public void initialize() throws Exception {
         //Creating CarbonSuper context
         super.init(TestUserMode.SUPER_TENANT_ADMIN);
-        apiEndPointUrl = getGatewayURLHttp() + API_END_POINT_POSTFIX_URL;
+        apiEndPointUrl = backEndServerUrl.getWebAppURLHttp() + API_END_POINT_POSTFIX_URL;
         storeURLHttp = getStoreURLHttp();
         //Login to API Publisher and Store with CarbonSuper admin
         apiPublisherClientCarbonSuperAdmin = new APIPublisherRestClient(getPublisherURLHttp());

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/APIVisibilityByPublicTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/APIVisibilityByPublicTestCase.java
@@ -75,7 +75,7 @@ public class APIVisibilityByPublicTestCase extends APIManagerLifecycleBaseTest {
     public void initialize() throws APIManagerIntegrationTestException, XPathExpressionException {
         //Creating CarbonSuper context
         super.init();
-        apiEndPointUrl = getGatewayURLHttp() + API_END_POINT_POSTFIX_URL;
+        apiEndPointUrl = backEndServerUrl.getWebAppURLHttp() + API_END_POINT_POSTFIX_URL;
         String publisherURLHttp = getPublisherURLHttp();
         storeURLHttp = getStoreURLHttp();
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/APIVisibilityByRoleTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/APIVisibilityByRoleTestCase.java
@@ -88,7 +88,7 @@ public class APIVisibilityByRoleTestCase extends APIManagerLifecycleBaseTest {
     public void initialize() throws Exception {
         //Creating CarbonSuper context
         super.init();
-        apiEndPointUrl = getGatewayURLHttp() + API_END_POINT_POSTFIX_URL;
+        apiEndPointUrl = backEndServerUrl.getWebAppURLHttp() + API_END_POINT_POSTFIX_URL;
         String publisherURLHttp = getPublisherURLHttp();
         storeURLHttp = getStoreURLHttp();
         //Login to API Publisher and Store with CarbonSuper admin

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/AccessibilityOfBlockAPITestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/AccessibilityOfBlockAPITestCase.java
@@ -67,7 +67,7 @@ public class AccessibilityOfBlockAPITestCase extends APIManagerLifecycleBaseTest
     @BeforeClass(alwaysRun = true)
     public void initialize() throws APIManagerIntegrationTestException, XPathExpressionException, MalformedURLException {
         super.init();
-        apiEndPointUrl = getGatewayURLHttp() + API_END_POINT_POSTFIX_URL;
+        apiEndPointUrl = backEndServerUrl.getWebAppURLHttp() + API_END_POINT_POSTFIX_URL;
         providerName = user.getUserName();
         apiCreationRequestBean =
                 new APICreationRequestBean(API_NAME, API_CONTEXT, API_VERSION_1_0_0, providerName, new URL(apiEndPointUrl));

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/AccessibilityOfDeprecatedOldAPIAndPublishedCopyAPITestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/AccessibilityOfDeprecatedOldAPIAndPublishedCopyAPITestCase.java
@@ -74,7 +74,7 @@ public class AccessibilityOfDeprecatedOldAPIAndPublishedCopyAPITestCase
     public void initialize() throws APIManagerIntegrationTestException, XPathExpressionException,
                                     MalformedURLException {
         super.init();
-        apiEndPointUrl = getGatewayURLHttp() + API_END_POINT_POSTFIX_URL;
+        apiEndPointUrl = backEndServerUrl.getWebAppURLHttp() + API_END_POINT_POSTFIX_URL;
         providerName = user.getUserName();
         apiCreationRequestBean =
                 new APICreationRequestBean(API_NAME, API_CONTEXT, API_VERSION_1_0_0,

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/AccessibilityOfOldAPIAndCopyAPIWithOutReSubscriptionTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/AccessibilityOfOldAPIAndCopyAPIWithOutReSubscriptionTestCase.java
@@ -69,7 +69,7 @@ public class AccessibilityOfOldAPIAndCopyAPIWithOutReSubscriptionTestCase extend
     @BeforeClass(alwaysRun = true)
     public void initialize() throws APIManagerIntegrationTestException, XPathExpressionException, MalformedURLException {
         super.init();
-        apiEndPointUrl = getGatewayURLHttp() +  API_END_POINT_POSTFIX_URL;
+        apiEndPointUrl = backEndServerUrl.getWebAppURLHttp() +  API_END_POINT_POSTFIX_URL;
         providerName = user.getUserName();
         apiCreationRequestBean =
                 new APICreationRequestBean(API_NAME, API_CONTEXT, API_VERSION_1_0_0, providerName

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/AccessibilityOfOldAPIAndCopyAPIWithReSubscriptionTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/AccessibilityOfOldAPIAndCopyAPIWithReSubscriptionTestCase.java
@@ -71,7 +71,7 @@ public class AccessibilityOfOldAPIAndCopyAPIWithReSubscriptionTestCase extends A
     @BeforeClass(alwaysRun = true)
     public void initialize() throws APIManagerIntegrationTestException, XPathExpressionException, MalformedURLException {
         super.init();
-        apiEndPointUrl = gatewayUrlsWrk.getWebAppURLHttp() + API_END_POINT_POSTFIX_URL;
+        apiEndPointUrl = backEndServerUrl.getWebAppURLHttp() + API_END_POINT_POSTFIX_URL;
         providerName = publisherContext.getContextTenant().getContextUser().getUserName();
         apiCreationRequestBean = new APICreationRequestBean(API_NAME, API_CONTEXT, API_VERSION_1_0_0,
                 providerName, new URL(apiEndPointUrl));

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/AccessibilityOfRetireAPITestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/AccessibilityOfRetireAPITestCase.java
@@ -68,7 +68,7 @@ public class AccessibilityOfRetireAPITestCase extends APIManagerLifecycleBaseTes
     @BeforeClass(alwaysRun = true)
     public void initialize() throws APIManagerIntegrationTestException, XPathExpressionException, MalformedURLException {
         super.init();
-        apiEndPointUrl = getGatewayURLHttp() + API_END_POINT_POSTFIX_URL;
+        apiEndPointUrl = backEndServerUrl.getWebAppURLHttp() + API_END_POINT_POSTFIX_URL;
         providerName = user.getUserName();
         apiCreationRequestBean =
                 new APICreationRequestBean(API_NAME, API_CONTEXT, API_VERSION_1_0_0, providerName,

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/AddEditRemoveRESTResourceTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/AddEditRemoveRESTResourceTestCase.java
@@ -71,7 +71,7 @@ public class
                                     RemoteException, MalformedURLException {
         super.init();
         postEndPointURL = getAPIInvocationURLHttp(INVOKABLE_API_CONTEXT) + API_POST_ENDPOINT_METHOD;
-        apiEndPointUrl = getGatewayURLHttp() + API_END_POINT_POSTFIX_URL;
+        apiEndPointUrl = backEndServerUrl.getWebAppURLHttp() + API_END_POINT_POSTFIX_URL;
         providerName = user.getUserName();
         String publisherURLHttp = getPublisherURLHttp();
         String storeURLHttp = getStoreURLHttp();

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/ChangeAPIEndPointURLTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/ChangeAPIEndPointURLTestCase.java
@@ -101,7 +101,7 @@ public class ChangeAPIEndPointURLTestCase extends APIManagerLifecycleBaseTest {
             dependsOnMethods = "testAPIInvocationBeforeChangeTheEndPointURL")
     public void testEditEndPointURL() throws APIManagerIntegrationTestException, MalformedURLException {
         //Create the API Request with new context
-        api2EndPointUrl = getGatewayURLHttp() + API2_END_POINT_POSTFIX_URL;
+        api2EndPointUrl = backEndServerUrl.getWebAppURLHttp() + API2_END_POINT_POSTFIX_URL;
         APICreationRequestBean apiCreationRequestBeanUpdate = new APICreationRequestBean(
                 API_NAME, API_CONTEXT, API_VERSION_1_0_0, providerName, new URL(api2EndPointUrl));
         apiCreationRequestBeanUpdate.setTags(API_TAGS);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/ChangeAPITagsTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/ChangeAPITagsTestCase.java
@@ -59,7 +59,7 @@ public class ChangeAPITagsTestCase extends APIManagerLifecycleBaseTest {
     @BeforeClass(alwaysRun = true)
     public void initialize() throws APIManagerIntegrationTestException, XPathExpressionException {
         super.init();
-        apiEndPointUrl = getGatewayURLHttp() + API_END_POINT_POSTFIX_URL;
+        apiEndPointUrl = backEndServerUrl.getWebAppURLHttp() + API_END_POINT_POSTFIX_URL;
         providerName = user.getUserName();
         String publisherURLHttp = getPublisherURLHttp();
         String storeURLHttp = getStoreURLHttp();

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/ChangeAuthTypeOfResourceTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/ChangeAuthTypeOfResourceTestCase.java
@@ -67,7 +67,7 @@ public class ChangeAuthTypeOfResourceTestCase extends APIManagerLifecycleBaseTes
     @BeforeClass(alwaysRun = true)
     public void initialize() throws Exception {
         super.init();
-        apiEndPointUrl = getGatewayURLHttp()+ API_END_POINT_POSTFIX_URL;
+        apiEndPointUrl = backEndServerUrl.getWebAppURLHttp()+ API_END_POINT_POSTFIX_URL;
         providerName = user.getUserName();
         String publisherURLHttp = getPublisherURLHttp();
         String storeURLHttp = getStoreURLHttp();

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/ChangeEndPointSecurityOfAPITestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/ChangeEndPointSecurityOfAPITestCase.java
@@ -66,7 +66,7 @@ public class ChangeEndPointSecurityOfAPITestCase extends APIManagerLifecycleBase
     @BeforeClass(alwaysRun = true)
     public void initialize() throws APIManagerIntegrationTestException, XPathExpressionException, RemoteException {
         super.init();
-        apiEndPointUrl = getGatewayURLHttp() + API_END_POINT_POSTFIX_URL;
+        apiEndPointUrl = backEndServerUrl.getWebAppURLHttp() + API_END_POINT_POSTFIX_URL;
         providerName = user.getUserName();
         String publisherURLHttp = getPublisherURLHttp();
         String storeURLHttp = getStoreURLHttp();

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/EditAPIAndCheckUpdatedInformationTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/EditAPIAndCheckUpdatedInformationTestCase.java
@@ -62,7 +62,7 @@ public class EditAPIAndCheckUpdatedInformationTestCase extends APIManagerLifecyc
     public void initialize() throws APIManagerIntegrationTestException, XPathExpressionException,
                                     MalformedURLException {
         super.init();
-        apiEndPointUrl = getGatewayURLHttp() + API_END_POINT_POSTFIX_URL;
+        apiEndPointUrl = backEndServerUrl.getWebAppURLHttp()() + API_END_POINT_POSTFIX_URL;
         providerName = user.getUserName();
         apiCreationRequestBean =
                 new APICreationRequestBean(API_NAME, API_CONTEXT, API_VERSION_1_0_0, providerName,

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/EditAPIContextAndCheckAccessibilityTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/EditAPIContextAndCheckAccessibilityTestCase.java
@@ -66,7 +66,7 @@ public class EditAPIContextAndCheckAccessibilityTestCase extends APIManagerLifec
     @BeforeClass(alwaysRun = true)
     public void initialize() throws APIManagerIntegrationTestException, XPathExpressionException, MalformedURLException {
         super.init();
-        apiEndPointUrl = getGatewayURLHttp() + API_END_POINT_POSTFIX_URL;
+        apiEndPointUrl = backEndServerUrl.getWebAppURLHttp() + API_END_POINT_POSTFIX_URL;
         providerName = user.getUserName();
         apiCreationRequestBean = new APICreationRequestBean(API_NAME, API_CONTEXT, API_VERSION_1_0_0, providerName,
                 new URL(apiEndPointUrl));

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/RegistryLifeCycleInclusionTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/RegistryLifeCycleInclusionTest.java
@@ -51,7 +51,7 @@ public class RegistryLifeCycleInclusionTest extends APIManagerLifecycleBaseTest{
     @BeforeClass(alwaysRun = true)
     public void setEnvironment() throws Exception {
         super.init();
-        apiEndPointUrl = getGatewayURLHttp() + API_END_POINT_POSTFIX_URL;
+        apiEndPointUrl = backEndServerUrl.getWebAppURLHttp() + API_END_POINT_POSTFIX_URL;
         providerName = user.getUserName();
         apiCreationRequestBean =
                 new APICreationRequestBean(API_NAME, API_CONTEXT, API_VERSION_1_0_0, providerName, new URL(apiEndPointUrl));

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/UsersAndDocsInAPIOverviewTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/UsersAndDocsInAPIOverviewTestCase.java
@@ -60,7 +60,7 @@ public class UsersAndDocsInAPIOverviewTestCase extends APIManagerLifecycleBaseTe
     @BeforeClass(alwaysRun = true)
     public void initialize() throws Exception {
         super.init();
-        apiEndPointUrl = getGatewayURLHttp() + API_END_POINT_POSTFIX_URL;
+        apiEndPointUrl = backEndServerUrl.getWebAppURLHttp() + API_END_POINT_POSTFIX_URL;
         providerName = user.getUserName();
         apiCreationRequestBean = new APICreationRequestBean(API_NAME, API_CONTEXT, API_VERSION_1_0_0, providerName,
                 new URL(apiEndPointUrl));

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/APIApplicationLifeCycleTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/APIApplicationLifeCycleTestCase.java
@@ -82,7 +82,7 @@ public class APIApplicationLifeCycleTestCase extends APIMIntegrationBaseTest {
         //Add all option methods
         apiPublisher.login(publisherContext.getContextTenant().getContextUser().getUserName(),
                 publisherContext.getContextTenant().getContextUser().getPassword());
-        APIRequest apiRequest = new APIRequest(APIName, APIContext, new URL(gatewayUrlsWrk.getWebAppURLHttp() + url));
+        APIRequest apiRequest = new APIRequest(APIName, APIContext, new URL(backEndServerUrl.getWebAppURLHttp() + url));
         apiRequest.setTags(tags);
         apiRequest.setDescription(description);
         apiRequest.setVersion(APIVersion);
@@ -333,7 +333,7 @@ public class APIApplicationLifeCycleTestCase extends APIMIntegrationBaseTest {
         apiPublisherRestClient.login(publisherContext.getContextTenant().getContextUser().getUserName(),
                 publisherContext.getContextTenant().getContextUser().getPassword());
 
-        APIRequest apiRequest = new APIRequest(APIName, APIContext, new URL(gatewayUrlsWrk.getWebAppURLHttp() + url));
+        APIRequest apiRequest = new APIRequest(APIName, APIContext, new URL(backEndServerUrl.getWebAppURLHttp() + url));
         apiRequest.setTags(tags);
         apiRequest.setDescription(description);
         apiRequest.setVersion(APIVersionOld);
@@ -417,7 +417,7 @@ public class APIApplicationLifeCycleTestCase extends APIMIntegrationBaseTest {
         apiPublisherRestClient.login(publisherContext.getContextTenant().getContextUser().getUserName(),
                 publisherContext.getContextTenant().getContextUser().getPassword());
 
-        APIRequest apiRequest = new APIRequest(APIName, APIContext, new URL(gatewayUrlsWrk.getWebAppURLHttp() + url));
+        APIRequest apiRequest = new APIRequest(APIName, APIContext, new URL(backEndServerUrl.getWebAppURLHttp() + url));
         apiRequest.setTags(tags);
         apiRequest.setDescription(description);
         apiRequest.setVersion(APIVersion);
@@ -477,7 +477,7 @@ public class APIApplicationLifeCycleTestCase extends APIMIntegrationBaseTest {
         apiPublisherRestClient.login(publisherContext.getContextTenant().getContextUser().getUserName(),
                 publisherContext.getContextTenant().getContextUser().getPassword());
 
-        APIRequest apiRequest = new APIRequest(APIName, APIContext, new URL(gatewayUrlsWrk.getWebAppURLHttp() + url));
+        APIRequest apiRequest = new APIRequest(APIName, APIContext, new URL(backEndServerUrl.getWebAppURLHttp() + url));
         apiRequest.setTags(tags);
         apiRequest.setDescription(description);
         apiRequest.setVersion(APIVersionOld);
@@ -571,7 +571,7 @@ public class APIApplicationLifeCycleTestCase extends APIMIntegrationBaseTest {
         String providerName = "admin";
         String APIVersion = "1.0.0";
         //add all option methods
-        APIRequest apiRequest = new APIRequest(APIName, APIContext, new URL(gatewayUrlsWrk.getWebAppURLHttp() + url));
+        APIRequest apiRequest = new APIRequest(APIName, APIContext, new URL(backEndServerUrl.getWebAppURLHttp() + url));
         apiRequest.setTags(tags);
         apiRequest.setDescription(description);
         apiRequest.setVersion(APIVersion);
@@ -593,7 +593,7 @@ public class APIApplicationLifeCycleTestCase extends APIMIntegrationBaseTest {
         String providerName = "admin";
         String APIVersion = "1.0.0";
         //add all option methods
-        APIRequest apiRequest = new APIRequest(APIName, APIContext, new URL(gatewayUrlsWrk.getWebAppURLHttp() + url));
+        APIRequest apiRequest = new APIRequest(APIName, APIContext, new URL(backEndServerUrl.getWebAppURLHttp() + url));
         apiRequest.setTags(tags);
         apiRequest.setDescription(description);
         apiRequest.setVersion(APIVersion);
@@ -616,7 +616,7 @@ public class APIApplicationLifeCycleTestCase extends APIMIntegrationBaseTest {
         String providerName = "admin";
         String APIVersion = "1.0.0";
         //add all option methods
-        APIRequest apiRequest = new APIRequest(APIName, APIContext, new URL(gatewayUrlsWrk.getWebAppURLHttp() + url));
+        APIRequest apiRequest = new APIRequest(APIName, APIContext, new URL(backEndServerUrl.getWebAppURLHttp() + url));
         apiRequest.setTags(tags);
         apiRequest.setDescription(description);
         apiRequest.setVersion(APIVersion);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/APIM684GenerateApplicationKeyTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/APIM684GenerateApplicationKeyTestCase.java
@@ -126,7 +126,7 @@ public class APIM684GenerateApplicationKeyTestCase extends APIMIntegrationBaseTe
         resourceBeanList.add(new APIResourceBean("POST", "Application & Application User", resTier, uriPost));
         String endpoint = "/services/customers/customerservice";
 
-        endpointUrl = gatewayUrlsWrk.getWebAppURLHttp() + webApp + endpoint;
+        endpointUrl = backEndServerUrl.getWebAppURLHttp() + webApp + endpoint;
         apiProvider = publisherContext.getContextTenant().getContextUser().getUserName();
 
     }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/APIMANAGER2611EndpointValidationTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/APIMANAGER2611EndpointValidationTestCase.java
@@ -65,7 +65,7 @@ public class APIMANAGER2611EndpointValidationTestCase extends APIManagerLifecycl
         String APIName = "APIMANAGER2611testAPI";
         String APIContext = "/testEndpointValid";
         //Service which does not support HTTP HEAD
-        String endPointToValidate = getGatewayURLHttp() + "oauth2/token";
+        String endPointToValidate = backEndServerUrl.getWebAppURLHttp() + "am/sample/calculator/v1";
         String providerName = user.getUserName();
         String APIVersion = "1.0.0";
         apiIdentifier = new APIIdentifier(providerName, APIName, APIVersion);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/AdvancedWebAppDeploymentConfig.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/AdvancedWebAppDeploymentConfig.java
@@ -79,7 +79,7 @@ public class AdvancedWebAppDeploymentConfig extends APIManagerLifecycleBaseTest 
     }
 
     private void initialize() throws Exception {
-        apiEndPointUrl = getGatewayURLHttp() + API_END_POINT_POSTFIX_URL;
+        apiEndPointUrl = backEndServerUrl.getWebAppURLHttp() + API_END_POINT_POSTFIX_URL;
         providerName = user.getUserName();
         String publisherURLHttp = getPublisherURLHttp();
         String storeURLHttp = getStoreURLHttp();

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/LoadBalancedEndPointTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/LoadBalancedEndPointTestCase.java
@@ -160,9 +160,9 @@ public class LoadBalancedEndPointTestCase extends APIMIntegrationBaseTest {
         String tags = "LB";
         String description = "LoadBalancedEnd-point";
 
-        firstProductionEndPoint = gatewayUrlsWrk.getWebAppURLHttp() + APIMIntegrationConstants.PRODEP1_WEB_APP_NAME;
-        secondProductionEndPoint = gatewayUrlsWrk.getWebAppURLHttp() + APIMIntegrationConstants.PRODEP2_WEB_APP_NAME;
-        thirdProductionEndPoint = gatewayUrlsWrk.getWebAppURLHttp() + APIMIntegrationConstants.PRODEP3_WEB_APP_NAME;
+        firstProductionEndPoint = backEndServerUrl.getWebAppURLHttp() + APIMIntegrationConstants.PRODEP1_WEB_APP_NAME;
+        secondProductionEndPoint = backEndServerUrl.getWebAppURLHttp() + APIMIntegrationConstants.PRODEP2_WEB_APP_NAME;
+        thirdProductionEndPoint = backEndServerUrl.getWebAppURLHttp() + APIMIntegrationConstants.PRODEP3_WEB_APP_NAME;
 
         ArrayList<String> endpointLB = new ArrayList<String>();
         endpointLB.add(firstProductionEndPoint);
@@ -260,9 +260,9 @@ public class LoadBalancedEndPointTestCase extends APIMIntegrationBaseTest {
         String descriptionSandbox = "SandboxEnd-point";
         String tagsSandbox = "sandbox";
 
-        firstProductionEndPoint = gatewayUrlsWrk.getWebAppURLHttp() + APIMIntegrationConstants.PRODEP1_WEB_APP_NAME;
-        secondProductionEndPoint = gatewayUrlsWrk.getWebAppURLHttp() + APIMIntegrationConstants.PRODEP2_WEB_APP_NAME;
-        thirdProductionEndPoint = gatewayUrlsWrk.getWebAppURLHttp() + APIMIntegrationConstants.PRODEP3_WEB_APP_NAME;
+        firstProductionEndPoint = backEndServerUrl.getWebAppURLHttp() + APIMIntegrationConstants.PRODEP1_WEB_APP_NAME;
+        secondProductionEndPoint = backEndServerUrl.getWebAppURLHttp() + APIMIntegrationConstants.PRODEP2_WEB_APP_NAME;
+        thirdProductionEndPoint = backEndServerUrl.getWebAppURLHttp() + APIMIntegrationConstants.PRODEP3_WEB_APP_NAME;
 
         //Add production endpoints
         List<String> endpointProd = new ArrayList<String>();
@@ -272,11 +272,11 @@ public class LoadBalancedEndPointTestCase extends APIMIntegrationBaseTest {
 
         //add sandbox endpoints
         String firstSandboxEndpoint =
-                gatewayUrlsWrk.getWebAppURLHttp() + APIMIntegrationConstants.SANDBOXEP1_WEB_APP_NAME;
+                backEndServerUrl.getWebAppURLHttp() + APIMIntegrationConstants.SANDBOXEP1_WEB_APP_NAME;
         String secondSandboxEndpoint =
-                gatewayUrlsWrk.getWebAppURLHttp() + APIMIntegrationConstants.SANDBOXEP2_WEB_APP_NAME;
+                backEndServerUrl.getWebAppURLHttp() + APIMIntegrationConstants.SANDBOXEP2_WEB_APP_NAME;
         String thirdSandboxEndpoint =
-                gatewayUrlsWrk.getWebAppURLHttp() + APIMIntegrationConstants.SANDBOXEP3_WEB_APP_NAME;
+                backEndServerUrl.getWebAppURLHttp() + APIMIntegrationConstants.SANDBOXEP3_WEB_APP_NAME;
 
         List<String> endpointSandbox = new ArrayList<String>();
         endpointSandbox.add(firstSandboxEndpoint);

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/platform-test-host-config.xsl
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/platform-test-host-config.xsl
@@ -31,5 +31,7 @@
     <xsl:template match="xs:instance/xs:ports/xs:port[@type='https']/text()">9443</xsl:template>
     <xsl:template match="xs:instance/xs:ports/xs:port[@type='nhttp']/text()">8280</xsl:template>
     <xsl:template match="xs:instance/xs:ports/xs:port[@type='nhttps']/text()">8243</xsl:template>
+    <xsl:template match="xs:instance[@name='backend-server']/xs:ports/xs:port[@type='http']/text()">9763</xsl:template>
+    <xsl:template match="xs:instance[@name='backend-server']/xs:ports/xs:port[@type='https']/text()">9443</xsl:template>
 
 </xsl:stylesheet>


### PR DESCRIPTION
## Purpose
> Purpose of this fix is to make the Backend URL and the ports configurable for platform tests and update the endpoint of the test cases to pick the connection URL via the backend server hostname and port.

## Approach
> By default the automation context have the endpoint configurations hardcoded in 'automation.xml'. This can be replaced through the "_platform-test-host-config.xsl_" template file when executing the platform tests. This PR will update the template to make the backend server host and port configurable and also adjust the test cases to consider the endpoint URL from the defined backend URL.

## Test environment
> OS - Centos , DB - MySQL 5.7 , JDK - Oracle JDK 1.8
 