### PR TITLE
Add capability to create custom subscription policies for tests

### DIFF
--- a/product-scenarios/7-managing-api-traffic-based-on-various-conditions/7.1-limit-access-to-an-application/7.1.1-define-and-assign-subscription-tiers/src/test/java/org/wso2/am/scenario/tests/define/subscription/tiers/SubscribeToAssignedTiersNegativeTestCase.java
+++ b/product-scenarios/7-managing-api-traffic-based-on-various-conditions/7.1-limit-access-to-an-application/7.1.1-define-and-assign-subscription-tiers/src/test/java/org/wso2/am/scenario/tests/define/subscription/tiers/SubscribeToAssignedTiersNegativeTestCase.java
@@ -70,7 +70,7 @@ public class SubscribeToAssignedTiersNegativeTestCase extends ScenarioTestBase {
         apiStore.login(ADMIN_USERNAME, ADMIN_PASSWORD);
     }
 
-    @Test(description = "7.1.1.4")
+    @Test(description = "7.1.1.5")
     public void testCreateAPIWithNoSubscriptionTiers() throws Exception {
         apiRequest = new APIRequest(apiNameNoTiers, apiContextNoTiers, apiVisibility, apiVersion, apiResource, null,
                 new URL(endpointUrl));
@@ -82,7 +82,7 @@ public class SubscribeToAssignedTiersNegativeTestCase extends ScenarioTestBase {
         Assert.assertTrue(responseData.getString("message").contains("No tier defined for the API"));
     }
 
-    @Test(description = "7.1.1.5")
+    @Test(description = "7.1.1.6")
     public void testSubscribeWithTierNotAssignedToAPI() throws Exception {
         apiRequest = new APIRequest(apiNameSubscribeToNotAssigned, apiContextSubscribeToNotAssigned, apiVisibility,
                 apiVersion, apiResource, goldTier, new URL(endpointUrl));

--- a/product-scenarios/scenarios-common/src/main/java/org/wso2/am/scenario/test/common/AdminDashboardRestClient.java
+++ b/product-scenarios/scenarios-common/src/main/java/org/wso2/am/scenario/test/common/AdminDashboardRestClient.java
@@ -1,0 +1,129 @@
+/*
+ *Copyright (c), WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *WSO2 Inc. licenses this file to you under the Apache License,
+ *Version 2.0 (the "License"); you may not use this file except
+ *in compliance with the License.
+ *You may obtain a copy of the License at
+ *
+ *http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *Unless required by applicable law or agreed to in writing,
+ *software distributed under the License is distributed on an
+ *"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *KIND, either express or implied.  See the License for the
+ *specific language governing permissions and limitations
+ *under the License.
+ */
+
+package org.wso2.am.scenario.test.common;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.am.integration.test.utils.APIManagerIntegrationTestException;
+import org.wso2.am.integration.test.utils.http.HTTPSClientUtils;
+import org.wso2.carbon.automation.test.utils.http.client.HttpResponse;
+
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+
+public class AdminDashboardRestClient {
+
+    private static final Log log = LogFactory.getLog(AdminDashboardRestClient.class);
+    private String backendURL;
+    private Map<String, String> requestHeaders = new HashMap<String, String>();
+
+    public AdminDashboardRestClient(String backendURL) {
+        this.backendURL = backendURL;
+        if (requestHeaders.get("Content-Type") == null) {
+            this.requestHeaders.put("Content-Type", "application/x-www-form-urlencoded");
+        }
+    }
+
+    /**
+     * Login to API Admin Portal
+     *
+     * @param userName - username to login
+     * @param password - password to login
+     * @return - http response
+     * @throws org.wso2.am.integration.test.utils.APIManagerIntegrationTestException - Throws if login to Admin Portal
+     *                                                                               fails
+     */
+    public HttpResponse login(String userName, String password) throws APIManagerIntegrationTestException {
+        HttpResponse response;
+        log.info("Login to Admin Portal " + backendURL + " as the user " + userName);
+        try {
+            response = HTTPSClientUtils.doPost(new URL(backendURL + "/site/blocks/user/login/ajax/login.jag"),
+                    "action=login&username=" + userName + "&password=" + password + "", requestHeaders);
+        } catch (Exception e) {
+            throw new APIManagerIntegrationTestException("Unable to login to the store app ", e);
+        }
+
+        String session = getSession(response.getHeaders());
+
+        if (session == null) {
+            throw new APIManagerIntegrationTestException("No session cookie found with response");
+        }
+
+        setSession(session);
+        return response;
+    }
+
+    /**
+     * Add new subscription policy
+     *
+     * @param subscriptionThrottlePolicyRequest
+     * @return http response
+     * @throws APIManagerIntegrationTestException
+     */
+    public HttpResponse addSubscriptionPolicy(SubscriptionThrottlePolicyRequest subscriptionThrottlePolicyRequest)
+            throws APIManagerIntegrationTestException {
+        try {
+            checkAuthentication();
+            return HTTPSClientUtils.doPost(new URL(
+                            backendURL + "/site/blocks/policy/subscription/edit/ajax/subscription-policy-edit.jag"),
+                    subscriptionThrottlePolicyRequest.generateRequestParameters(), requestHeaders);
+        } catch (Exception e) {
+            throw new APIManagerIntegrationTestException("Add new subscription policy failed", e);
+        }
+    }
+
+    /**
+     * Delete subscription policy
+     *
+     * @param policyName
+     * @return http response
+     * @throws APIManagerIntegrationTestException
+     */
+    public HttpResponse deleteSubscriptionPolicy(String policyName) throws APIManagerIntegrationTestException {
+        try {
+            checkAuthentication();
+            return HTTPSClientUtils.doPost(new URL(
+                            backendURL + "/site/blocks/policy/subscription/manage/ajax/subscription-policy-manage.jag"),
+                    "action=deleteSubscriptionPolicy&policy=" + policyName, requestHeaders);
+        } catch (Exception e) {
+            throw new APIManagerIntegrationTestException("Delete subscription policy failed", e);
+        }
+    }
+
+    private String getSession(Map<String, String> responseHeaders) {
+        return responseHeaders.get("Set-Cookie");
+    }
+
+    private String setSession(String session) {
+        return requestHeaders.put("Cookie", session);
+    }
+
+    /**
+     * Check whether the user is logged in
+     *
+     * @throws org.wso2.am.integration.test.utils.APIManagerIntegrationTestException - If session cookie not found in
+     *                                                                               the request header
+     */
+    private void checkAuthentication() throws APIManagerIntegrationTestException {
+        if (requestHeaders.get("Cookie") == null) {
+            throw new APIManagerIntegrationTestException("No Session Cookie found. Please login first");
+        }
+    }
+}

--- a/product-scenarios/scenarios-common/src/main/java/org/wso2/am/scenario/test/common/ScenarioTestBase.java
+++ b/product-scenarios/scenarios-common/src/main/java/org/wso2/am/scenario/test/common/ScenarioTestBase.java
@@ -58,9 +58,11 @@ public class ScenarioTestBase {
     protected static String publisherURL;
     protected static String storeURL;
     protected static String keyManagerURL;
+    protected static String adminURL;
     private static Properties infraProperties;
     public static final String PUBLISHER_URL = "PublisherUrl";
     public static final String STORE_URL = "StoreUrl";
+    public static final String ADMIN_URL = "AdminUrl";
     public static final String KEYAMANAGER_URL = "KeyManagerUrl";
     protected static String resourceLocation = System.getProperty("framework.resource.location");
 
@@ -82,6 +84,10 @@ public class ScenarioTestBase {
         storeURL = infraProperties.getProperty(STORE_URL);
         if (storeURL == null) {
             storeURL = "https://localhost:9443/store";
+        }
+        adminURL = infraProperties.getProperty(ADMIN_URL);
+        if (adminURL == null) {
+            adminURL = "https://localhost:9443/admin";
         }
         setKeyStoreProperties();
     }

--- a/product-scenarios/scenarios-common/src/main/java/org/wso2/am/scenario/test/common/ScenarioTestConstants.java
+++ b/product-scenarios/scenarios-common/src/main/java/org/wso2/am/scenario/test/common/ScenarioTestConstants.java
@@ -19,6 +19,7 @@ public class ScenarioTestConstants {
     public static final String PUBLISHER_ROLE  = "Internal/publisher";
     public static final String CREATOR_ROLE  = "Internal/creator";
     public static final String SUBSCRIBER_ROLE  = "Internal/subscriber";
+    public static final String EVERYONE_ROLE = "Internal/everyone";
     public static final String TENANT_WSO2  = "wso2.com";
 
 }

--- a/product-scenarios/scenarios-common/src/main/java/org/wso2/am/scenario/test/common/SubscriptionThrottlePolicyRequest.java
+++ b/product-scenarios/scenarios-common/src/main/java/org/wso2/am/scenario/test/common/SubscriptionThrottlePolicyRequest.java
@@ -1,0 +1,176 @@
+/*
+ *Copyright (c), WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *WSO2 Inc. licenses this file to you under the Apache License,
+ *Version 2.0 (the "License"); you may not use this file except
+ *in compliance with the License.
+ *You may obtain a copy of the License at
+ *
+ *http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *Unless required by applicable law or agreed to in writing,
+ *software distributed under the License is distributed on an
+ *"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *KIND, either express or implied.  See the License for the
+ *specific language governing permissions and limitations
+ *under the License.
+ */
+package org.wso2.am.scenario.test.common;
+
+import org.wso2.am.integration.test.utils.bean.AbstractRequest;
+
+public class SubscriptionThrottlePolicyRequest extends AbstractRequest {
+
+    private String policyName;
+    private String description;
+    private String defaultQuotaPolicy = "requestCount";
+    private String defaultRequestCount;
+    private String defaultUnitTime;
+    private String defaultTimeUnit;
+    private String rateLimitCount = "-1";
+    private String rateLimitTimeUnit = "NA";
+    private String attributes = "[{\"name\":\"key\", \"value\":\"values\"}]";
+    private String stopOnQuotaReach = "true";
+    private String tierPlan = "FREE";
+    private String permissionType = "allow";
+    private String roles = ScenarioTestConstants.EVERYONE_ROLE;
+
+    public SubscriptionThrottlePolicyRequest(String policyName, String description, String requestCount,
+            String unitTime, String timeUnit) {
+        this.policyName = policyName;
+        this.description = description;
+        this.defaultRequestCount = requestCount;
+        this.defaultUnitTime = unitTime;
+        this.defaultTimeUnit = timeUnit;
+    }
+
+    @Override
+    public void setAction() {
+        if (action != null) {
+            super.setAction(action);
+        } else {
+            super.setAction("add");
+        }
+    }
+
+    public String getPolicyName() {
+        return policyName;
+    }
+
+    public void setPolicyName(String policyName) {
+        this.policyName = policyName;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getDefaultQuotaPolicy() {
+        return defaultQuotaPolicy;
+    }
+
+    public void setDefaultQuotaPolicy(String defaultQuotaPolicy) {
+        this.defaultQuotaPolicy = defaultQuotaPolicy;
+    }
+
+    public String getDefaultRequestCount() {
+        return defaultRequestCount;
+    }
+
+    public void setDefaultRequestCount(String defaultRequestCount) {
+        this.defaultRequestCount = defaultRequestCount;
+    }
+
+    public String getDefaultUnitTime() {
+        return defaultUnitTime;
+    }
+
+    public void setDefaultUnitTime(String defaultUnitTime) {
+        this.defaultUnitTime = defaultUnitTime;
+    }
+
+    public String getDefaultTimeUnit() {
+        return defaultTimeUnit;
+    }
+
+    public void setDefaultTimeUnit(String defaultTimeUnit) {
+        this.defaultTimeUnit = defaultTimeUnit;
+    }
+
+    public String getRateLimitCount() {
+        return rateLimitCount;
+    }
+
+    public void setRateLimitCount(String rateLimitCount) {
+        this.rateLimitCount = rateLimitCount;
+    }
+
+    public String getRateLimitTimeUnit() {
+        return rateLimitTimeUnit;
+    }
+
+    public void setRateLimitTimeUnit(String rateLimitTimeUnit) {
+        this.rateLimitTimeUnit = rateLimitTimeUnit;
+    }
+
+    public String getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(String attributes) {
+        this.attributes = attributes;
+    }
+
+    public String getStopOnQuotaReach() {
+        return stopOnQuotaReach;
+    }
+
+    public void setStopOnQuotaReach(String stopOnQuotaReach) {
+        this.stopOnQuotaReach = stopOnQuotaReach;
+    }
+
+    public String getTierPlan() {
+        return tierPlan;
+    }
+
+    public void setTierPlan(String tierPlan) {
+        this.tierPlan = tierPlan;
+    }
+
+    public String getPermissionType() {
+        return permissionType;
+    }
+
+    public void setPermissionType(String permissionType) {
+        this.permissionType = permissionType;
+    }
+
+    public String getRoles() {
+        return roles;
+    }
+
+    public void setRoles(String roles) {
+        this.roles = roles;
+    }
+
+    @Override
+    public void init() {
+        addParameter("policyName", policyName);
+        addParameter("description", description);
+        addParameter("defaultQuotaPolicy", defaultQuotaPolicy);
+        addParameter("defaultRequestCount", defaultRequestCount);
+        addParameter("defaultUnitTime", defaultUnitTime);
+        addParameter("defaultTimeUnit", defaultTimeUnit);
+        addParameter("rateLimitCount", rateLimitCount);
+        addParameter("rateLimitTimeUnit", rateLimitTimeUnit);
+        addParameter("attributes", attributes);
+        addParameter("stopOnQuotaReach", stopOnQuotaReach);
+        addParameter("tierPlan", tierPlan);
+        addParameter("permissionType", permissionType);
+        addParameter("roles", roles);
+    }
+}


### PR DESCRIPTION
## Purpose
This PR adds the capability to create and delete subscription throttling policies for Test scenarios.
This also adds a test case for custom subscription tier availability.