### PR TITLE
Removed unwanted attributes from swagger definition in product-Scenario API request

### DIFF
--- a/product-scenarios/scenarios-common/src/main/java/org/wso2/am/scenario/test/common/APIRequest.java
+++ b/product-scenarios/scenarios-common/src/main/java/org/wso2/am/scenario/test/common/APIRequest.java
@@ -243,7 +243,6 @@ public class APIRequest extends AbstractRequest {
     public void constructSwagger() {
         setSwagger("{\"swagger\":\"2.0\",\"paths\":{" + "\"" + resource + "\""
                 + ":{\"post\":{\"parameters\":[{\"name\":\"Payload\",\"description\":\"Request Body\",\"required\":false,\"in\":\"body\",\"schema\":{\"type\":\"object\",\"properties\":{\"payload\":{\"type\":\"string\"}}}}],\"responses\":{\"200\":{\"description\":\"\"}}}}},\"info\":{\"title\": "
-                + "\"" + name + "\"" + ",\"version\":" + "\"" + version + "\"" + ",\"roles\":" + "\"" + roles + "\"" + ",\"visibility\":" + "\"" +
-                visibility +  "\"" + "}}");
+                + "\"" + name + "\"" + ",\"version\":" + "\"" + version + "\"" + "}}");
     }
 }


### PR DESCRIPTION
## Purpose
Fixed the issue in the swagger definition in product scenarios
Roles and Visibility send as the form data and it won't be added to the API request.
