### PR TITLE
Throw an error if user try to import api with already existing context URL

### DIFF
--- a/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/APIImportExportConstants.java
+++ b/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/APIImportExportConstants.java
@@ -104,4 +104,8 @@ public final class APIImportExportConstants {
     public static final String ALIAS_JSON_KEY = "alias";
 
     public static final String CERTIFICATE_CONTENT_JSON_KEY = "certificate";
+
+    public static final String SEARCH_TYPE_CONTEXT = "Context";
+
+    public static final String SEARCH_TYPE_NAME = "Name";
 }

--- a/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/utils/APIImportUtil.java
+++ b/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/utils/APIImportUtil.java
@@ -247,7 +247,7 @@ public final class APIImportUtil {
             }
 
             //Checking whether this is a duplicate API
-            allMatchedApis = provider.searchAPIs(importedApi.getId().getApiName(), "Name", null);
+            allMatchedApis = provider.searchAPIs(importedApi.getId().getApiName(), APIImportExportConstants.SEARCH_TYPE_NAME, null);
             //if an API exist with the same name
             if (!allMatchedApis.isEmpty()) {
                 for (API matchAPI : allMatchedApis) {
@@ -259,6 +259,16 @@ public final class APIImportUtil {
                         throw new APIImportException(errorMessage);
                     }
                 }
+            }
+
+            //Checking context duplication
+            List<API> contextMatchedApis = provider.searchAPIs(importedApi.getContext(), APIImportExportConstants.SEARCH_TYPE_CONTEXT, null);
+            if (contextMatchedApis.size() > 0) {
+                String errMsg = "Error occurred while adding the API [" + importedApi.getId().getApiName()
+                        + '-' + importedApi.getId().getVersion() + "]. A duplicate context[" + importedApi.getContext()
+                        + "] already exists";
+                log.error(errMsg);
+                throw new APIImportException(errMsg);
             }
 
         } catch (IOException e) {


### PR DESCRIPTION

Signed-off-by: nimanthag <nimanthag@wso2.com>

## Purpose
> Resolves https://github.com/wso2/product-apim/issues/4331
## Goals
> Throw an error if user try to import api with already existing context URL

## Approach
> Before importing api, do a API search using context which specified in the api.json of the importing api. If the search returns an API abort the new import.

## Developer test record.
<img width="1200" alt="servererror" src="https://user-images.githubusercontent.com/42195796/52774567-82734a00-3063-11e9-8368-fea85daae674.png">
<img width="1225" alt="clienterror" src="https://user-images.githubusercontent.com/42195796/52774568-830be080-3063-11e9-9aec-5917cfdca336.png">
