### PR TITLE
Add cross tenant API export support for super admin for migration 

### DIFF
--- a/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/APIImportExportConstants.java
+++ b/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/APIImportExportConstants.java
@@ -92,4 +92,6 @@ public final class APIImportExportConstants {
     public static final String CHARSET = "UTF-8";
 
     public static final String AUTHENTICATION_ADMIN_SERVICE_ENDPOINT = "AuthenticationAdmin";
+
+    public static final String MIGRATION_ENABLED = "migrationEnabled";
 }

--- a/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/APIImportExportConstants.java
+++ b/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/APIImportExportConstants.java
@@ -93,5 +93,5 @@ public final class APIImportExportConstants {
 
     public static final String AUTHENTICATION_ADMIN_SERVICE_ENDPOINT = "AuthenticationAdmin";
 
-    public static final String MIGRATION_ENABLED = "migrationEnabled";
+    public static final String MIGRATION_MODE = "migrationMode";
 }

--- a/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/APIService.java
+++ b/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/APIService.java
@@ -99,7 +99,7 @@ public class APIService {
             if (APIExportUtil.isCrossTenantAccessPermissionsViolated(apiDomain, userName)) {
                 String error = "Not authorized to export API :\"" + name + "-" + version + "-" + providerName;
                 String backEndError = error + ". Reason: Cross Tenant API access is not allowed. Both the facts; setting " +
-                        "'migrationEnabled=true' system property set at APIM Server startup and the requester being a super " +
+                        "'migrationMode=true' system property set at APIM Server startup and the requester being a super " +
                         "tenant admin, should be satisfied for this to be allowed";
                 log.error(backEndError);
                 return Response.status(Response.Status.FORBIDDEN).entity(error).type(MediaType.APPLICATION_JSON).build();

--- a/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/utils/APIExportUtil.java
+++ b/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/utils/APIExportUtil.java
@@ -40,7 +40,6 @@ import org.wso2.carbon.apimgt.api.model.Documentation;
 import org.wso2.carbon.apimgt.api.model.Scope;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.APIManagerFactory;
-import org.wso2.carbon.apimgt.impl.definitions.APIDefinitionFromOpenAPISpec;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
 import org.wso2.carbon.apimgt.importexport.APIImportExportConstants;
 import org.wso2.carbon.context.CarbonContext;
@@ -818,7 +817,7 @@ public class APIExportUtil {
 
     /**
      * Checks whether the request is violating cross tenant permission policies. Cross tenant resource access is allowed
-     * only for the super tenant admin user, only if the server is started with 'migrationEnabled=true' system property set.
+     * only for the super tenant admin user, only if the server is started with 'migrationMode=true' system property set.
      *
      * @param apiDomain Tenant domain of the API's provider
      * @param username  Logged in user name
@@ -832,7 +831,7 @@ public class APIExportUtil {
         if (!isCrossTenantAccess) {
             return false;
         }
-        boolean migrationEnabled = Boolean.getBoolean(APIImportExportConstants.MIGRATION_ENABLED);
+        boolean migrationMode = Boolean.getBoolean(APIImportExportConstants.MIGRATION_MODE);
         String superAdminRole = null;
         try {
             superAdminRole = ServiceReferenceHolder.getInstance().getRealmService().
@@ -862,7 +861,7 @@ public class APIExportUtil {
         }
 
         boolean isSuperTenantAdmin = isSuperTenantUser && isSuperAdminRoleNameExist;
-        boolean hasMigrationSpecificPermissions = migrationEnabled && isSuperTenantAdmin;
+        boolean hasMigrationSpecificPermissions = migrationMode && isSuperTenantAdmin;
 
         return !hasMigrationSpecificPermissions;
     }


### PR DESCRIPTION
## Purpose
Adding cross tenant API export support into the api-import-export REST API. This is for the objective of APIM 2.6.0 to 3.0.0 migration. 

## Approach
This support is enabled under the conditions that the caller is a super admin user and the server is started with migrationMode=true system property. And this is implemented by starting tenantFlow if the above conditions are satisfied.
