### PR TITLE
Add an APIRequest overload method and refactor swagger definition

### DIFF
--- a/product-scenarios/scenarios-common/src/main/java/org/wso2/am/scenario/test/common/APIRequest.java
+++ b/product-scenarios/scenarios-common/src/main/java/org/wso2/am/scenario/test/common/APIRequest.java
@@ -86,6 +86,25 @@ public class APIRequest extends AbstractRequest {
         constructSwagger();
     }
 
+    public APIRequest(String name, String context, String visibility, String version, String resource,
+                      String tiersCollection, URL productionEndpointUrl, URL sandboxEndpointUrl) {
+        this.name = name;
+        this.context = context;
+        this.visibility = visibility;
+        this.version = version;
+        this.resource = resource;
+        this.tiersCollection = tiersCollection;
+        try {
+            this.endpoint =
+                    new JSONObject("{\"production_endpoints\":{\"url\":\""+ productionEndpointUrl + "\"," +
+                            "\"config\":null},\"sandbox_endpoints\":{\"url\":\""+ sandboxEndpointUrl + "\"," +
+                            "\"config\":null},\"endpoint_type\":\"http\"}");
+        } catch (JSONException e) {
+            log.error("JSON construct error", e);
+        }
+        constructSwagger();
+    }
+
     public APIRequest(String name, String context, String visibility, String roles, String version, String resource,
                       String tiersCollection, URL endpointUrl) {
 
@@ -242,7 +261,12 @@ public class APIRequest extends AbstractRequest {
 
     public void constructSwagger() {
         setSwagger("{\"swagger\":\"2.0\",\"paths\":{" + "\"" + resource + "\""
-                + ":{\"post\":{\"parameters\":[{\"name\":\"Payload\",\"description\":\"Request Body\",\"required\":false,\"in\":\"body\",\"schema\":{\"type\":\"object\",\"properties\":{\"payload\":{\"type\":\"string\"}}}}],\"responses\":{\"200\":{\"description\":\"\"}}}}},\"info\":{\"title\": "
-                + "\"" + name + "\"" + ",\"version\":" + "\"" + version + "\"" + "}}");
+                + ":{\"post\":{\"x-auth-type\":\"Application %26 Application User\",\"x-throttling-tier\":\""
+                + tiersCollection + "\",\"parameters\":[{\"name\":\"Payload\",\"description\":\"Request Body\"," +
+                "\"required\":false,\"in\":\"body\",\"schema\":{\"type\":\"object\",\"properties\":{\"payload\":" +
+                "{\"type\":\"string\"}}}}],\"responses\":{\"200\":{\"description\":\"\"}}},\"get\":{\"x-auth-type\":" +
+                "\"Application %26 Application User\",\"x-throttling-tier\":\"" + tiersCollection + "\",\"responses\"" +
+                ":{\"200\":{\"description\":\"\"}}}}},\"info\":{\"title\": " + "\"" + name + "\"" + ",\"version\":" +
+                "\"" + version + "\"}}");
     }
 }


### PR DESCRIPTION
## Purpose
An overloaded APIRequest method was added to facilitate creation of an API with both production and sandbox urls.
The swagger definition was refactored to create both 'post' and 'get' resource. 'x-auth-type' and 'x-throttling-tier' values were added to facilitate invocation of API.