### PR TITLE
Add endpoint certificate import/export capability to tool.

### DIFF
--- a/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/APIImportExportConstants.java
+++ b/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/APIImportExportConstants.java
@@ -94,4 +94,14 @@ public final class APIImportExportConstants {
     public static final String AUTHENTICATION_ADMIN_SERVICE_ENDPOINT = "AuthenticationAdmin";
 
     public static final String MIGRATION_MODE = "migrationMode";
+
+    public static final String META_INFO_DIRECTORY = "Meta-information";
+
+    public static final String ENDPOINTS_CERTIFICATE_FILE = "endpoint_certificates.json";
+
+    public static final String HOSTNAME_JSON_KEY = "hostName";
+
+    public static final String ALIAS_JSON_KEY = "alias";
+
+    public static final String CERTIFICATE_CONTENT_JSON_KEY = "certificate";
 }

--- a/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/CertificateDetail.java
+++ b/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/CertificateDetail.java
@@ -1,0 +1,52 @@
+/*
+ *
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ * /
+ */
+package org.wso2.carbon.apimgt.importexport;
+
+/**
+ * Class to hold certificate information detail hostname/alias/certificate which will write to a json file
+ *
+ */
+public class CertificateDetail {
+    private String hostName;
+    private String alias;
+    private String certificate;
+
+    public String getHostName() {
+        return hostName;
+    }
+
+    public void setHostName(String hostName) {
+        this.hostName = hostName;
+    }
+
+    public void setAlias(String alias) {
+        this.alias = alias;
+    }
+
+    public void setCertificate(String certificate) {
+        this.certificate = certificate;
+    }
+
+    public String getAlias() {
+        return alias;
+    }
+
+    public String getCertificate() {
+        return certificate;
+    }
+}


### PR DESCRIPTION
Signed-off-by: nimanthag <nimanthag@wso2.com>

## Purpose
> Resolve https://github.com/wso2/product-apim/issues/4205

## Goals
> Adding endpoint certificate import/export capability to the tool.

## Approach
> 1. Retrieve the API, get the prod/ sandbox endpoint definitions. 
2. Extract hostnames from prod/ sandbox endpoints.
3. Remove duplicate hostnames.
4. Extract certificate metadata and certificate content using the hostname and tenant id.
5. hostname, alias, 64bit encoded certificate content saved to a JSON file inside Meta-information.
6. Use the aforementioned file to import certificates when API importing.

> Summary of user stories addressed by this change>

**Developer test record**
<img width="1124" alt="screen shot 2019-02-13 at 4 34 43 pm" src="https://user-images.githubusercontent.com/42195796/52707516-e6d3d200-2fad-11e9-81c1-595333bf1020.png">
<img width="1220" alt="screen shot 2019-02-13 at 4 34 57 pm" src="https://user-images.githubusercontent.com/42195796/52707517-e76c6880-2fad-11e9-9fd8-3266a2092a51.png">
