### PR TITLE
Upgrade Saxon-HE version in endorsed lib

### DIFF
--- a/modules/distribution/product/src/main/assembly/bin.xml
+++ b/modules/distribution/product/src/main/assembly/bin.xml
@@ -140,7 +140,7 @@
           <directory>../../p2-profile/product/target/wso2carbon-core-${carbon.kernel.version}/lib/endorsed</directory>
           <outputDirectory>wso2am-${pom.version}/lib/endorsed</outputDirectory>
 	    <includes>
-                <include>**/Saxon-HE-9.4.jar</include>
+                <include>**/Saxon-HE-9.5.1-8.jar</include>
             </includes>
         </fileSet>
         <fileSet>


### PR DESCRIPTION
## Purpose
> upgrade Saxon-HE version. this version is compatible with both jdk8 and jdk11

## Related PRs
> https://github.com/wso2/carbon-apimgt/pull/5913
