### PR TITLE
Add 3.2.1.13 test case.

### DIFF
--- a/product-scenarios/3-securing-an-api-with-different-security-protocols/3.2-api-developers-want-to-secure-their-api-using-an-user-access-control-machanism/3.2.1-api-developer-wants-to-secure-api-resources-using-user-roles/pom.xml
+++ b/product-scenarios/3-securing-an-api-with-different-security-protocols/3.2-api-developers-want-to-secure-their-api-using-an-user-access-control-machanism/3.2.1-api-developer-wants-to-secure-api-resources-using-user-roles/pom.xml
@@ -48,6 +48,7 @@
                     <systemPropertyVariables>
                         <framework.resource.location>${project.parent.parent.basedir}/../scenarios-common/src/main/resources/</framework.resource.location>
                         <maven.test.haltafterfailure>false</maven.test.haltafterfailure>
+                        <test.resource.location>${project.basedir}/src/test/resources/</test.resource.location>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/product-scenarios/3-securing-an-api-with-different-security-protocols/3.2-api-developers-want-to-secure-their-api-using-an-user-access-control-machanism/3.2.1-api-developer-wants-to-secure-api-resources-using-user-roles/src/test/java/org/wso2/am/scenario/tests/api/secure/userRoles/SecureUsingUserRolesNegativeTestCases.java
+++ b/product-scenarios/3-securing-an-api-with-different-security-protocols/3.2-api-developers-want-to-secure-their-api-using-an-user-access-control-machanism/3.2.1-api-developer-wants-to-secure-api-resources-using-user-roles/src/test/java/org/wso2/am/scenario/tests/api/secure/userRoles/SecureUsingUserRolesNegativeTestCases.java
@@ -26,19 +26,28 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.am.integration.test.utils.APIManagerIntegrationTestException;
 
+import org.wso2.am.integration.test.utils.bean.APILifeCycleState;
+import org.wso2.am.integration.test.utils.bean.APILifeCycleStateRequest;
 import org.wso2.am.scenario.test.common.APIPublisherRestClient;
+import org.wso2.am.scenario.test.common.APIRequest;
 import org.wso2.am.scenario.test.common.ScenarioTestBase;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.automation.test.utils.http.client.HttpResponse;
 
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.testng.Assert.assertEquals;
 
 public class SecureUsingUserRolesNegativeTestCases extends ScenarioTestBase {
+
     private static final Log log = LogFactory.getLog(SecureUsingUserRolesNegativeTestCases.class);
     private APIPublisherRestClient apiPublisher;
+    private APIPublisherRestClient apiPublisherAdmin;
     private static final String ADMIN_LOGIN_USERNAME = "admin";
     private static final String ADMIN_LOGIN_PW = "admin";
     private static final String API_ADMIN_PERMISSION = "/permission/admin";
@@ -56,6 +65,33 @@ public class SecureUsingUserRolesNegativeTestCases extends ScenarioTestBase {
     private static final String ROLE_EXISTANCE = "isRoleExist";
     List<String> userList = new ArrayList();
     List<String> roleList = new ArrayList();
+    private String description = "This is a API creation description";
+    private String tag = "APICreationTag";
+    private String tierCollection = "Silver";
+    private String bizOwner = "wso2Test";
+    private String bizOwnerMail = "wso2test@gmail.com";
+    private String techOwner = "wso2";
+    private String techOwnerMail = "wso2@gmail.com";
+    private String endpointType = "secured";
+    private String endpointAuthType = "basicAuth";
+    private String epUsername = "wso2";
+    private String epPassword = "wso2123";
+    private String default_version_checked = "default_version";
+    private String responseCache = "enabled";
+    private String cacheTimeout = "300";
+    private String subscriptions = "all_tenants";
+    private String http_checked = "http";
+    private String https_checked = "";
+    private String inSequence = "debug_in_flow";
+    private String outSequence = "debug_out_flow";
+    private String apiVersion = "1.0.0";
+    private String apiResource = "/find";
+    private String apiVisibility = "public";
+    private String backendEndPoint = "http://ws.cdyne.com/phoneverify/phoneverify.asmx";
+    private String apiName = "ScopeTest";
+    private String apiContext = "phone";
+    private File swagger_file;
+    String resourceLocation = System.getProperty("test.resource.location");
 
     private void setupUserData() {
         try {
@@ -96,6 +132,33 @@ public class SecureUsingUserRolesNegativeTestCases extends ScenarioTestBase {
         }
     }
 
+    public static String readFromFile(String file_name) throws IOException {
+        BufferedReader br = new BufferedReader(new FileReader(file_name));
+        StringBuilder sb = new StringBuilder();
+        int x;
+        while ((x = br.read()) != -1) {
+            sb.append((char) x);
+        }
+        String payloadText = sb.toString();
+        return payloadText;
+    }
+
+    private void createAndPublishAPI() throws APIManagerIntegrationTestException {
+        APIRequest apiRequest = new APIRequest(apiName, apiContext, apiVisibility, "", apiVersion, apiResource, description, tag,
+                tierCollection, backendEndPoint, bizOwner, bizOwnerMail, techOwner, techOwnerMail, endpointType,
+                endpointAuthType, epUsername, epPassword, default_version_checked, responseCache, cacheTimeout,
+                subscriptions, http_checked, https_checked, inSequence, outSequence);
+
+        //Design API with name,context,version,visibility,apiResource and with all optional values
+        HttpResponse serviceResponse = apiPublisher.addAPI(apiRequest);
+        verifyResponse(serviceResponse);
+        HttpResponse serviceResponseGetApi = apiPublisher.getAPI(apiName, SUPER_USER);
+
+        APILifeCycleStateRequest updateRequest = new APILifeCycleStateRequest(apiName, SUPER_USER,
+                APILifeCycleState.PUBLISHED);
+        apiPublisher.changeAPILifeCycleStatus(updateRequest);
+    }
+
     @DataProvider(name = "ScopeAndInValidRoleDataProvider")
     public static Object[][] ValidRoleDataProvider() {
         return new Object[][]{
@@ -106,9 +169,13 @@ public class SecureUsingUserRolesNegativeTestCases extends ScenarioTestBase {
     }
 
     @BeforeClass(alwaysRun = true)
-    public void init() throws APIManagerIntegrationTestException, APIManagementException {
+    public void init() throws APIManagerIntegrationTestException {
+        setupUserData();
         apiPublisher = new APIPublisherRestClient(publisherURL);
         apiPublisher.login(SUPER_USER, SUPER_USER_LOGIN_PW);
+        apiPublisherAdmin = new APIPublisherRestClient(publisherURL);
+        apiPublisherAdmin.login(ADMIN_LOGIN_USERNAME, ADMIN_LOGIN_PW);
+        createAndPublishAPI();
     }
 
     @Test(description = "3.2.1.9", dataProvider = "ScopeAndInValidRoleDataProvider",
@@ -118,7 +185,20 @@ public class SecureUsingUserRolesNegativeTestCases extends ScenarioTestBase {
         verifyResponse(httpResponse);
         assertEquals(new JSONObject(httpResponse.getData()).get(ROLE_EXISTANCE).toString(), "false",
                 "Error in scope creation with Invalid values. Role  : " + role);
+    }
 
+    @Test(description = "3.2.1.13")
+    public void testScopeWithDuplicateKey() throws Exception {
+        // This swagger will create "item_view" scope and assign it to a resource.
+        swagger_file = new File(resourceLocation + File.separator + "swaggerFiles/APIScopeTest1.json");
+        String payload = readFromFile(swagger_file.getAbsolutePath());
+        HttpResponse updateResponse = apiPublisher.updateResourceOfAPI(SUPER_USER, apiName, apiVersion, payload);
+        verifyResponse(updateResponse);
+        // Redeclare scope with item_view key.
+        HttpResponse httpResponse = apiPublisher.validateScope(ITEM_VIEW, AGENT_ROLE);
+        verifyResponse(httpResponse);
+        assertEquals(new JSONObject(httpResponse.getData()).get(SCOPE_EXISTANCE).toString(), "true",
+                "Error in scope creation with Invalid values. Scope  : " + ITEM_VIEW);
     }
 
     @AfterClass(alwaysRun = true)
@@ -129,5 +209,6 @@ public class SecureUsingUserRolesNegativeTestCases extends ScenarioTestBase {
         } catch (APIManagementException ex) {
             log.error("Users or role deletion failed", ex);
         }
+        apiPublisherAdmin.deleteAPI(apiName, apiVersion, SUPER_USER);
     }
 }

--- a/product-scenarios/3-securing-an-api-with-different-security-protocols/3.2-api-developers-want-to-secure-their-api-using-an-user-access-control-machanism/3.2.1-api-developer-wants-to-secure-api-resources-using-user-roles/src/test/java/org/wso2/am/scenario/tests/api/secure/userRoles/SecureUsingUserRolesNegativeTestCases.java
+++ b/product-scenarios/3-securing-an-api-with-different-security-protocols/3.2-api-developers-want-to-secure-their-api-using-an-user-access-control-machanism/3.2.1-api-developer-wants-to-secure-api-resources-using-user-roles/src/test/java/org/wso2/am/scenario/tests/api/secure/userRoles/SecureUsingUserRolesNegativeTestCases.java
@@ -198,7 +198,7 @@ public class SecureUsingUserRolesNegativeTestCases extends ScenarioTestBase {
         HttpResponse httpResponse = apiPublisher.validateScope(ITEM_VIEW, AGENT_ROLE);
         verifyResponse(httpResponse);
         assertEquals(new JSONObject(httpResponse.getData()).get(SCOPE_EXISTANCE).toString(), "true",
-                "Error in scope creation with Invalid values. Scope  : " + ITEM_VIEW);
+                "Error in scope creation with duplicate key : " + ITEM_VIEW);
     }
 
     @AfterClass(alwaysRun = true)

--- a/product-scenarios/3-securing-an-api-with-different-security-protocols/3.2-api-developers-want-to-secure-their-api-using-an-user-access-control-machanism/3.2.1-api-developer-wants-to-secure-api-resources-using-user-roles/src/test/resources/swaggerFiles/APIScopeTest1.json
+++ b/product-scenarios/3-securing-an-api-with-different-security-protocols/3.2-api-developers-want-to-secure-their-api-using-an-user-access-control-machanism/3.2.1-api-developer-wants-to-secure-api-resources-using-user-roles/src/test/resources/swaggerFiles/APIScopeTest1.json
@@ -1,0 +1,62 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "APIScopeTestAPI",
+    "version": "1.0.0"
+  },
+  "basePath": "/contextJsonV2",
+  "paths": {
+    "/*": {
+      "put": {
+        "responses": {
+          "200": {}
+        },
+        "x-auth-type": "Application User",
+        "x-throttling-tier": "Unlimited",
+        "x-scope": "item_view"
+      },
+      "post": {
+        "responses": {
+          "200": {}
+        },
+        "x-auth-type": "Application User",
+        "x-throttling-tier": "Unlimited",
+        "x-scope": ""
+      },
+      "get": {
+        "responses": {
+          "200": {}
+        },
+        "x-auth-type": "Application User",
+        "x-throttling-tier": "Unlimited",
+        "x-scope": ""
+      },
+      "delete": {
+        "responses": {
+          "200": {}
+        },
+        "x-auth-type": "Application User",
+        "x-throttling-tier": "Unlimited"
+      },
+      "options": {
+        "responses": {
+          "200": {}
+        },
+        "x-auth-type": "None",
+        "x-throttling-tier": "Unlimited"
+      }
+    }
+  },
+  "x-wso2-security": {
+    "apim": {
+      "x-wso2-scopes": [
+        {
+          "name": "item_view",
+          "description": "",
+          "key": "item_view",
+          "roles": "managerRole"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Signed-off-by: nimanthag <nimanthag@wso2.com>

## Purpose
> Improve code coverage.
## Goals
> Add scenario to test for untested areas.

## Approach
> API  developers should not be able to create scopes with duplicate keys.

Developer Create an API and assign a scope with key "key1" to a resource.
Developer tries to create another scope with key "key1". It should not be allowed.
## User stories

## Developer testing record
<img width="1680" alt="screen shot 2019-02-01 at 9 22 36 am" src="https://user-images.githubusercontent.com/42195796/52101869-8e8eee80-2603-11e9-8420-0d4fae63eb2a.png">
