### PR TITLE
fix integration tests for #3911

### DIFF
--- a/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/utils/base/APIMIntegrationConstants.java
+++ b/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/utils/base/APIMIntegrationConstants.java
@@ -102,9 +102,9 @@ public class APIMIntegrationConstants {
 
     public static class RESOURCE_TIER {
         public static final String UNLIMITED = "Unlimited";
-        public static final String ULTIMATE = "Ultimate";
+        public static final String TENK_PER_MIN = "10KPerMin";
         public static final String TWENTYK_PER_MIN = "20KPerMin";
-        public static final String BASIC = "Basic";
+        public static final String FIFTYK_PER_MIN = "50KPerMin";
 
         public static final int ULTIMATE_LIMIT = 20;
         public static final int PLUS_LIMIT = 5;

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/ChangeResourceTierAndTestInvokingTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/ChangeResourceTierAndTestInvokingTestCase.java
@@ -233,7 +233,7 @@ public class ChangeResourceTierAndTestInvokingTestCase extends APIManagerLifecyc
         Thread.sleep(THROTTLING_UNIT_TIME + THROTTLING_ADDITIONAL_WAIT_TIME);
 
         String swagger = " {\"paths\":{\"/*\":{\"get\":{\"x-auth-type\":\"Application \",\"x-throttling-tier\":" +
-                "\"" + APIMIntegrationConstants.RESOURCE_TIER.ULTIMATE
+                "\"" + "Ultimate"
                 + "\",\"responses\":{\"200\":\"{}\"}}}},\"swagger\":\"2.0\",\"x-wso2-security\":{\"apim\"" +
                 ":{\"x-wso2-scopes\":[]}},\"info\":{\"licence\":{},\"title\":\"" + API_NAME + "\",\"description\":" +
                 "\"This is test API create by API manager integration test\",\"contact\":{\"email\":null,\"name\":null}," +
@@ -242,7 +242,7 @@ public class ChangeResourceTierAndTestInvokingTestCase extends APIManagerLifecyc
         apiPublisherClientUser1.updateResourceOfAPI(providerName, API_NAME, API_VERSION_1_0_0, swagger);
 
         apiStoreClientUser1.waitForSwaggerDocument(user.getUserName(), API_NAME, API_VERSION_1_0_0,
-                APIMIntegrationConstants.RESOURCE_TIER.ULTIMATE, executionMode);
+                "Ultimate", executionMode);
 
         waitForAPIDeploymentSync(user.getUserName(), API_NAME, API_VERSION_1_0_0, APIMIntegrationConstants.IS_API_EXISTS);
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/sdk/SDKGenerationTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/sdk/SDKGenerationTestCase.java
@@ -75,6 +75,9 @@ public class SDKGenerationTestCase extends APIMIntegrationBaseTest {
         //login to API publisher as first tenant admin to create the API
         apiPublisher = new APIPublisherRestClient(publisherURLHttp);
         apiPublisher.login(apiProvider, firstTenantAdminPassword);
+        //Wait till CommonConfigDeployer finishes adding the default set of policies to the database after tenant admin
+        //login, if not api creation fails since Unlimited resource tier is not available in database.
+        waitForAPIDeployment();
         //prepare API to create and publish
         String apiContext = "testContext";
         String url = "https://localhost:9443/test";

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/APIImportExportTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/APIImportExportTestCase.java
@@ -184,22 +184,22 @@ public class APIImportExportTestCase extends APIMIntegrationBaseTest {
                 APIMIntegrationConstants.RESOURCE_TIER.TWENTYK_PER_MIN, "/post");
         APIResourceBean res2 = new APIResourceBean("GET",
                 APIMIntegrationConstants.ResourceAuthTypes.APPLICATION.getAuthType(),
-                APIMIntegrationConstants.RESOURCE_TIER.BASIC, "/get");
+                APIMIntegrationConstants.RESOURCE_TIER.FIFTYK_PER_MIN, "/get");
         APIResourceBean res3 = new APIResourceBean("PUT",
                 APIMIntegrationConstants.ResourceAuthTypes.APPLICATION_USER.getAuthType(),
-                APIMIntegrationConstants.RESOURCE_TIER.ULTIMATE, "/put");
+                APIMIntegrationConstants.RESOURCE_TIER.TENK_PER_MIN, "/put");
         APIResourceBean res4 = new APIResourceBean("DELETE",
                 APIMIntegrationConstants.ResourceAuthTypes.APPLICATION_AND_APPLICATION_USER.getAuthType(),
                 APIMIntegrationConstants.RESOURCE_TIER.UNLIMITED, "/delete");
         APIResourceBean res5 = new APIResourceBean("PATCH",
                 APIMIntegrationConstants.ResourceAuthTypes.NONE.getAuthType(),
-                APIMIntegrationConstants.RESOURCE_TIER.BASIC, "/patch");
+                APIMIntegrationConstants.RESOURCE_TIER.FIFTYK_PER_MIN, "/patch");
         APIResourceBean res6 = new APIResourceBean("HEAD",
                 APIMIntegrationConstants.ResourceAuthTypes.NONE.getAuthType(),
-                APIMIntegrationConstants.RESOURCE_TIER.BASIC, "/head");
+                APIMIntegrationConstants.RESOURCE_TIER.FIFTYK_PER_MIN, "/head");
         APIResourceBean res7 = new APIResourceBean("OPTIONS",
                 APIMIntegrationConstants.ResourceAuthTypes.NONE.getAuthType(),
-                APIMIntegrationConstants.RESOURCE_TIER.BASIC, "/options");
+                APIMIntegrationConstants.RESOURCE_TIER.FIFTYK_PER_MIN, "/options");
         resList.add(res1);
         resList.add(res2);
         resList.add(res3);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/APIM4765ResourceOrderInSwagger.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/APIM4765ResourceOrderInSwagger.java
@@ -91,18 +91,18 @@ import static org.testng.Assert.assertTrue;
                 APILifeCycleState.PUBLISHED);
         apiPublisher.changeAPILifeCycleStatus(updateRequest);
 
-        String swagger = "{\"paths\":{\"/*\":{\"get\":{\"x-auth-type\":\"Application \",\"x-throttling-tier\":\"Plus\","
+        String swagger = "{\"paths\":{\"/*\":{\"get\":{\"x-auth-type\":\"Application \",\"x-throttling-tier\":\"10KPerMin\","
                 + "\"responses\":{\"200\":{}}}},\"/post\":{\"get\":{\"x-auth-type\":\"Application \","
-                + "\"x-throttling-tier\":\"Plus\",\"responses\":{\"200\":{}}}},\"/list\":{\"get\":{\"x-auth-type\":"
-                + "\"Application \",\"x-throttling-tier\":\"Plus\",\"responses\":{\"200\":{}}}}},\"swagger\":\"2.0\","
+                + "\"x-throttling-tier\":\"10KPerMin\",\"responses\":{\"200\":{}}}},\"/list\":{\"get\":{\"x-auth-type\":"
+                + "\"Application \",\"x-throttling-tier\":\"10KPerMin\",\"responses\":{\"200\":{}}}}},\"swagger\":\"2.0\","
                 + "\"x-wso2-security\":{\"apim\":{\"x-wso2-scopes\":[]}},\"info\":{\"licence\":{},\"title\":"
                 + "\"TokenTestAPI\",\"description\":\"This is test API create by API manager integration test\","
                 + "\"contact\":{\"email\":null,\"name\":null},\"version\":\"1.0.0\"}}";
 
         String resourceOrder = "{\"paths\":{\"/*\":{\"get\":{\"x-auth-type\":\"Application \",\"x-throttling-tier\""
-                + ":\"Plus\",\"responses\":{\"200\":{}}}},\"/post\":{\"get\":{\"x-auth-type\":\"Application \","
-                + "\"x-throttling-tier\":\"Plus\",\"responses\":{\"200\":{}}}},\"/list\":{\"get\":"
-                + "{\"x-auth-type\":\"Application \",\"x-throttling-tier\":\"Plus\",\"responses\":{\"200\":{}}}}}";
+                + ":\"10KPerMin\",\"responses\":{\"200\":{}}}},\"/post\":{\"get\":{\"x-auth-type\":\"Application \","
+                + "\"x-throttling-tier\":\"10KPerMin\",\"responses\":{\"200\":{}}}},\"/list\":{\"get\":"
+                + "{\"x-auth-type\":\"Application \",\"x-throttling-tier\":\"10KPerMin\",\"responses\":{\"200\":{}}}}}";
 
         apiPublisher.updateResourceOfAPI(providerName, APIName, APIVersion, swagger);
         //get swagger doc.

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/APIMANAGER4081PaginationCountTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/APIMANAGER4081PaginationCountTestCase.java
@@ -114,7 +114,9 @@ public class APIMANAGER4081PaginationCountTestCase extends APIMIntegrationBaseTe
                 apiPublisher.login
                         (publisherContext.getContextTenant().getTenantAdmin().getUserName() + "@" + tenantDomain,
                          publisherContext.getContextTenant().getTenantAdmin().getPassword());
-
+                //Wait till CommonConfigDeployer finishes adding the default set of policies to the database after tenant admin
+                //login, if not api creation fails since Unlimited resource tier is not available in database.
+                waitForAPIDeployment();
                 APIRequest apiRequest = new APIRequest(APIName, APIContext, new URL(url));
                 apiRequest.setTags(tags);
                 apiRequest.setDescription(description);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/APIScopeTestForTenantsTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/APIScopeTestForTenantsTestCase.java
@@ -182,6 +182,9 @@ public class APIScopeTestForTenantsTestCase extends APIMIntegrationBaseTest {
         String description = "This is a test API created by API manager integration test";
 
         apiPublisher.login(adminUser, adminPassword);
+        //Wait till CommonConfigDeployer finishes adding the default set of policies to the database after tenant admin
+        //login, if not api creation fails since Unlimited resource tier is not available in database.
+        waitForAPIDeployment();
         APIRequest apiRequest = new APIRequest(apiName, apiContext, new URL(url));
         apiRequest.setDescription(description);
         apiRequest.setVersion(apiVersion);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/CopyNewVersionTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/CopyNewVersionTestCase.java
@@ -61,7 +61,7 @@ public class CopyNewVersionTestCase extends APIMIntegrationBaseTest {
     private String description="Test Description";
     private static final String WEB_APP_FILE_NAME="jaxrs_basic";
     private String tier= APIMIntegrationConstants.API_TIER.GOLD;
-    private String resTier= APIMIntegrationConstants.RESOURCE_TIER.ULTIMATE;
+    private String resTier= APIMIntegrationConstants.RESOURCE_TIER.TENK_PER_MIN;
     private String endPointType="http";
 
     @Factory(dataProvider = "userModeDataProvider")

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/NewCopyWithDefaultVersion.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/NewCopyWithDefaultVersion.java
@@ -60,7 +60,7 @@ public class NewCopyWithDefaultVersion extends APIMIntegrationBaseTest {
     private String visibility = "public";
     private String description = "Test Description";
     private String tier= APIMIntegrationConstants.API_TIER.GOLD;
-    private String resTier= APIMIntegrationConstants.RESOURCE_TIER.ULTIMATE;
+    private String resTier= APIMIntegrationConstants.RESOURCE_TIER.TENK_PER_MIN;
     private String endPointType = "http";
 
     @Factory(dataProvider = "userModeDataProvider")

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/SameVersionAPITestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/SameVersionAPITestCase.java
@@ -58,7 +58,7 @@ public class SameVersionAPITestCase extends APIMIntegrationBaseTest{
     private String visibility="public";
     private String description="Test Description";
     private String tier= APIMIntegrationConstants.API_TIER.GOLD;
-    private String resTier= APIMIntegrationConstants.RESOURCE_TIER.ULTIMATE;
+    private String resTier= APIMIntegrationConstants.RESOURCE_TIER.TENK_PER_MIN;
     private String endPointType="http";
 
     @Factory(dataProvider = "userModeDataProvider")

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/rest-api-test-data/APILifecycleTestCase.txt
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/rest-api-test-data/APILifecycleTestCase.txt
@@ -48,18 +48,18 @@
                         \"subscriptionAvailability\": \"current_tenant\",\r\n   \"subscriptionAvailableTenants\": [],\r\n
                         \"destinationStatsEnabled\": \"Disabled\",\r\n   \"apiDefinition\":
                         \"{\\\"paths\\\":{\\\"\\\\\/*\\\":{\\\"put\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",
-                        \\\"x-throttling-tier\\\":\\\"CustomTier\\\",\\\"parameters\\\":[{\\\"schema\\\":{\\\"type\\\":\\\"object\\\"},
+                        \\\"x-throttling-tier\\\":\\\"Unlimited\\\",\\\"parameters\\\":[{\\\"schema\\\":{\\\"type\\\":\\\"object\\\"},
                         \\\"description\\\":\\\"Request Body\\\",\\\"name\\\":
                         \\\"Payload\\\",\\\"required\\\":false,\\\"in\\\":\\\"body\\\"}],\\\"responses\\\":{\\\"200\\\":{}}},
-                        \\\"post\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",\\\"x-throttling-tier\\\":\\\"CustomTier\\\",
+                        \\\"post\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",\\\"x-throttling-tier\\\":\\\"Unlimited\\\",
                         \\\"parameters\\\":[{\\\"schema\\\":{\\\"type\\\":\\\"object\\\"},\\\"description\\\":\\\"Request Body\\\",
                         \\\"name\\\":\\\"Payload\\\",\\\"required\\\":false,\\\"in\\\":\\\"body\\\"}],
                         \\\"responses\\\":{\\\"200\\\":{}}},\\\"get\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",
-                        \\\"x-throttling-tier\\\":\\\"CustomTier\\\",\\\"responses\\\":{\\\"200\\\":{}}},
+                        \\\"x-throttling-tier\\\":\\\"Unlimited\\\",\\\"responses\\\":{\\\"200\\\":{}}},
                         \\\"delete\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",
-                        \\\"x-throttling-tier\\\":\\\"CustomTier\\\",\\\"responses\\\":{\\\"200\\\":{}}},
+                        \\\"x-throttling-tier\\\":\\\"Unlimited\\\",\\\"responses\\\":{\\\"200\\\":{}}},
                         \\\"patch\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",
-                        \\\"x-throttling-tier\\\":\\\"CustomTier\\\",\\\"parameters\\\":[{\\\"schema\\\":{\\\"type\\\":\\\"object\\\"},
+                        \\\"x-throttling-tier\\\":\\\"Unlimited\\\",\\\"parameters\\\":[{\\\"schema\\\":{\\\"type\\\":\\\"object\\\"},
                         \\\"description\\\":\\\"Request Body\\\",\\\"name\\\":\\\"Payload\\\",\\\"required\\\":false,\\\"in\\\":\\\"body\\\"}],
                         \\\"responses\\\":{\\\"200\\\":{}}}}},\\\"swagger\\\":\\\"2.0\\\",
                         \\\"info\\\":{\\\"title\\\":\\\"api1\\\",\\\"version\\\":\\\"1\\\"}}\",\r\n

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/rest-api-test-data/APIM5898.txt
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/rest-api-test-data/APIM5898.txt
@@ -84,18 +84,18 @@
                         \"subscriptionAvailability\": \"current_tenant\",\r\n   \"subscriptionAvailableTenants\": [],\r\n
                         \"destinationStatsEnabled\": \"Disabled\",\r\n   \"apiDefinition\":
                         \"{\\\"paths\\\":{\\\"\\\\\/*\\\":{\\\"put\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",
-                        \\\"x-throttling-tier\\\":\\\"PlatinumTier\\\",\\\"parameters\\\":[{\\\"schema\\\":{\\\"type\\\":\\\"object\\\"},
+                        \\\"x-throttling-tier\\\":\\\"Unlimited\\\",\\\"parameters\\\":[{\\\"schema\\\":{\\\"type\\\":\\\"object\\\"},
                         \\\"description\\\":\\\"Request Body\\\",\\\"name\\\":
                         \\\"Payload\\\",\\\"required\\\":false,\\\"in\\\":\\\"body\\\"}],\\\"responses\\\":{\\\"200\\\":{}}},
-                        \\\"post\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",\\\"x-throttling-tier\\\":\\\"PlatinumTier\\\",
+                        \\\"post\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",\\\"x-throttling-tier\\\":\\\"Unlimited\\\",
                         \\\"parameters\\\":[{\\\"schema\\\":{\\\"type\\\":\\\"object\\\"},\\\"description\\\":\\\"Request Body\\\",
                         \\\"name\\\":\\\"Payload\\\",\\\"required\\\":false,\\\"in\\\":\\\"body\\\"}],
                         \\\"responses\\\":{\\\"200\\\":{}}},\\\"get\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",
-                        \\\"x-throttling-tier\\\":\\\"PlatinumTier\\\",\\\"responses\\\":{\\\"200\\\":{}}},
+                        \\\"x-throttling-tier\\\":\\\"Unlimited\\\",\\\"responses\\\":{\\\"200\\\":{}}},
                         \\\"delete\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",
-                        \\\"x-throttling-tier\\\":\\\"PlatinumTier\\\",\\\"responses\\\":{\\\"200\\\":{}}},
+                        \\\"x-throttling-tier\\\":\\\"Unlimited\\\",\\\"responses\\\":{\\\"200\\\":{}}},
                         \\\"patch\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",
-                        \\\"x-throttling-tier\\\":\\\"PlatinumTier\\\",\\\"parameters\\\":[{\\\"schema\\\":{\\\"type\\\":\\\"object\\\"},
+                        \\\"x-throttling-tier\\\":\\\"Unlimited\\\",\\\"parameters\\\":[{\\\"schema\\\":{\\\"type\\\":\\\"object\\\"},
                         \\\"description\\\":\\\"Request Body\\\",\\\"name\\\":\\\"Payload\\\",\\\"required\\\":false,\\\"in\\\":\\\"body\\\"}],
                         \\\"responses\\\":{\\\"200\\\":{}}}}},\\\"swagger\\\":\\\"2.0\\\",
                         \\\"info\\\":{\\\"title\\\":\\\"api1\\\",\\\"version\\\":\\\"1\\\"}}\",\r\n

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/rest-api-test-data/MultipleSubscriptionsTestCase.txt
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/rest-api-test-data/MultipleSubscriptionsTestCase.txt
@@ -84,18 +84,18 @@
                         \"subscriptionAvailability\": \"current_tenant\",\r\n   \"subscriptionAvailableTenants\": [],\r\n
                         \"destinationStatsEnabled\": \"Disabled\",\r\n   \"apiDefinition\":
                         \"{\\\"paths\\\":{\\\"\\\\\/*\\\":{\\\"put\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",
-                        \\\"x-throttling-tier\\\":\\\"PlatinumTier\\\",\\\"parameters\\\":[{\\\"schema\\\":{\\\"type\\\":\\\"object\\\"},
+                        \\\"x-throttling-tier\\\":\\\"Unlimited\\\",\\\"parameters\\\":[{\\\"schema\\\":{\\\"type\\\":\\\"object\\\"},
                         \\\"description\\\":\\\"Request Body\\\",\\\"name\\\":
                         \\\"Payload\\\",\\\"required\\\":false,\\\"in\\\":\\\"body\\\"}],\\\"responses\\\":{\\\"200\\\":{}}},
-                        \\\"post\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",\\\"x-throttling-tier\\\":\\\"PlatinumTier\\\",
+                        \\\"post\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",\\\"x-throttling-tier\\\":\\\"Unlimited\\\",
                         \\\"parameters\\\":[{\\\"schema\\\":{\\\"type\\\":\\\"object\\\"},\\\"description\\\":\\\"Request Body\\\",
                         \\\"name\\\":\\\"Payload\\\",\\\"required\\\":false,\\\"in\\\":\\\"body\\\"}],
                         \\\"responses\\\":{\\\"200\\\":{}}},\\\"get\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",
-                        \\\"x-throttling-tier\\\":\\\"PlatinumTier\\\",\\\"responses\\\":{\\\"200\\\":{}}},
+                        \\\"x-throttling-tier\\\":\\\"Unlimited\\\",\\\"responses\\\":{\\\"200\\\":{}}},
                         \\\"delete\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",
-                        \\\"x-throttling-tier\\\":\\\"PlatinumTier\\\",\\\"responses\\\":{\\\"200\\\":{}}},
+                        \\\"x-throttling-tier\\\":\\\"Unlimited\\\",\\\"responses\\\":{\\\"200\\\":{}}},
                         \\\"patch\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",
-                        \\\"x-throttling-tier\\\":\\\"PlatinumTier\\\",\\\"parameters\\\":[{\\\"schema\\\":{\\\"type\\\":\\\"object\\\"},
+                        \\\"x-throttling-tier\\\":\\\"Unlimited\\\",\\\"parameters\\\":[{\\\"schema\\\":{\\\"type\\\":\\\"object\\\"},
                         \\\"description\\\":\\\"Request Body\\\",\\\"name\\\":\\\"Payload\\\",\\\"required\\\":false,\\\"in\\\":\\\"body\\\"}],
                         \\\"responses\\\":{\\\"200\\\":{}}}}},\\\"swagger\\\":\\\"2.0\\\",
                         \\\"info\\\":{\\\"title\\\":\\\"api1\\\",\\\"version\\\":\\\"1\\\"}}\",\r\n
@@ -165,18 +165,18 @@
                         \"subscriptionAvailability\": \"current_tenant\",\r\n   \"subscriptionAvailableTenants\": [],\r\n
                         \"destinationStatsEnabled\": \"Disabled\",\r\n   \"apiDefinition\":
                         \"{\\\"paths\\\":{\\\"\\\\\/*\\\":{\\\"put\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",
-                        \\\"x-throttling-tier\\\":\\\"PlatinumTier\\\",\\\"parameters\\\":[{\\\"schema\\\":{\\\"type\\\":\\\"object\\\"},
+                        \\\"x-throttling-tier\\\":\\\"Unlimited\\\",\\\"parameters\\\":[{\\\"schema\\\":{\\\"type\\\":\\\"object\\\"},
                         \\\"description\\\":\\\"Request Body\\\",\\\"name\\\":
                         \\\"Payload\\\",\\\"required\\\":false,\\\"in\\\":\\\"body\\\"}],\\\"responses\\\":{\\\"200\\\":{}}},
-                        \\\"post\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",\\\"x-throttling-tier\\\":\\\"PlatinumTier\\\",
+                        \\\"post\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",\\\"x-throttling-tier\\\":\\\"Unlimited\\\",
                         \\\"parameters\\\":[{\\\"schema\\\":{\\\"type\\\":\\\"object\\\"},\\\"description\\\":\\\"Request Body\\\",
                         \\\"name\\\":\\\"Payload\\\",\\\"required\\\":false,\\\"in\\\":\\\"body\\\"}],
                         \\\"responses\\\":{\\\"200\\\":{}}},\\\"get\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",
-                        \\\"x-throttling-tier\\\":\\\"PlatinumTier\\\",\\\"responses\\\":{\\\"200\\\":{}}},
+                        \\\"x-throttling-tier\\\":\\\"Unlimited\\\",\\\"responses\\\":{\\\"200\\\":{}}},
                         \\\"delete\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",
-                        \\\"x-throttling-tier\\\":\\\"PlatinumTier\\\",\\\"responses\\\":{\\\"200\\\":{}}},
+                        \\\"x-throttling-tier\\\":\\\"Unlimited\\\",\\\"responses\\\":{\\\"200\\\":{}}},
                         \\\"patch\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",
-                        \\\"x-throttling-tier\\\":\\\"PlatinumTier\\\",\\\"parameters\\\":[{\\\"schema\\\":{\\\"type\\\":\\\"object\\\"},
+                        \\\"x-throttling-tier\\\":\\\"Unlimited\\\",\\\"parameters\\\":[{\\\"schema\\\":{\\\"type\\\":\\\"object\\\"},
                         \\\"description\\\":\\\"Request Body\\\",\\\"name\\\":\\\"Payload\\\",\\\"required\\\":false,\\\"in\\\":\\\"body\\\"}],
                         \\\"responses\\\":{\\\"200\\\":{}}}}},\\\"swagger\\\":\\\"2.0\\\",
                         \\\"info\\\":{\\\"title\\\":\\\"api1\\\",\\\"version\\\":\\\"1\\\"}}\",\r\n

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/rest-api-test-data/SubscriptionTestCase.txt
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/rest-api-test-data/SubscriptionTestCase.txt
@@ -84,18 +84,18 @@
                         \"subscriptionAvailability\": \"current_tenant\",\r\n   \"subscriptionAvailableTenants\": [],\r\n
                         \"destinationStatsEnabled\": \"Disabled\",\r\n   \"apiDefinition\":
                         \"{\\\"paths\\\":{\\\"\\\\\/*\\\":{\\\"put\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",
-                        \\\"x-throttling-tier\\\":\\\"PlatinumTier\\\",\\\"parameters\\\":[{\\\"schema\\\":{\\\"type\\\":\\\"object\\\"},
+                        \\\"x-throttling-tier\\\":\\\"Unlimited\\\",\\\"parameters\\\":[{\\\"schema\\\":{\\\"type\\\":\\\"object\\\"},
                         \\\"description\\\":\\\"Request Body\\\",\\\"name\\\":
                         \\\"Payload\\\",\\\"required\\\":false,\\\"in\\\":\\\"body\\\"}],\\\"responses\\\":{\\\"200\\\":{}}},
-                        \\\"post\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",\\\"x-throttling-tier\\\":\\\"PlatinumTier\\\",
+                        \\\"post\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",\\\"x-throttling-tier\\\":\\\"Unlimited\\\",
                         \\\"parameters\\\":[{\\\"schema\\\":{\\\"type\\\":\\\"object\\\"},\\\"description\\\":\\\"Request Body\\\",
                         \\\"name\\\":\\\"Payload\\\",\\\"required\\\":false,\\\"in\\\":\\\"body\\\"}],
                         \\\"responses\\\":{\\\"200\\\":{}}},\\\"get\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",
-                        \\\"x-throttling-tier\\\":\\\"PlatinumTier\\\",\\\"responses\\\":{\\\"200\\\":{}}},
+                        \\\"x-throttling-tier\\\":\\\"Unlimited\\\",\\\"responses\\\":{\\\"200\\\":{}}},
                         \\\"delete\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",
-                        \\\"x-throttling-tier\\\":\\\"PlatinumTier\\\",\\\"responses\\\":{\\\"200\\\":{}}},
+                        \\\"x-throttling-tier\\\":\\\"Unlimited\\\",\\\"responses\\\":{\\\"200\\\":{}}},
                         \\\"patch\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",
-                        \\\"x-throttling-tier\\\":\\\"PlatinumTier\\\",\\\"parameters\\\":[{\\\"schema\\\":{\\\"type\\\":\\\"object\\\"},
+                        \\\"x-throttling-tier\\\":\\\"Unlimited\\\",\\\"parameters\\\":[{\\\"schema\\\":{\\\"type\\\":\\\"object\\\"},
                         \\\"description\\\":\\\"Request Body\\\",\\\"name\\\":\\\"Payload\\\",\\\"required\\\":false,\\\"in\\\":\\\"body\\\"}],
                         \\\"responses\\\":{\\\"200\\\":{}}}}},\\\"swagger\\\":\\\"2.0\\\",
                         \\\"info\\\":{\\\"title\\\":\\\"api1\\\",\\\"version\\\":\\\"1\\\"}}\",\r\n

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/rest-api-test-data/TagTestCase.txt
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/rest-api-test-data/TagTestCase.txt
@@ -48,18 +48,18 @@
                         \"subscriptionAvailability\": \"current_tenant\",\r\n   \"subscriptionAvailableTenants\": [],\r\n
                         \"destinationStatsEnabled\": \"Disabled\",\r\n   \"apiDefinition\":
                         \"{\\\"paths\\\":{\\\"\\\\\/*\\\":{\\\"put\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",
-                        \\\"x-throttling-tier\\\":\\\"TempTier\\\",\\\"parameters\\\":[{\\\"schema\\\":{\\\"type\\\":\\\"object\\\"},
+                        \\\"x-throttling-tier\\\":\\\"Unlimited\\\",\\\"parameters\\\":[{\\\"schema\\\":{\\\"type\\\":\\\"object\\\"},
                         \\\"description\\\":\\\"Request Body\\\",\\\"name\\\":
                         \\\"Payload\\\",\\\"required\\\":false,\\\"in\\\":\\\"body\\\"}],\\\"responses\\\":{\\\"200\\\":{}}},
-                        \\\"post\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",\\\"x-throttling-tier\\\":\\\"TempTier\\\",
+                        \\\"post\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",\\\"x-throttling-tier\\\":\\\"Unlimited\\\",
                         \\\"parameters\\\":[{\\\"schema\\\":{\\\"type\\\":\\\"object\\\"},\\\"description\\\":\\\"Request Body\\\",
                         \\\"name\\\":\\\"Payload\\\",\\\"required\\\":false,\\\"in\\\":\\\"body\\\"}],
                         \\\"responses\\\":{\\\"200\\\":{}}},\\\"get\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",
-                        \\\"x-throttling-tier\\\":\\\"TempTier\\\",\\\"responses\\\":{\\\"200\\\":{}}},
+                        \\\"x-throttling-tier\\\":\\\"Unlimited\\\",\\\"responses\\\":{\\\"200\\\":{}}},
                         \\\"delete\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",
-                        \\\"x-throttling-tier\\\":\\\"TempTier\\\",\\\"responses\\\":{\\\"200\\\":{}}},
+                        \\\"x-throttling-tier\\\":\\\"Unlimited\\\",\\\"responses\\\":{\\\"200\\\":{}}},
                         \\\"patch\\\":{\\\"x-auth-type\\\":\\\"Application & Application User\\\",
-                        \\\"x-throttling-tier\\\":\\\"TempTier\\\",\\\"parameters\\\":[{\\\"schema\\\":{\\\"type\\\":\\\"object\\\"},
+                        \\\"x-throttling-tier\\\":\\\"Unlimited\\\",\\\"parameters\\\":[{\\\"schema\\\":{\\\"type\\\":\\\"object\\\"},
                         \\\"description\\\":\\\"Request Body\\\",\\\"name\\\":\\\"Payload\\\",\\\"required\\\":false,\\\"in\\\":\\\"body\\\"}],
                         \\\"responses\\\":{\\\"200\\\":{}}}}},\\\"swagger\\\":\\\"2.0\\\",
                         \\\"info\\\":{\\\"title\\\":\\\"api1\\\",\\\"version\\\":\\\"1\\\"}}\",\r\n


### PR DESCRIPTION
## Purpose
This PR fixes test cases for https://github.com/wso2/carbon-apimgt/pull/5852

## Approach

Fix tests case failures due the validation of x-throttling tier (resource tiers) in swagger api definition. Replaced the non-existing throttling tier values with existing tier names in test cases.
After creating a tenant and log in for first time and trying to create an API, it fails due to default throttling policies are not available in DB. Hence this fix waits for CommonConfigDeployer to add the policies to DB.

