### PR TITLE
Fix Publishing new Versions of API's with "Deprecate Old Versions" th…

### DIFF
--- a/modules/distribution/product/src/main/conf/master-datasources.xml
+++ b/modules/distribution/product/src/main/conf/master-datasources.xml
@@ -36,7 +36,7 @@
             </jndiConfig>
             <definition type="RDBMS">
                 <configuration>
-                    <url>jdbc:h2:repository/database/WSO2AM_DB;DB_CLOSE_ON_EXIT=FALSE</url>
+                    <url>jdbc:h2:repository/database/WSO2AM_DB;DB_CLOSE_ON_EXIT=FALSE;MVCC=TRUE</url>
                     <username>wso2carbon</username>
                     <password>wso2carbon</password>
                     <defaultAutoCommit>true</defaultAutoCommit>
@@ -58,7 +58,7 @@
             </jndiConfig>
             <definition type="RDBMS">
                 <configuration>
-                    <url>jdbc:h2:../tmpStatDB/WSO2AM_STATS_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000;AUTO_SERVER=TRUE</url>
+                    <url>jdbc:h2:../tmpStatDB/WSO2AM_STATS_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000;AUTO_SERVER=TRUE;MVCC=TRUE</url>
                     <username>wso2carbon</username>
                     <password>wso2carbon</password>
                     <defaultAutoCommit>true</defaultAutoCommit>
@@ -80,7 +80,7 @@
             </jndiConfig>
             <definition type="RDBMS">
                 <configuration>
-                    <url>jdbc:h2:repository/database/WSO2MB_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000</url>
+                    <url>jdbc:h2:repository/database/WSO2MB_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000;MVCC=TRUE</url>
                     <username>wso2carbon</username>
                     <password>wso2carbon</password>
                     <driverClassName>org.h2.Driver</driverClassName>


### PR DESCRIPTION
## Purpose
>  Resolves https://github.com/wso2/product-apim/issues/4057

## Goals
> When different threads access the DB concurrently some action may throw the aforementioned timeout error. We can tune H2 DB to overcome this problem.


## Approach
> Set MVCC=TRUE in DB URL. The MVCC feature allows higher concurrency than using (table level or row level) locks. When using MVCC in this database, delete, insert and update operations will only issue a shared lock on the table. An exclusive lock is still used when adding or removing columns when dropping the table, and when using SELECT ... FOR UPDATE. 

## Related PRs
> https://github.com/wso2/carbon-apimgt/pull/5891

