### PR TITLE
Change test-results copying directory

### DIFF
--- a/product-scenarios/test.sh
+++ b/product-scenarios/test.sh
@@ -105,7 +105,7 @@ mvn clean install -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf
 
 #=============== Copy Surefire Reports ===========================================
 
-echo "Copying surefire-reports to ${OUTPUT_DIR}"
-mkdir -p ${OUTPUT_DIR}
-find . -name "surefire-reports" -exec cp --parents -r {} ${OUTPUT_DIR} \;
-find . -name "aggregate-surefire-report" -exec cp --parents -r {} ${OUTPUT_DIR} \;
+echo "Copying surefire-reports to ${OUTPUT_DIR}/scenarios"
+mkdir -p ${OUTPUT_DIR}/scenarios
+find . -name "surefire-reports" -exec cp --parents -r {} ${OUTPUT_DIR}/scenarios \;
+find . -name "aggregate-surefire-report" -exec cp --parents -r {} ${OUTPUT_DIR}/scenarios \;


### PR DESCRIPTION
## Purpose
Previously all the results have been copying to the ${OUTPUT_DIR}.
In order to distinguish scenario-test-results from other outputs (ex: aggregate coverage reports, etc.), a sub-directory `scenarios` is added to ${OUTPUT_DIR}.
So the scenario-test-results should be copied to `${OUTPUT_DIR}/scenarios`.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes