### PR TITLE
Add code coverage report generating implementation

### DIFF
--- a/product-scenarios/code-coverage/code-coverage.sh
+++ b/product-scenarios/code-coverage/code-coverage.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+
+# Copyright (c) 2018, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#=== FUNCTION ==================================================================
+# NAME: generate_code_coverage
+# DESCRIPTION: Genaret code coverage reports.
+# PARAMETER 1: Path to input directory
+# PARAMETER 2: Path to output directory
+#===============================================================================
+
+#set -o xtrace
+
+FILE=""
+VAR_TEST_PLAN_ID=""
+VAR_IS_TESTGRID=""
+VAR_TINKERER_ENDPOINT=""
+VAR_TINKERER_USERNAME=""
+VAR_TINKERER_PASSWORD=""
+VAR_REM_DIR=""
+
+function generate_code_coverage(){
+    INPUT_DIR=$1
+    OUTPUT_DIR=$2
+    HOME=`pwd`
+
+    FILE="${INPUT_DIR}/deployment.properties"
+    PROP_TEST_PLAN_ID=TEST_PLAN_ID
+    PROP_TESTGRID=IS_TESTGRID
+    PROP_TINKERE_ENDPOINT=TESTGRID_TINKERER_ENDPOINT
+    PROP_SERVER_DIR=RemoteProductDir
+    PROP_TINKERER_USERNAME=TESTGRID_TINKERER_USERNAME
+    PROP_TINKERER_PASSWORD=TESTGRID_TINKERER_PASSWORD
+    user=ubuntu
+
+    #=============== Read Deployment.property file ===============================================
+
+    VAR_TEST_PLAN_ID=`cat ${FILE} | grep -w "$PROP_TEST_PLAN_ID" ${FILE} | cut -d'=' -f2`
+    VAR_IS_TESTGRID=`cat ${FILE} | grep -w "$PROP_TESTGRID" ${FILE} | cut -d'=' -f2`
+    VAR_TINKERER_ENDPOINT=$(echo "$(grep -w "$PROP_TINKERE_ENDPOINT" ${FILE} | cut -d'=' -f2)" | sed 's/\\//g')
+    VAR_TINKERER_USERNAME=`grep -w "$PROP_TINKERER_USERNAME" ${FILE} | cut -d'=' -f2`
+    VAR_TINKERER_PASSWORD=`grep -w "$PROP_TINKERER_PASSWORD" ${FILE} | cut -d'=' -f2`
+    VAR_REM_DIR=`grep -w "$PROP_SERVER_DIR" ${FILE} | cut -d'=' -f2`
+
+    #=============== Code Coverage Report Generation ===========================================
+
+    #Copy files to the client side through tinkerer
+    if [ "$VAR_IS_TESTGRID" = True ] || [ "$VAR_IS_TESTGRID" = true ]; then
+
+        #Get IP address
+        echo "Get the IP address of client"
+        ipaddress=$(echo `curl http://169.254.169.254/latest/meta-data/public-ipv4`)
+
+        #Get Active Agents for the defined test plan
+        mkdir -p "${HOME}"/code-coverage/resources
+        echo $(curl -X GET "${VAR_TINKERER_ENDPOINT}"/api/test-plan/"${VAR_TEST_PLAN_ID}"/agents \
+        -u "${VAR_TINKERER_USERNAME}":"${VAR_TINKERER_PASSWORD}") > "${HOME}"/code-coverage/resources/agentsList.json
+
+        python -m json.tool "${HOME}"/code-coverage/resources/agentsList.json | \
+        awk -F'"' '/instanceName/{print $4}' > "${HOME}"/code-coverage/resources/agent_name_list.txt
+
+        i=0
+        while read line
+        do
+            agent_name[$i]="$line"
+
+            #Stop the wso2server.sh
+            echo "Stop the server in node ${agent_name[i]}"
+
+            echo $(tinkerer_curl_commands ${agent_name[i]} "$VAR_REM_DIR/bin/wso2server.sh\tstop")
+
+            sleep 30
+
+            #Zip the jacoco folder
+            echo "Zip the jacoco folder in node ${agent_name[i]}"
+
+            echo $(tinkerer_curl_commands ${agent_name[i]} "cd\t$VAR_REM_DIR/repository/logs/jacoco;\tzip\t-r\tjacoco.zip\t.")
+
+            #Generate key
+            echo "Generate a key in node ${agent_name[i]}"
+
+            echo $(tinkerer_curl_commands ${agent_name[i]} "mkdir\t-p\t$VAR_REM_DIR/../keys")
+            echo $(tinkerer_curl_commands ${agent_name[i]} "ssh-keygen\t-b\t2048\t-t\trsa\t-f\t$VAR_REM_DIR/../keys/deploy.key\t-q\t-N\t''")
+
+            #Add key to authorized_keys
+            echo "Add key of node ${agent_name[i]} to the authorized_keys in client side"
+
+            echo `tinkerer_curl_commands ${agent_name[i]} "cat\t$VAR_REM_DIR/../keys/deploy.key.pub"` | \
+            sed -nE 's/.*"response":"(.*)","completed.*/\1/p' >> /home/ubuntu/.ssh/authorized_keys
+
+            #Copy file to client side
+            echo "Copy file to the client side from ${agent_name[i]}"
+            mkdir -p ${HOME}/code-coverage/resources/instance$((i+1))
+
+            #Give permission to .key file
+            tinkerer_curl_commands ${agent_name[i]} "sudo\tchmod\t400\t$VAR_REM_DIR/../keys/deploy.key"
+
+            echo $(tinkerer_curl_commands ${agent_name[i]} \
+            "scp\t-o\tStrictHostKeyChecking=no\t-i\t$VAR_REM_DIR/../keys/deploy.key\t$VAR_REM_DIR/repository/logs/jacoco/jacoco.zip\t$user@$ipaddress:$HOME/code-coverage/resources/instance$((i+1))")
+            sleep 30
+
+            echo "Extract the copied coverage artifact file of ${agent_name[i]}"
+            unzip ${HOME}/code-coverage/resources/instance$((i+1))/jacoco.zip \
+            -d ${HOME}/code-coverage/resources/instance$((i+1))/jacoco
+
+            sleep 40
+
+            i=$((i+1))
+
+        done < "${HOME}"/code-coverage/resources/agent_name_list.txt
+
+        #Execute code-coverage POM and generate coverage reports
+        echo "Generate coverage reports from coverage artifacts"
+        mvn clean install -f ${HOME}/code-coverage/pom.xml
+
+        #Copy Code Coverage Reports
+        echo "Copy code coverage reports to the output directory"
+        cp -r ${HOME}/code-coverage/target/scenario-code-coverage ${OUTPUT_DIR}
+
+    fi
+}
+
+#=== FUNCTION ==================================================================
+# NAME: testgrid tinkerer curl commands
+# DESCRIPTION: Curl command to perform shell commands on server side through testgrid tinkerer
+# PARAMETER 1: agent_name
+# PARAMETER 2: shell_command which need to execute on server sides
+#===============================================================================
+function tinkerer_curl_commands(){
+
+    agent_name=$1
+    shell_command=$2
+
+    curl -X POST "${VAR_TINKERER_ENDPOINT}"/api/test-plan/"${VAR_TEST_PLAN_ID}"/agent/"${agent_name}"/operation \
+           -H 'content-type: application/json' \
+           -d '{"code":"SHELL", "request":"'$shell_command'"}' \
+           -u "${VAR_TINKERER_USERNAME}":"${VAR_TINKERER_PASSWORD}"
+
+     sleep 30
+}

--- a/product-scenarios/code-coverage/code-coverage.sh
+++ b/product-scenarios/code-coverage/code-coverage.sh
@@ -129,6 +129,12 @@ function generate_code_coverage(){
         echo "Copy code coverage reports to the output directory"
         cp -r ${HOME}/code-coverage/target/scenario-code-coverage ${OUTPUT_DIR}
 
+        #Copy Code Coverage Artifacts to the output directory
+        echo "Copy code coverage artifacts to the output directory"
+        mkdir ${HOME}/code-coverage/resources/code-coverage-artifacts
+        cp -r ${HOME}/code-coverage/resources/instance* ${HOME}/code-coverage/resources/code-coverage-artifacts
+        cp -r ${HOME}/code-coverage/resources/code-coverage-artifacts ${OUTPUT_DIR}
+
     fi
 }
 

--- a/product-scenarios/code-coverage/code-coverage.sh
+++ b/product-scenarios/code-coverage/code-coverage.sh
@@ -37,7 +37,6 @@ function generate_code_coverage(){
 
     #=============== Read Deployment.property file ===============================================
 
-    source ${HOME}/test.sh
     VAR_TEST_PLAN_ID=$(get_prop 'TEST_PLAN_ID')
     VAR_IS_TESTGRID=$(get_prop 'IS_TESTGRID')
     VAR_TINKERER_ENDPOINT=$(echo $(get_prop 'TESTGRID_TINKERER_ENDPOINT') | sed 's/\\//g')
@@ -142,9 +141,19 @@ function tinkerer_curl_commands(){
     shell_command=$2
 
     curl -X POST "${VAR_TINKERER_ENDPOINT}"/api/test-plan/"${VAR_TEST_PLAN_ID}"/agent/"${agent_name}"/operation \
-           -H 'content-type: application/json' \
-           -d '{"code":"SHELL", "request":"'$shell_command'"}' \
+           -H "content-type: application/json" \
+           -d "{\"code\":\"SHELL\", \"request\":\"$shell_command\"}" \
            -u "${VAR_TINKERER_USERNAME}":"${VAR_TINKERER_PASSWORD}"
 
      sleep 30
+}
+
+#=== FUNCTION ==================================================================
+# NAME: get_prop
+# DESCRIPTION: Retrieve specific property from deployment.properties file
+# PARAMETER 1: property_value
+#===============================================================================
+function get_prop {
+    local prop=$(grep -w "${1}" "${INPUT_DIR}/deployment.properties" | cut -d'=' -f2)
+    echo $prop
 }

--- a/product-scenarios/code-coverage/code-coverage.sh
+++ b/product-scenarios/code-coverage/code-coverage.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2018, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+# Copyright (c) 2019, WSO2 Inc. (http://wso2.com) All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@
 
 #set -o xtrace
 
-FILE=""
 VAR_TEST_PLAN_ID=""
 VAR_IS_TESTGRID=""
 VAR_TINKERER_ENDPOINT=""
@@ -36,23 +35,16 @@ function generate_code_coverage(){
     OUTPUT_DIR=$2
     HOME=`pwd`
 
-    FILE="${INPUT_DIR}/deployment.properties"
-    PROP_TEST_PLAN_ID=TEST_PLAN_ID
-    PROP_TESTGRID=IS_TESTGRID
-    PROP_TINKERE_ENDPOINT=TESTGRID_TINKERER_ENDPOINT
-    PROP_SERVER_DIR=RemoteProductDir
-    PROP_TINKERER_USERNAME=TESTGRID_TINKERER_USERNAME
-    PROP_TINKERER_PASSWORD=TESTGRID_TINKERER_PASSWORD
-    user=ubuntu
-
     #=============== Read Deployment.property file ===============================================
 
-    VAR_TEST_PLAN_ID=`cat ${FILE} | grep -w "$PROP_TEST_PLAN_ID" ${FILE} | cut -d'=' -f2`
-    VAR_IS_TESTGRID=`cat ${FILE} | grep -w "$PROP_TESTGRID" ${FILE} | cut -d'=' -f2`
-    VAR_TINKERER_ENDPOINT=$(echo "$(grep -w "$PROP_TINKERE_ENDPOINT" ${FILE} | cut -d'=' -f2)" | sed 's/\\//g')
-    VAR_TINKERER_USERNAME=`grep -w "$PROP_TINKERER_USERNAME" ${FILE} | cut -d'=' -f2`
-    VAR_TINKERER_PASSWORD=`grep -w "$PROP_TINKERER_PASSWORD" ${FILE} | cut -d'=' -f2`
-    VAR_REM_DIR=`grep -w "$PROP_SERVER_DIR" ${FILE} | cut -d'=' -f2`
+    source ${HOME}/test.sh
+    VAR_TEST_PLAN_ID=$(get_prop 'TEST_PLAN_ID')
+    VAR_IS_TESTGRID=$(get_prop 'IS_TESTGRID')
+    VAR_TINKERER_ENDPOINT=$(echo $(get_prop 'TESTGRID_TINKERER_ENDPOINT') | sed 's/\\//g')
+    VAR_TINKERER_USERNAME=$(get_prop 'TESTGRID_TINKERER_USERNAME')
+    VAR_TINKERER_PASSWORD=$(get_prop 'TESTGRID_TINKERER_PASSWORD')
+    VAR_REM_DIR=$(get_prop 'RemoteProductDir')
+    user=ubuntu
 
     #=============== Code Coverage Report Generation ===========================================
 

--- a/product-scenarios/code-coverage/pom.xml
+++ b/product-scenarios/code-coverage/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
-  ~ Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~ Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/product-scenarios/code-coverage/pom.xml
+++ b/product-scenarios/code-coverage/pom.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+  ~ Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <artifactId>product-scenarios</artifactId>
+        <groupId>org.wso2.am</groupId>
+        <version>2.6.0</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <version>2.6.0</version>
+    <name>WSO2 API Manager - Code Coverage POM</name>
+    <artifactId>code-coverage</artifactId>
+    <packaging>pom</packaging>
+    <url>http://wso2.org</url>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.ant</artifactId>
+            <version>${jacoco.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <id>with-tests</id>
+            <activation>
+                <property>
+                    <name>!maven.test.skip</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>copy-jacoco-dependencies</id>
+                                <phase>compile</phase>
+                                <goals>
+                                    <goal>copy-dependencies</goal>
+                                </goals>
+                                <configuration>
+                                    <outputDirectory>${project.build.directory}</outputDirectory>
+                                    <includeTypes>jar</includeTypes>
+                                    <includeArtifactIds>org.jacoco.ant</includeArtifactIds>
+                                    <stripVersion>true</stripVersion>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <!-- Ant plugin - Merge Jacoco Reports -->
+                    <!-- Logging and distribution modules are not checked since not relevant -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target xmlns:jacoco="antlib:org.jacoco.ant">
+                                        <taskdef uri="antlib:org.jacoco.ant" resource="org/jacoco/ant/antlib.xml">
+                                            <classpath path="${project.build.directory}" />
+                                        </taskdef>
+                                        <jacoco:report>
+                                            <executiondata>
+                                                <fileset dir="../..">
+                                                    <include name="**/code-coverage/*/instance1/*/jacoco.exec" />
+                                                </fileset>
+                                                <fileset dir="../..">
+                                                    <include name="**/code-coverage/*/instance2/*/jacoco.exec" />
+                                                </fileset>
+                                            </executiondata>
+                                            <structure name="Scenario Coverage Report">
+                                                <classfiles>
+                                                    <fileset dir="../..">
+                                                        <include name="**/code-coverage/*/instance1/*/classes/**" />
+                                                    </fileset>
+                                                    <fileset dir="../..">
+                                                        <include name="**/code-coverage/*/instance2/*/classes/**" />
+                                                    </fileset>
+                                                </classfiles>
+                                            </structure>
+                                            <html destdir="${project.build.directory}/scenario-code-coverage/jacoco" />
+                                            <xml destfile="${project.build.directory}/scenario-code-coverage/jacoco/coverage-report.xml"/>
+                                            <csv destfile="${project.build.directory}/scenario-code-coverage/jacoco/coverage-report.csv"/>
+                                        </jacoco:report>
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.jacoco</groupId>
+                                <artifactId>org.jacoco.ant</artifactId>
+                                <version>${jacoco.version}</version>
+                            </dependency>
+                        </dependencies>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+    <properties>
+        <jacoco.version>0.7.9</jacoco.version>
+    </properties>
+</project>

--- a/product-scenarios/test.sh
+++ b/product-scenarios/test.sh
@@ -92,3 +92,9 @@ echo "Copying surefire-reports to ${OUTPUT_DIR}"
 mkdir -p ${OUTPUT_DIR}
 find . -name "surefire-reports" -exec cp --parents -r {} ${OUTPUT_DIR} \;
 find . -name "aggregate-surefire-report" -exec cp --parents -r {} ${OUTPUT_DIR} \;
+
+#=============== Code Coverage Report Generation ===========================================
+
+echo "Generating Scenario Code Coverage Reports"
+source ${HOME}/code-coverage/code-coverage.sh
+generate_code_coverage ${INPUT_DIR} ${OUTPUT_DIR}

--- a/product-scenarios/test.sh
+++ b/product-scenarios/test.sh
@@ -114,4 +114,4 @@ find . -name "aggregate-surefire-report" -exec cp --parents -r {} ${OUTPUT_DIR} 
 
 echo "Generating Scenario Code Coverage Reports"
 source ${HOME}/code-coverage/code-coverage.sh
-generate_code_coverage ${INPUT_DIR} ${OUTPUT_DIR}
+generate_code_coverage ${INPUT_DIR} ${OUTPUT_DIR}/scenarios

--- a/product-scenarios/test.sh
+++ b/product-scenarios/test.sh
@@ -81,6 +81,12 @@ echo "output directory : ${OUTPUT_DIR}"
 
 export DATA_BUCKET_LOCATION=${INPUT_DIR}
 
+# Retrieve specific property from deployment.properties file
+function get_prop {
+    local prop=$(grep -w "${1}" "${INPUT_DIR}/deployment.properties" | cut -d'=' -f2)
+    echo $prop
+}
+
 #=============== Execute Scenarios ===============================================
 mvn clean install -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
 -fae -B -f pom.xml

--- a/product-scenarios/test.sh
+++ b/product-scenarios/test.sh
@@ -114,4 +114,4 @@ find . -name "aggregate-surefire-report" -exec cp --parents -r {} ${OUTPUT_DIR} 
 
 echo "Generating Scenario Code Coverage Reports"
 source ${HOME}/code-coverage/code-coverage.sh
-generate_code_coverage ${INPUT_DIR} ${OUTPUT_DIR}/scenarios
+generate_code_coverage ${INPUT_DIR} ${OUTPUT_DIR}


### PR DESCRIPTION
## Purpose
> Generate jacoco code coverage reports for apim scenario tests.

## Goals
> Get the code coverage results from scenario test execution

## Approach
> Add a separate directory with code-coverage.sh file and pom.xml file. 
code-coverage.sh file defines the steps needed to copy coverage artifacts from server side to client side. As the deployment cannot be accessed by the test slave, testgrid tinkerer is used to copy coverage artifacts from server side. Code coverage reports will be generated only of the tests executes via testgrid. Because the tinkerer is testgrid specific mechanism.

> Normally test executes in two-node-deployment. In that case the we combine the coverage artifacts from both the nodes and generate a single code coverage report via jacoco maven plugin.

## Automation tests
 - Scenario tests 
   > Code coverage information