### PR TITLE
Add thread sleep when token endpoint call returns response 404

### DIFF
--- a/product-scenarios/4-application-development-using-apis/4.1-application-developers-should-be-able-to-use-apis-in-their-applications/4.1.1-registering-an-application/src/test/java/org/wso2/am/scenario/tests/register/application/ApplicationCreationTestCases.java
+++ b/product-scenarios/4-application-development-using-apis/4.1-application-developers-should-be-able-to-use-apis-in-their-applications/4.1.1-registering-an-application/src/test/java/org/wso2/am/scenario/tests/register/application/ApplicationCreationTestCases.java
@@ -196,16 +196,11 @@ public class ApplicationCreationTestCases extends ScenarioTestBase {
                     "grant_type=password&username=admin&password=admin");
             log.info("key manager url token endpoint response code :" + keyManagerURLResponse.getResponseCode());
             log.info("key manager url token endpoint response data :" + keyManagerURLResponse.getData());
-            if(keyManagerURLResponse.getResponseCode() == 404) {
-                Thread.sleep(3600000);
-            }
             HttpResponse gatewayResponse = HttpClient.doPost(gatewayHttpsURL + "/token", headers,
                     "grant_type=password&username=admin&password=admin");
             log.info("Gateway url token endpoint response code  :" + gatewayResponse.getResponseCode());
             log.info("Gateway url token endpoint response data  :" + gatewayResponse.getData());
-            if(gatewayResponse.getResponseCode() == 404) {
-                Thread.sleep(3600000);
-            }
+            Thread.sleep(3600000);
         }
     }
 

--- a/product-scenarios/4-application-development-using-apis/4.1-application-developers-should-be-able-to-use-apis-in-their-applications/4.1.1-registering-an-application/src/test/java/org/wso2/am/scenario/tests/register/application/ApplicationCreationTestCases.java
+++ b/product-scenarios/4-application-development-using-apis/4.1-application-developers-should-be-able-to-use-apis-in-their-applications/4.1.1-registering-an-application/src/test/java/org/wso2/am/scenario/tests/register/application/ApplicationCreationTestCases.java
@@ -196,10 +196,16 @@ public class ApplicationCreationTestCases extends ScenarioTestBase {
                     "grant_type=password&username=admin&password=admin");
             log.info("key manager url token endpoint response code :" + keyManagerURLResponse.getResponseCode());
             log.info("key manager url token endpoint response data :" + keyManagerURLResponse.getData());
+            if(keyManagerURLResponse.getResponseCode() == 404) {
+                Thread.sleep(3600000);
+            }
             HttpResponse gatewayResponse = HttpClient.doPost(gatewayHttpsURL + "/token", headers,
                     "grant_type=password&username=admin&password=admin");
             log.info("Gateway url token endpoint response code  :" + gatewayResponse.getResponseCode());
             log.info("Gateway url token endpoint response data  :" + gatewayResponse.getData());
+            if(gatewayResponse.getResponseCode() == 404) {
+                Thread.sleep(3600000);
+            }
         }
     }
 


### PR DESCRIPTION
## Purpose
When a token endpoint call returns a response code 404, a thread sleep of 1 hr is added to debug the test failure.