### PR TITLE
Integration test cases for updating Oauth application owner

### DIFF
--- a/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/utils/clients/AdminDashboardRestClient.java
+++ b/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/utils/clients/AdminDashboardRestClient.java
@@ -140,6 +140,56 @@ public class AdminDashboardRestClient {
             throw new APIManagerIntegrationTestException("Get all tiers failed", e);
         }        
     }
+
+    /**
+     * Get all applications within a specific tenant domain
+     * @return http response
+     * @throws APIManagerIntegrationTestException
+     * @param search
+     * @param start
+     * @param draw
+     * @param offset
+     * @param columnId
+     * @param sortOrder
+     */
+    public HttpResponse getapplicationsByTenantId(String search, String start, String draw, String offset,
+                                                  String columnId, String sortOrder)
+            throws APIManagerIntegrationTestException {
+        try {
+            checkAuthentication();
+            return HTTPSClientUtils.doPost(
+                    new URL(backendURL
+                            + "admin/site/blocks/application-owner/get-applications/ajax/get-applications.jag"),
+                            "action=getApplicationsByTenantIdWithPagination&start=" + start + "&length=" + offset
+                            + "&search[value]=" + search + "&draw=" + draw + "&order[0][column]=" + columnId
+                            + "&order[0][dir]=" + sortOrder, requestHeaders);
+        } catch (Exception e) {
+            throw new APIManagerIntegrationTestException("Get all applications with pagination failed", e);
+        }
+    }
+
+    /**
+     * Update application owner
+     * @return http response
+     * @throws APIManagerIntegrationTestException
+     * @param newOwner
+     * @param oldOwner
+     * @param uuid
+     * @param appName
+     */
+    public HttpResponse updateApplicationOwner(String newOwner, String oldOwner, String uuid, String appName)
+            throws APIManagerIntegrationTestException {
+        try {
+            checkAuthentication();
+            return HTTPSClientUtils.doPost(
+                    new URL(backendURL
+                            + "admin/site/blocks/application-owner/change-owner/ajax/change-owner.jag"),
+                            "action=changeOwner&newOwner=" + newOwner + "&oldOwner=" + oldOwner
+                            + "&applicationUuid=" + uuid + "&applicationName=" + appName, requestHeaders);
+        } catch (Exception e) {
+            throw new APIManagerIntegrationTestException("Updating application owner failed", e);
+        }
+    }
     
     private String getSession(Map<String, String> responseHeaders) {
         return responseHeaders.get("Set-Cookie");

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -187,6 +187,7 @@
             <class name="org.wso2.am.integration.tests.other.APIMANAGER5326CustomStatusMsgTestCase"/>
             <!--class name="org.wso2.am.integration.tests.application.ApplicationCallbackURLTestCase"/-->
             <class name="org.wso2.am.integration.tests.application.AuthApplicationUpdateTestCase"/>
+            <class name="org.wso2.am.integration.tests.admin.OAuthApplicationOwnerUpdateTestCase"/>
             <class name="org.wso2.am.integration.tests.application.GrantTypeTokenGenerateTestCase"/>
             <class name="org.wso2.am.integration.tests.application.APIMANAGER3706ApplicationUpdateTestCase"/>
             <class name="org.wso2.am.integration.tests.api.sdk.SDKGenerationTestCase"/>


### PR DESCRIPTION
## Purpose
> 

- Integration test cases to retrieve applications with pagination within a tenant domain.

- Test cases to update Oauth application owner within tenant domain and across tenant domain.

