### PR TITLE
Fix incorrectly named module

### DIFF
--- a/product-scenarios/2-collaborative-api-development/pom.xml
+++ b/product-scenarios/2-collaborative-api-development/pom.xml
@@ -37,7 +37,7 @@
 
     <modules>
         <module>2.1-manage-publisher-portal-operations-for-users</module>
-        <module>2.2-manage-visibility-of-APIs-in-Publisher-portal</module>
+        <module>2.2-manage-visibility-of-apis-in-publisher-portal</module>
     </modules>
 
     <repositories>


### PR DESCRIPTION
## Purpose
Usecase 2.2 was renamed recently and module reference was not renamed mistakenly.
This PR will fix it.