### PR TITLE
Adding Store API indexing wait logic

### DIFF
--- a/product-scenarios/1-manage-public-partner-private-apis/1.5-expose-api-to-the-app-developer/1.5.1-expose-api-visible-to-all-public-app-developer-without-restriction/src/test/java/org/wso2/am/scenario/tests/rest/api/publicVisibility/PublicRestApiVisibilityTestCase.java
+++ b/product-scenarios/1-manage-public-partner-private-apis/1.5-expose-api-to-the-app-developer/1.5.1-expose-api-visible-to-all-public-app-developer-without-restriction/src/test/java/org/wso2/am/scenario/tests/rest/api/publicVisibility/PublicRestApiVisibilityTestCase.java
@@ -89,31 +89,8 @@ public class PublicRestApiVisibilityTestCase extends ScenarioTestBase {
         assertTrue(apiResponsePublisher.getData().contains(apiName), apiName + " is not visible in publisher");
         verifyResponse(apiResponsePublisher);
 
-        apiStoreClient = new APIStoreRestClient(storeURL);
-        HttpResponse apiResponseStore;
-
-        while (waitTime > System.currentTimeMillis()) {
-            HttpResponse response = null;
-            apiResponseStore = apiStoreClient.getAPIListFromStoreAsAnonymousUser(tenantDomain);
-
-            log.info("WAIT for availability of API: " + apiName);
-
-            if (apiResponseStore != null) {
-                log.info("Data: " + response.getData());
-                if (response.getData().contains(apiName)) {
-                    verifyResponse(apiResponseStore);
-                    assertTrue(apiResponseStore.getData().contains(apiName));
-                    verifyResponse(apiResponseStore);
-                    break;
-                } else {
-                    try {
-                        Thread.sleep(500);
-                    } catch (InterruptedException ignored) {
-
-                    }
-                }
-            }
-        }
+        // wait till API indexed in Store
+        isAPIVisibleInStoreForAnonymousUser(apiName, "carbon.super");
     }
 
     @Test(description = "1.5.1.2")
@@ -123,9 +100,6 @@ public class PublicRestApiVisibilityTestCase extends ScenarioTestBase {
         apiContext = "/findVerification";
         apiRequest = new APIRequest(apiName, apiContext, apiVisibility, apiVersion, apiResource, tierCollection,
                 new URL(backendEndPoint));
-
-        long currentTime = System.currentTimeMillis();
-        long waitTime = currentTime + WAIT_TIME;
 
         HttpResponse apiCreationResponse = apiPublisher.addAPI(apiRequest);
         assertEquals(apiCreationResponse.getResponseCode(), Response.Status.OK.getStatusCode(),
@@ -143,28 +117,8 @@ public class PublicRestApiVisibilityTestCase extends ScenarioTestBase {
         HttpResponse apiPublishResponse = apiPublisher.changeAPILifeCycleStatus(updateLifeCycle);
         verifyResponse(apiPublishResponse);
 
-        apiStoreClient = new APIStoreRestClient(storeURL);
-        HttpResponse apiResponseStore;
-
-        while (waitTime > System.currentTimeMillis()) {
-            apiResponseStore = apiStoreClient.getSwaggerDocumentWithoutLogin(admin, apiName, apiVersion);
-
-            log.info("WAIT for availability of resource in API: " + apiName);
-
-            if (apiResponseStore != null) {
-                log.info("Data: " + apiResponseStore.getData());
-                if (apiResponseStore.getData().contains(apiResource)) {
-                    assertTrue(apiResponseStore.getData().contains(apiResource));
-                    break;
-                } else {
-                    try {
-                        Thread.sleep(500);
-                    } catch (InterruptedException ignored) {
-
-                    }
-                }
-            }
-        }
+        // wait till API indexed in Store
+        isAPIVisibleInStoreForAnonymousUser(apiName, "carbon.super");
     }
 
     @AfterClass(alwaysRun = true)

--- a/product-scenarios/7-managing-api-traffic-based-on-various-conditions/7.1-limit-access-to-an-application/7.1.1-define-and-assign-subscription-tiers/src/test/java/org/wso2/am/scenario/tests/define/subscription/tiers/SubscribeToAssignedTiersTestCase.java
+++ b/product-scenarios/7-managing-api-traffic-based-on-various-conditions/7.1-limit-access-to-an-application/7.1.1-define-and-assign-subscription-tiers/src/test/java/org/wso2/am/scenario/tests/define/subscription/tiers/SubscribeToAssignedTiersTestCase.java
@@ -89,6 +89,10 @@ public class SubscribeToAssignedTiersTestCase extends ScenarioTestBase {
                 APILifeCycleState.PUBLISHED);
         HttpResponse publishServiceResponse = apiPublisher.changeAPILifeCycleStatus(updateRequest);
         Assert.assertTrue(publishServiceResponse.getData().contains(APILifeCycleState.PUBLISHED.getState()));
+        
+        // wait till API indexed in Store
+        isAPIVisibleInStoreForAnonymousUser(apiRepublishedWithDiffTier, "carbon.super");
+
         //Create Application for single tier
         HttpResponse addApplicationResponse = apiStore
                 .addApplication(applicationNameSingleTier, APIMIntegrationConstants.APPLICATION_TIER.UNLIMITED, "",
@@ -113,6 +117,10 @@ public class SubscribeToAssignedTiersTestCase extends ScenarioTestBase {
                 APILifeCycleState.PUBLISHED);
         HttpResponse publishServiceResponse = apiPublisher.changeAPILifeCycleStatus(updateRequest);
         Assert.assertTrue(publishServiceResponse.getData().contains(APILifeCycleState.PUBLISHED.getState()));
+
+        // wait till API indexed in Store
+        isAPIVisibleInStoreForAnonymousUser(apiRepublishedWithDiffTier, "carbon.super");
+
         //Create Application for multiple tiers
         HttpResponse addApplicationResponse = apiStore
                 .addApplication(applicationNameMultipleTier, APIMIntegrationConstants.APPLICATION_TIER.UNLIMITED, "",
@@ -146,6 +154,10 @@ public class SubscribeToAssignedTiersTestCase extends ScenarioTestBase {
                 APILifeCycleState.PUBLISHED);
         HttpResponse publishServiceResponse = apiPublisher.changeAPILifeCycleStatus(updateRequest);
         Assert.assertTrue(publishServiceResponse.getData().contains(APILifeCycleState.PUBLISHED.getState()));
+
+        // wait till API indexed in Store
+        isAPIVisibleInStoreForAnonymousUser(apiRepublishedWithDiffTier, "carbon.super");
+
         //Create Application to subscribe before republishing
         HttpResponse addApplicationResponse = apiStore
                 .addApplication(applicationNameBeforeAPIRepublish, APIMIntegrationConstants.APPLICATION_TIER.UNLIMITED,


### PR DESCRIPTION
## Purpose

When an API is published from publisher it takes a little time to appear in store. So whenever we publish an API and check for availability in store, we need to invoke **isAPIVisibleInStoreForAnonymousUser** method.