### PR TITLE
Improves integration tests for comments

### DIFF
--- a/modules/integration-tests/src/test/java/org/wso2/carbon/apimgt/rest/integration/tests/publisher/APILifeCycleTestCaseIT.java
+++ b/modules/integration-tests/src/test/java/org/wso2/carbon/apimgt/rest/integration/tests/publisher/APILifeCycleTestCaseIT.java
@@ -44,7 +44,7 @@ import java.util.UUID;
 public class APILifeCycleTestCaseIT {
 
     private API api;
-    private Comment comment;
+    private Comment comment, commentReply;
 
     @Test
     public void testCreateApi() throws AMIntegrationTestException {
@@ -168,6 +168,7 @@ public class APILifeCycleTestCaseIT {
         API api = (API) apiList.getList().get(0);
         Assert.assertTrue(api.getTransport().contains("http"));  // This is only available in the expanded api object.
     }
+
     @Test(dependsOnMethods = "testCreateApi")
     public void testApisApiIdCommentsPost() throws AMIntegrationTestException {
         CommentIndividualApi commentIndividualApi = TestUtil.getPublisherApiClient("user1", TestUtil.getUser("user1"),
@@ -178,7 +179,7 @@ public class APILifeCycleTestCaseIT {
         comment.setApiId(apiId);
         comment.setCommentText("this is a sample comment");
         comment.setCategory("sample category");
-        comment.setParentCommentId(UUID.randomUUID().toString());
+        comment.setParentCommentId(null);
         comment.setEntryPoint("APIPublisher");
         comment.setUsername("admin");
         comment.setCreatedBy("admin");
@@ -187,6 +188,20 @@ public class APILifeCycleTestCaseIT {
         comment.setLastUpdatedTime(time.toString());
         comment = commentIndividualApi.apisApiIdCommentsPost(apiId, comment);
         Assert.assertNotNull(comment.getCommentId());
+
+        commentReply = new Comment();
+        commentReply.setApiId(apiId);
+        commentReply.setCommentText("reply to the first comment");
+        commentReply.setCategory("sample category");
+        commentReply.setParentCommentId(comment.getCommentId());
+        commentReply.setEntryPoint("APIPublisher");
+        commentReply.setUsername("admin");
+        commentReply.setCreatedBy("admin");
+        commentReply.setLastUpdatedBy("admin");
+        commentReply.setCreatedTime(time.toString());
+        commentReply.setLastUpdatedTime(time.toString());
+        commentReply = commentIndividualApi.apisApiIdCommentsPost(apiId, commentReply);
+        Assert.assertNotNull(commentReply.getCommentId());
     }
 
     @Test(dependsOnMethods = "testApisApiIdCommentsPost")

--- a/modules/integration-tests/src/test/java/org/wso2/carbon/apimgt/rest/integration/tests/store/APICommentsTestCaseIT.java
+++ b/modules/integration-tests/src/test/java/org/wso2/carbon/apimgt/rest/integration/tests/store/APICommentsTestCaseIT.java
@@ -37,8 +37,8 @@ import java.util.UUID;
 
 public class APICommentsTestCaseIT {
 
-    private Comment comment;
     private API api;
+    private Comment comment, commentReply;
 
     @Test
     public void testApisApiIdCommentsPost() throws AMIntegrationTestException {
@@ -51,7 +51,7 @@ public class APICommentsTestCaseIT {
         comment.setApiId(apiId);
         comment.setCommentText("this is a sample comment");
         comment.setCategory("sample category");
-        comment.setParentCommentId(UUID.randomUUID().toString());
+        comment.setParentCommentId(null);
         comment.setEntryPoint("APIStore");
         comment.setUsername("admin");
         comment.setCreatedBy("admin");
@@ -60,6 +60,20 @@ public class APICommentsTestCaseIT {
         comment.setLastUpdatedTime(time.toString());
         comment = commentIndividualApi.apisApiIdCommentsPost(apiId, comment);
         Assert.assertNotNull(comment.getCommentId());
+
+        commentReply = new Comment();
+        commentReply.setApiId(apiId);
+        commentReply.setCommentText("reply to the first comment");
+        commentReply.setCategory("sample category");
+        commentReply.setParentCommentId(comment.getCommentId());
+        commentReply.setEntryPoint("APIStore");
+        commentReply.setUsername("admin");
+        commentReply.setCreatedBy("admin");
+        commentReply.setLastUpdatedBy("admin");
+        commentReply.setCreatedTime(time.toString());
+        commentReply.setLastUpdatedTime(time.toString());
+        commentReply = commentIndividualApi.apisApiIdCommentsPost(apiId, commentReply);
+        Assert.assertNotNull(commentReply.getCommentId());
     }
 
     @Test(dependsOnMethods = "testApisApiIdCommentsPost")


### PR DESCRIPTION
## Purpose
Modify integration tests for the comments feature backend.tc.

## Goals
To test the function to retrieve nested comments in both API Store and API Publisher using integration tests.

## Approach
Please refer the mail threads subjected as “[Dev] [APIM 3.0] API Comments” and “[Architecture] Project 240: Communication channel between API Providers and API Consumers”

## User stories
- Test whether the nested comments can be retrieved from API Store.
- Test whether the nested comments can be retrieved from API Publisher.

## Documentation
N/A - since this is regarding integration tests.

## Automation tests
 - Integration tests
   - Modified test cases for API Publisher comments in
product-apim/modules/integration-tests/src/test/java/org/wso2/carbon/apimgt/rest/integration/tests/publisher/APILifeCycleTestCaseIT.java
   - Modified test cases for API Publisher comments in
product-apim/modules/integration-tests/src/test/java/org/wso2/carbon/apimgt/rest/integration/tests/store/APICommentsTestCaseIT.java

## Related PRs
https://github.com/wso2/carbon-apimgt/pull/5843

## Test environment
- jdk1.8.0_144
- Ubuntu 16.04 LTS