### PR TITLE
Add fixed to ContentSearchTestCase

### DIFF
--- a/modules/distribution/product/src/main/conf/registry.xml
+++ b/modules/distribution/product/src/main/conf/registry.xml
@@ -235,8 +235,8 @@
             <!--indexer class="org.wso2.carbon.governance.registry.extensions.indexers.RXTIndexer" mediaTypeRegEx="application/wsdl\+xml" profiles ="default,api-store,api-publisher"/>
             <indexer class="org.wso2.carbon.governance.registry.extensions.indexers.RXTIndexer" mediaTypeRegEx="application/x-xsd\+xml " profiles ="default,api-store,api-publisher"/>
             <indexer class="org.wso2.carbon.governance.registry.extensions.indexers.RXTIndexer" mediaTypeRegEx="application/policy\+xml" profiles ="default,api-store,api-publisher"/-->
-            <indexer class="org.wso2.carbon.apimgt.impl.indexing.indexer.CustomAPIIndexer" mediaTypeRegEx="application/vnd.(.)+\+xml" profiles ="default,api-store,api-publisher"/>
             <indexer class="org.wso2.carbon.apimgt.impl.indexing.indexer.DocumentIndexer" mediaTypeRegEx="application/vnd.wso2-document\+xml" profiles ="default,api-store,api-publisher"/>
+            <indexer class="org.wso2.carbon.apimgt.impl.indexing.indexer.CustomAPIIndexer" mediaTypeRegEx="application/vnd.(.)+\+xml" profiles ="default,api-store,api-publisher"/>
             <!--indexer class="org.wso2.carbon.registry.indexing.indexer.XMLIndexer" mediaTypeRegEx="application/(.)+\+xml"/>
             <indexer class="org.wso2.carbon.registry.indexing.indexer.PlainTextIndexer" mediaTypeRegEx="text/(.)+"/>
             <indexer class="org.wso2.carbon.registry.indexing.indexer.PlainTextIndexer" mediaTypeRegEx="application/x-javascript"/-->

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/restapi/ContentSearchTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/restapi/ContentSearchTestCase.java
@@ -82,7 +82,7 @@ public class ContentSearchTestCase extends APIMIntegrationBaseTest {
             throws Exception {
         log.info("Basic Content Search");
         String contentSearchTestAPI = "contentSearchTestAPI";
-        String description = "UnifiedSearchFeature";
+        String description = "Unified Search Feature";
         APIRequest apiRequest = createAPIRequest(contentSearchTestAPI, contentSearchTestAPI, endpointURL, version,
                 user.getUserName(), description);
         apiPublisher.login(user.getUserName(), user.getPassword());

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/restapi/ContentSearchTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/restapi/ContentSearchTestCase.java
@@ -95,7 +95,7 @@ public class ContentSearchTestCase extends APIMIntegrationBaseTest {
         //check in publisher
         for (int i = 0; i <= retries; i++) {
             HttpGet getPublisherAPIs = new HttpGet(
-                    getStoreURLHttps() + publisherRestAPIBasePath + "results?query=" + description);
+                    getStoreURLHttps() + publisherRestAPIBasePath + "search?query=" + description);
             getPublisherAPIs.setHeader("Authorization", "Bearer " + accessToken);
             HttpResponse publisherResponse = client.execute(getPublisherAPIs);
             if (getResultCount(publisherResponse) == 1) {
@@ -112,7 +112,7 @@ public class ContentSearchTestCase extends APIMIntegrationBaseTest {
         }
 
         for (int i = 0; i <= retries; i++) {
-            HttpGet getStoreAPIs = new HttpGet(getStoreURLHttps() + storeRestAPIBasePath + "results?query=" + description);
+            HttpGet getStoreAPIs = new HttpGet(getStoreURLHttps() + storeRestAPIBasePath + "search?query=" + description);
             if (TestUserMode.TENANT_ADMIN == userMode) {
                 getStoreAPIs.setHeader("X-WSO2-Tenant", user.getUserDomain());
             }
@@ -138,7 +138,7 @@ public class ContentSearchTestCase extends APIMIntegrationBaseTest {
                 APILifeCycleState.CREATED);
         apiPublisher.changeAPILifeCycleStatus(updateRequest);
         for (int i = 0; i <= retries; i++) {
-            HttpGet getStoreAPIs = new HttpGet(getStoreURLHttps() + storeRestAPIBasePath + "results?query=" + description);
+            HttpGet getStoreAPIs = new HttpGet(getStoreURLHttps() + storeRestAPIBasePath + "search?query=" + description);
             if (TestUserMode.TENANT_ADMIN == userMode) {
                 getStoreAPIs.setHeader("X-WSO2-Tenant", user.getUserDomain());
             }
@@ -188,7 +188,7 @@ public class ContentSearchTestCase extends APIMIntegrationBaseTest {
         //check in publisher
         for (int i = 0; i <= retries; i++) {
             HttpGet getPublisherAPIs = new HttpGet(
-                    getPublisherURLHttps() + publisherRestAPIBasePath + "results?query=github4156");
+                    getPublisherURLHttps() + publisherRestAPIBasePath + "search?query=github4156");
             getPublisherAPIs.setHeader("Authorization", "Bearer " + accessToken);
             HttpResponse publisherResponse = client.execute(getPublisherAPIs);
             if (getResultCount(publisherResponse) == 1) {
@@ -206,7 +206,7 @@ public class ContentSearchTestCase extends APIMIntegrationBaseTest {
 
         //check in store
         for (int i = 0; i <= retries; i++) {
-            HttpGet getStoreAPIs = new HttpGet(getStoreURLHttps() + storeRestAPIBasePath + "results?query=github4156");
+            HttpGet getStoreAPIs = new HttpGet(getStoreURLHttps() + storeRestAPIBasePath + "search?query=github4156");
             if (TestUserMode.TENANT_ADMIN == userMode) {
                 getStoreAPIs.setHeader("X-WSO2-Tenant", user.getUserDomain());
             }
@@ -266,7 +266,7 @@ public class ContentSearchTestCase extends APIMIntegrationBaseTest {
         //check with user1
         for (int i = 0; i <= retries; i++) {
             HttpGet getAPIsForUser1 = new HttpGet(
-                    getPublisherURLHttps() + publisherRestAPIBasePath + "results?query=" + description);
+                    getPublisherURLHttps() + publisherRestAPIBasePath + "search?query=" + description);
             if (TestUserMode.TENANT_ADMIN == userMode) {
                 user1 = user1 + "@" + user.getUserDomain();
             }
@@ -289,7 +289,7 @@ public class ContentSearchTestCase extends APIMIntegrationBaseTest {
         //check with user2 who doesn't have permissions for api
         for (int i = 0; i <= retries; i++) {
             HttpGet getAPIsForUser2 = new HttpGet(
-                    getPublisherURLHttps() + publisherRestAPIBasePath + "results?query=" + description);
+                    getPublisherURLHttps() + publisherRestAPIBasePath + "search?query=" + description);
             if (TestUserMode.TENANT_ADMIN == userMode) {
                 user2 = user2 + "@" + user.getUserDomain();
             }
@@ -353,7 +353,7 @@ public class ContentSearchTestCase extends APIMIntegrationBaseTest {
         //check with user1
         for (int i = 0; i <= retries; i++) {
             HttpGet getAPIsForUser1 = new HttpGet(
-                    getStoreURLHttps() + storeRestAPIBasePath + "results?query=" + description);
+                    getStoreURLHttps() + storeRestAPIBasePath + "search?query=" + description);
             if (TestUserMode.TENANT_ADMIN == userMode) {
                 getAPIsForUser1.setHeader("X-WSO2-Tenant", user.getUserDomain());
                 user1 = user1 + "@" + user.getUserDomain();
@@ -377,7 +377,7 @@ public class ContentSearchTestCase extends APIMIntegrationBaseTest {
         //check with user2 who doesn't have permissions for api
         for (int i = 0; i <= retries; i++) {
             HttpGet getAPIsForUser2 = new HttpGet(
-                    getStoreURLHttps() + storeRestAPIBasePath + "results?query=" + description);
+                    getStoreURLHttps() + storeRestAPIBasePath + "search?query=" + description);
             if (TestUserMode.TENANT_ADMIN == userMode) {
                 getAPIsForUser2.setHeader("X-WSO2-Tenant", user.getUserDomain());
                 user2 = user2 + "@" + user.getUserDomain();

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/restapi/ContentSearchTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/restapi/ContentSearchTestCase.java
@@ -52,6 +52,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.URLEncoder;
 import java.util.HashMap;
 
 public class ContentSearchTestCase extends APIMIntegrationBaseTest {
@@ -95,7 +96,8 @@ public class ContentSearchTestCase extends APIMIntegrationBaseTest {
         //check in publisher
         for (int i = 0; i <= retries; i++) {
             HttpGet getPublisherAPIs = new HttpGet(
-                    getStoreURLHttps() + publisherRestAPIBasePath + "search?query=" + description);
+                    getPublisherURLHttps() + publisherRestAPIBasePath + "search?query=" + URLEncoder
+                            .encode(description, "UTF-8"));
             getPublisherAPIs.setHeader("Authorization", "Bearer " + accessToken);
             HttpResponse publisherResponse = client.execute(getPublisherAPIs);
             if (getResultCount(publisherResponse) == 1) {
@@ -112,7 +114,8 @@ public class ContentSearchTestCase extends APIMIntegrationBaseTest {
         }
 
         for (int i = 0; i <= retries; i++) {
-            HttpGet getStoreAPIs = new HttpGet(getStoreURLHttps() + storeRestAPIBasePath + "search?query=" + description);
+            HttpGet getStoreAPIs = new HttpGet(getStoreURLHttps() + storeRestAPIBasePath + "search?query=" + URLEncoder
+                    .encode(description, "UTF-8"));
             if (TestUserMode.TENANT_ADMIN == userMode) {
                 getStoreAPIs.setHeader("X-WSO2-Tenant", user.getUserDomain());
             }
@@ -138,7 +141,8 @@ public class ContentSearchTestCase extends APIMIntegrationBaseTest {
                 APILifeCycleState.CREATED);
         apiPublisher.changeAPILifeCycleStatus(updateRequest);
         for (int i = 0; i <= retries; i++) {
-            HttpGet getStoreAPIs = new HttpGet(getStoreURLHttps() + storeRestAPIBasePath + "search?query=" + description);
+            HttpGet getStoreAPIs = new HttpGet(getStoreURLHttps() + storeRestAPIBasePath + "search?query=" + URLEncoder
+                    .encode(description, "UTF-8"));
             if (TestUserMode.TENANT_ADMIN == userMode) {
                 getStoreAPIs.setHeader("X-WSO2-Tenant", user.getUserDomain());
             }


### PR DESCRIPTION
## Purpose
This PR adds fixes to ContentSearchTest case.
1. /results api resource was renamed to /search and that change is added to testcase with this PR.

Adds a fix to Document Search.
1. This PR engages DocumentIndexer before CustomAPIIndexer to make sure DocumentIndexer gets triggered for all new document artifacts.
