### PR TITLE
Disable failing test case

### DIFF
--- a/product-scenarios/1-manage-public-partner-private-apis/1.1-expose-service-as-rest-api/1.1.2-create-rest-api-by-import-oas-document/src/test/java/org/wso2/am/scenario/tests/rest/api/creation/RESTApiCreationUsingOASDocTestCase.java
+++ b/product-scenarios/1-manage-public-partner-private-apis/1.1-expose-service-as-rest-api/1.1.2-create-rest-api-by-import-oas-document/src/test/java/org/wso2/am/scenario/tests/rest/api/creation/RESTApiCreationUsingOASDocTestCase.java
@@ -272,7 +272,7 @@ public class RESTApiCreationUsingOASDocTestCase extends ScenarioTestBase {
     }
 
     //TODO: Commented due to the SSL certification issue for read from url still occurs
-    @Test(description = "1.1.2.2", dataProvider = "OASDocsWithJsonURL", dataProviderClass = ScenarioDataProvider.class)
+    @Test(description = "1.1.2.2", dataProvider = "OASDocsWithJsonURL", dataProviderClass = ScenarioDataProvider.class, enabled = false)
     public void testCreateApiUsingValidOASDocumentFromJsonURL(String url) throws Exception {
 
         swagger_url = url;


### PR DESCRIPTION
## Purpose
RESTApiCreationUsingOASDocTestCase.testCreateApiUsingValidOASDocumentFromJsonURL is failling. Disabling it for the moment