### PR TITLE
Adding platform tests -3.1.1.5, 3.1.1.14

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/header/CustomHeaderTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/header/CustomHeaderTestCase.java
@@ -1,0 +1,137 @@
+/*
+ *Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *WSO2 Inc. licenses this file to you under the Apache License,
+ *Version 2.0 (the "License"); you may not use this file except
+ *in compliance with the License.
+ *You may obtain a copy of the License at
+ *
+ *http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *Unless required by applicable law or agreed to in writing,
+ *software distributed under the License is distributed on an
+ *"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *KIND, either express or implied.  See the License for the
+ *specific language governing permissions and limitations
+ *under the License.
+ */
+
+package org.wso2.am.integration.tests.header;
+
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+import org.wso2.am.integration.test.utils.base.APIMIntegrationConstants;
+import org.wso2.am.integration.test.utils.bean.APILifeCycleState;
+import org.wso2.am.integration.test.utils.bean.APILifeCycleStateRequest;
+import org.wso2.am.integration.test.utils.bean.APIRequest;
+import org.wso2.am.integration.test.utils.clients.APIPublisherRestClient;
+import org.wso2.am.integration.test.utils.clients.APIStoreRestClient;
+import org.wso2.am.integration.tests.api.lifecycle.APIManagerLifecycleBaseTest;
+import org.wso2.carbon.apimgt.api.model.APIIdentifier;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.carbon.automation.test.utils.http.client.HttpRequestUtil;
+import org.wso2.carbon.automation.test.utils.http.client.HttpResponse;
+import org.wso2.carbon.integration.common.utils.mgt.ServerConfigurationManager;
+
+import static org.testng.Assert.assertEquals;
+import static org.wso2.am.integration.tests.restapi.RESTAPITestConstants.APPLICATION_JSON_CONTENT;
+import static org.wso2.am.integration.tests.restapi.RESTAPITestConstants.AUTHORIZATION_KEY;
+
+import javax.ws.rs.core.Response;
+import java.io.File;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+
+public class CustomHeaderTestCase extends APIManagerLifecycleBaseTest {
+    private ServerConfigurationManager serverConfigurationManager;
+    private final String CUSTOM_AUTHORIZATION_HEADER = "Test-Custom-Header";
+    private final String API1_NAME = "CustomAuthHeaderTestAPI1";
+    private final String API1_CONTEXT = "customAuthHeaderTest1";
+    private final String API1_VERSION = "1.0.0";
+    String apiProviderName;
+    private final String APPLICATION1_NAME = "CustomHeaderTest-Application";
+    private final String API_END_POINT_METHOD = "customers/123";
+
+    private final String API2_NAME = "CustomAuthHeaderTestAPI2";
+    private final String API2_CONTEXT = "customAuthHeaderTest2";
+    private final String API2_VERSION = "1.0.0";
+    private String accessToken;
+
+    @Factory(dataProvider = "userModeDataProvider")
+    public CustomHeaderTestCase(TestUserMode userMode) {
+        this.userMode = userMode;
+    }
+
+    @DataProvider
+    public static Object[][] userModeDataProvider() {
+        return new Object[][]{
+                new Object[]{TestUserMode.SUPER_TENANT_ADMIN}
+        };
+    }
+
+    @BeforeClass(alwaysRun = true)
+    public void setEnvironment() throws Exception {
+        super.init(userMode);
+        serverConfigurationManager = new ServerConfigurationManager(gatewayContextWrk);
+        serverConfigurationManager.applyConfiguration(new File(
+                getAMResourceLocation() + File.separator + "configFiles" + File.separator + "customHeaderTest"
+                        + File.separator + "api-manager.xml"));
+        apiPublisher = new APIPublisherRestClient(getPublisherURLHttp());
+        apiStore = new APIStoreRestClient(getStoreURLHttp());
+        apiPublisher.login(user.getUserName(), user.getPassword());
+        apiStore.login(user.getUserName(), user.getPassword());
+        apiProviderName = publisherContext.getContextTenant().getContextUser().getUserName();
+        // Create application
+        apiStore.addApplication(APPLICATION1_NAME, APIMIntegrationConstants.APPLICATION_TIER.UNLIMITED, "",
+                "this-is-test");
+        //get access token
+        accessToken = generateApplicationKeys(apiStore, APPLICATION1_NAME).getAccessToken();
+    }
+
+    @Test(groups = {"wso2.am"}, description = "Set a customer Auth header for all APIs in the system. (Test ID: 3.1.1.5, 3.1.1.14)")
+    public void testSystemWideCustomAuthHeader() throws Exception {
+        APIIdentifier apiIdentifier1 = new APIIdentifier(user.getUserName(), API1_NAME, API1_VERSION);
+
+        String url = getGatewayURLHttp() + "jaxrs_basic/services/customers/customerservice";
+        APIRequest apiRequest = new APIRequest(API1_NAME, API1_CONTEXT, new URL(url), new URL(url));
+        apiRequest.setVersion(API1_VERSION);
+        apiRequest.setProvider(user.getUserName());
+        apiPublisher.addAPI(apiRequest);
+        APILifeCycleStateRequest updateRequest =
+                new APILifeCycleStateRequest(API1_NAME, apiProviderName, APILifeCycleState.PUBLISHED);
+        apiPublisher.changeAPILifeCycleStatus(updateRequest);
+        String invocationUrl = getAPIInvocationURLHttp(API1_CONTEXT, API1_VERSION) + "/" + API_END_POINT_METHOD;
+
+        waitForAPIDeploymentSync(user.getUserName(), API1_NAME, API1_VERSION, APIMIntegrationConstants.IS_API_EXISTS);
+        subscribeToAPI(apiIdentifier1, APPLICATION1_NAME, apiStore);
+
+        // Test whether a request made with a valid token using the relevant custom auth header should yield the proper
+        // response from the back-end, assuming the application has a valid subscription to the API. (Test ID: 3.1.1.5)
+        Map<String, String> requestHeaders1 = new HashMap<>();
+        requestHeaders1.put("accept", "application/json");
+        requestHeaders1.put(CUSTOM_AUTHORIZATION_HEADER, "Bearer " + accessToken);
+        HttpResponse apiResponse1 = HttpRequestUtil.doGet(invocationUrl, requestHeaders1);
+        assertEquals(apiResponse1.getResponseCode(), Response.Status.OK.getStatusCode(),
+                "Response code mismatched");
+
+        //Test whether the 401 Unauthorized Response will be returned when the default Auth header "Authorization"
+        //is used to invoke the API when the system wide custom Authorization header is configured (Test ID :3.1.1.14))
+        Map<String, String> requestHeaders2 = new HashMap<>();
+        requestHeaders2.put("accept", APPLICATION_JSON_CONTENT);
+        requestHeaders2.put(AUTHORIZATION_KEY, "Bearer " + accessToken);
+        HttpResponse apiResponse2 = HttpRequestUtil.doGet(invocationUrl, requestHeaders2);
+        assertEquals(apiResponse2.getResponseCode(), Response.Status.UNAUTHORIZED.getStatusCode(),
+                "Response code mismatched");
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void destroy() throws Exception {
+        apiPublisher.deleteAPI(API1_NAME, API1_VERSION, apiProviderName);
+        apiStore.removeApplication(APPLICATION1_NAME);
+        super.cleanUp();
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/customHeaderTest/api-manager.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/customHeaderTest/api-manager.xml
@@ -1,0 +1,672 @@
+<APIManager>
+    <!-- JNDI name of the data source to be used by the API publisher, API store and API
+         key manager. This data source should be defined in the master-datasources.xml file
+         in conf/datasources directory. -->
+    <DataSourceName>jdbc/WSO2AM_DB</DataSourceName>
+
+    <!-- This parameter is used when adding api management capability to other products like GReg, AS, DSS etc.-->
+    <GatewayType>Synapse</GatewayType>
+
+    <!-- This parameter is used to enable the securevault support when try to publish endpoint secured APIs. Values should be "true" or "false".
+    By default secure vault is disabled.-->
+    <EnableSecureVault>false</EnableSecureVault>
+
+    <!-- This parameter is used to enable mutual tls based authentication support for APIs, when this is disabled,
+    APIs will be protected with OAuth2 security-->
+    <EnableMTLSForAPIs>false</EnableMTLSForAPIs>
+
+    <!-- Authentication manager configuration for API publisher and API store. This is
+         a required configuration for both web applications as their user authentication
+         logic relies on this. -->
+    <AuthManager>
+        <!-- Server URL of the Authentication service -->
+        <ServerURL>https://localhost:${mgt.transport.https.port}${carbon.context}services/</ServerURL>
+        <!-- Admin username for the Authentication manager. -->
+        <Username>${admin.username}</Username>
+        <!-- Admin password for the Authentication manager. -->
+        <Password>${admin.password}</Password>
+        <!-- Indicates whether the permissions checking of the user (on the Publisher and Store) should be done
+           via a remote service. The check will be done on the local server when false. -->
+        <CheckPermissionsRemotely>false</CheckPermissionsRemotely>
+    </AuthManager>
+
+    <JWTConfiguration>
+        <!-- Enable/Disable JWT generation. Default is false. -->
+        <!-- EnableJWTGeneration>false</EnableJWTGeneration-->
+
+        <!-- Name of the security context header to be added to the validated requests. -->
+        <JWTHeader>X-JWT-Assertion</JWTHeader>
+
+        <!-- Fully qualified name of the class that will retrieve additional user claims
+             to be appended to the JWT. If not specified no claims will be appended.If user wants to add all user claims in the
+             jwt token, he needs to enable this parameter.
+             The DefaultClaimsRetriever class adds user claims from the default carbon user store. -->
+        <!--ClaimsRetrieverImplClass>org.wso2.carbon.apimgt.impl.token.DefaultClaimsRetriever</ClaimsRetrieverImplClass-->
+
+        <!-- The dialectURI under which the claimURIs that need to be appended to the
+             JWT are defined. Not used with custom ClaimsRetriever implementations. The
+             same value is used in the keys for appending the default properties to the
+             JWT. -->
+        <!--ConsumerDialectURI>http://wso2.org/claims</ConsumerDialectURI-->
+
+        <!-- Signature algorithm. Accepts "SHA256withRSA" or "NONE". To disable signing explicitly specify "NONE". -->
+        <!--SignatureAlgorithm>SHA256withRSA</SignatureAlgorithm-->
+
+        <!-- This parameter specifies which implementation should be used for generating the Token. JWTGenerator is the
+	     default implementation provided. -->
+        <JWTGeneratorImpl>org.wso2.carbon.apimgt.keymgt.token.JWTGenerator</JWTGeneratorImpl>
+
+        <!-- This parameter specifies which implementation should be used for generating the Token. For URL safe JWT
+             Token generation the implementation is provided in URLSafeJWTGenerator -->
+        <!--<JWTGeneratorImpl>org.wso2.carbon.apimgt.keymgt.token.URLSafeJWTGenerator</JWTGeneratorImpl>-->
+
+    </JWTConfiguration>
+
+    <!-- Primary/secondary login configuration for APIstore. If user likes to keep two login attributes in a distributed setup, to login the APIstore,
+		he should configure this section. Primary login doesn't have a claimUri associated with it. But secondary login, which is a claim attribute,
+		is associated with a claimuri.-->
+    <!--LoginConfig>
+            <UserIdLogin  primary="true">
+        <ClaimUri></ClaimUri>
+        </UserIdLogin>
+        <EmailLogin  primary="false">
+            <ClaimUri>http://wso2.org/claims/emailaddress</ClaimUri>
+        </EmailLogin>
+    </LoginConfig-->
+
+    <!-- Credentials for the API gateway admin server. This configuration
+         is mainly used by the API publisher and store to connect to the API gateway and
+         create/update published API configurations. -->
+    <APIGateway>
+        <!-- The environments to which an API will be published -->
+        <Environments>
+            <!-- Environments can be of different types. Allowed values are 'hybrid', 'production' and 'sandbox'.
+                 An API deployed on a 'production' type gateway will only support production keys
+                 An API deployed on a 'sandbox' type gateway will only support sandbox keys
+                 An API deployed on a 'hybrid' type gateway will support both production and sandbox keys. -->
+            <!-- api-console element specifies whether the environment should be listed in API Console or not -->
+            <Environment type="hybrid" api-console="true">
+                <Name>Production and Sandbox</Name>
+                <Description>This is a hybrid gateway that handles both production and sandbox token traffic.</Description>
+                <!-- Server URL of the API gateway -->
+                <ServerURL>https://localhost:${mgt.transport.https.port}${carbon.context}services/</ServerURL>
+		        <!-- Admin username for the API gateway. -->
+                <Username>${admin.username}</Username>
+                <!-- Admin password for the API gateway.-->
+                <Password>${admin.password}</Password>
+                <!-- Endpoint URLs for the APIs hosted in this API gateway.-->
+                <GatewayEndpoint>http://${carbon.local.ip}:${http.nio.port},https://${carbon.local.ip}:${https.nio.port}</GatewayEndpoint>
+                <!-- Endpoint of the Websocket APIs hosted in this API Gateway -->
+                <GatewayWSEndpoint>ws://${carbon.local.ip}:9099</GatewayWSEndpoint>
+            </Environment>
+        </Environments>
+    </APIGateway>
+
+    <CacheConfigurations>
+	    <!-- Enable/Disable token caching at the Gateway-->
+        <EnableGatewayTokenCache>true</EnableGatewayTokenCache>
+	    <!-- Enable/Disable API resource caching at the Gateway-->
+        <EnableGatewayResourceCache>true</EnableGatewayResourceCache>
+        <!-- Enable/Disable API key validation information caching at key-management server -->
+        <EnableKeyManagerTokenCache>false</EnableKeyManagerTokenCache>
+        <!-- This parameter specifies whether Recently Added APIs will be loaded from the cache or not.
+             If there are multiple API modification during a short time period, better to disable cache. -->
+        <EnableRecentlyAddedAPICache>false</EnableRecentlyAddedAPICache>
+        <!-- This parameter specifies whether scopes are taken from cache or not. If you are modifying application
+        subscriptions frequently, modifying the user roles frequently or updating the subscribed APIs frequently, it
+        is better to turn-off this cache-->
+        <EnableScopeCache>true</EnableScopeCache>
+        <!-- This indicates whether the role cache need to enabled in the publisher. If this is disabled, there will
+        be a call to key manager to all the calls to API publisher APIs. It is highly recommended to enable this
+        cache. However, if the system is in a state, where the role addition and deletion happens seamlessly, the
+        cache will be in in-valid state.-->
+        <EnablePublisherRoleCache>true</EnablePublisherRoleCache>
+	    <!-- JWT claims Cache expiry in seconds -->
+        <!--JWTClaimCacheExpiry>900</JWTClaimCacheExpiry-->
+        <!-- Expiry time for the apim key mgt validation info cache -->
+        <!--TokenCacheExpiry>900</TokenCacheExpiry-->
+        <!-- This parameter specifies the expiration time of the TagCache. TagCache will
+             only be created when this element is uncommented. When the specified
+             time duration gets elapsed ,tag cache will get re-generated. -->
+        <!--TagCacheDuration>120000</TagCacheDuration-->
+        <!-- JWT Claim cache can be disabled only if below config <EnableJWTClaimCache> is set as 'false'. The default
+          value is 'true'.
+          Other than this config, also <EnableGatewayTokenCache> and <EnableKeyManagerTokenCache> should have been set
+          as 'false' to completely disable JWTClaimCache.
+         -->
+        <EnableJWTClaimCache>true</EnableJWTClaimCache>
+    </CacheConfigurations>
+
+    <!--
+        API usage tracker configuration used by the StreamProcessor data publisher and
+        Google Analytics publisher in API gateway.
+    -->
+    <Analytics>
+        <!-- Enable Analytics for API Manager -->
+        <Enabled>false</Enabled>
+
+        <!-- Server URL of the remote StreamProcessor server used to collect statistics. Must
+             be specified in protocol://hostname:port/ format.
+
+             An event can also be published to multiple Receiver Groups each having 1 or more receivers. Receiver
+             Groups are delimited by curly braces whereas receivers are delimited by commas.
+             Ex - Multiple Receivers within a single group
+             tcp://localhost:7612/,tcp://localhost:7613/,tcp://localhost:7614/
+
+             Ex - Multiple Receiver Groups with two receivers each
+             {tcp://localhost:7612/,tcp://localhost:7613},{tcp://localhost:7712/,tcp://localhost:7713/} -->
+        <StreamProcessorServerURL>{tcp://localhost:7612}</StreamProcessorServerURL>
+        <!--StreamProcessorAuthServerURL>{ssl://localhost:7712}</StreamProcessorAuthServerURL-->
+        <!-- Administrator username to login to the remote StreamProcessor server. -->
+        <StreamProcessorUsername>${admin.username}</StreamProcessorUsername>
+        <!-- Administrator password to login to the remote StreamProcessor server. -->
+        <StreamProcessorPassword>${admin.password}</StreamProcessorPassword>
+
+        <!-- For APIM implemented Statistic client for RDBMS -->
+        <StatsProviderImpl>org.wso2.carbon.apimgt.usage.client.impl.APIUsageStatisticsRestClientImpl</StatsProviderImpl>
+
+        <!-- StreamProcessor REST API configuration -->
+        <StreamProcessorRestApiURL>https://localhost:7444</StreamProcessorRestApiURL>
+        <StreamProcessorRestApiUsername>${admin.username}</StreamProcessorRestApiUsername>
+        <StreamProcessorRestApiPassword>${admin.password}</StreamProcessorRestApiPassword>
+
+        <!-- Below property is used to skip trying to connect to event receiver nodes when publishing events even if
+            the stats enabled flag is set to true. -->
+        <SkipEventReceiverConnection>false</SkipEventReceiverConnection>
+
+        <!--Skip workflow data publisher initiation and even publishing-->
+        <SkipWorkflowEventPublisher>false</SkipWorkflowEventPublisher>
+
+        <!-- API Usage Data Publisher. -->
+        <PublisherClass>org.wso2.carbon.apimgt.usage.publisher.APIMgtUsageDataBridgeDataPublisher</PublisherClass>
+
+        <!-- If below property set to true,then the response message size will be calculated and publish
+             with each successful API invocation event. -->
+        <PublishResponseMessageSize>false</PublishResponseMessageSize>
+        <!-- Data publishing stream names and versions of API requests, responses and faults. If the default values
+            are changed, the toolbox also needs to be changed accordingly. -->
+        <Streams>
+            <Request>
+                <Name>org.wso2.apimgt.statistics.request</Name>
+                <Version>3.0.0</Version>
+            </Request>
+            <Fault>
+                <Name>org.wso2.apimgt.statistics.fault</Name>
+                <Version>3.0.0</Version>
+            </Fault>
+            <Throttle>
+                <Name>org.wso2.apimgt.statistics.throttle</Name>
+                <Version>3.0.0</Version>
+            </Throttle>
+            <Workflow>
+                <Name>org.wso2.apimgt.statistics.workflow</Name>
+                <Version>1.0.0</Version>
+            </Workflow>
+	        <AlertTypes>
+                <Name>org.wso2.analytics.apim.alertStakeholderInfo</Name>
+                <Version>1.0.1</Version>
+            </AlertTypes>
+        </Streams>
+
+    </Analytics>
+
+    <!--
+        API key validator configuration used by API key manager (IS), API store and API gateway.
+        API gateway uses it to validate and authenticate users against the provided API keys.
+    -->
+    <APIKeyValidator>
+        <!-- Server URL of the API key manager -->
+        <ServerURL>https://localhost:${mgt.transport.https.port}${carbon.context}services/</ServerURL>
+
+        <!-- Admin username for API key manager. -->
+        <Username>${admin.username}</Username>
+        <!-- Admin password for API key manager. -->
+        <Password>${admin.password}</Password>
+
+        <!-- Configurations related to enable thrift support for key-management related communication.
+             If you want to switch back to Web Service Client, change the value of "KeyValidatorClientType" to "WSClient".
+             In a distributed environment;
+             -If you are at the Gateway node, you need to point "ThriftClientPort" value to the "ThriftServerPort" value given at KeyManager node.
+             -If you need to start two API Manager instances in the same machine, you need to give different ports to "ThriftServerPort" value in two nodes.
+             -ThriftServerHost - Allows to configure a hostname for the thrift server. It uses the carbon hostname by default.
+	         -The Gateway uses this parameter to connect to the key validation thrift service. -->
+        <KeyValidatorClientType>ThriftClient</KeyValidatorClientType>
+        <ThriftClientConnectionTimeOut>10000</ThriftClientConnectionTimeOut>
+        <!--ThriftClientPort>10397</ThriftClientPort-->
+
+        <EnableThriftServer>true</EnableThriftServer>
+        <ThriftServerHost>localhost</ThriftServerHost>
+        <!--ThriftServerPort>10397</ThriftServerPort-->
+
+        <!--ConnectionPool>
+            <MaxIdle>100</MaxIdle>
+            <InitIdleCapacity>50</InitIdleCapacity>
+        </ConnectionPool-->
+        <!-- Specifies the implementation to be used for KeyValidationHandler. Steps for validating a token can be controlled by plugging in a 
+             custom KeyValidation Handler -->
+        <KeyValidationHandlerClassName>org.wso2.carbon.apimgt.keymgt.handlers.DefaultKeyValidationHandler</KeyValidationHandlerClassName>
+    </APIKeyValidator>
+
+    <!-- Uncomment this section only if you are going to have an instance other than KeyValidator as your KeyManager.
+         Unless a ThirdParty KeyManager is used, you don't need to configure this section. -->
+    <!--APIKeyManager>
+        <KeyManagerClientImpl>org.wso2.carbon.apimgt.impl.AMDefaultKeyManagerImpl</KeyManagerClientImpl>
+        <Configuration>
+            <ServerURL>https://localhost:${mgt.transport.https.port}${carbon.context}services/</ServerURL>
+            <Username>${admin.username}</Username>
+            <Password>${admin.password}</Password>
+            <TokenURL>https://${carbon.local.ip}:${https.nio.port}/token</TokenURL>
+            <RevokeURL>https://${carbon.local.ip}:${https.nio.port}/revoke</RevokeURL>
+        </Configuration>
+    </APIKeyManager-->
+
+    <OAuthConfigurations>
+        <!-- Remove OAuth headers from outgoing message. -->
+        <!--RemoveOAuthHeadersFromOutMessage>true</RemoveOAuthHeadersFromOutMessage-->
+        <!--Authorization header-->
+        <AuthorizationHeader>Test-Custom-Header</AuthorizationHeader>
+        <!-- Scope used for marking Application Tokens. If a token is generated with this scope, they will be treated as Application Access Tokens -->
+        <ApplicationTokenScope>am_application_scope</ApplicationTokenScope>
+        <!-- All  scopes under the ScopeWhitelist element are not validating against roles that has assigned to it.
+             By default ^device_.* and openid scopes have been white listed internally. -->
+        <!--ScopeWhitelist>
+            <Scope>^device_.*</Scope>
+            <Scope>openid</Scope>
+        </ScopeWhitelist-->
+        <!-- Name of the token API -->
+        <TokenEndPointName>/oauth2/token</TokenEndPointName>
+        <!-- This the API URL for revoke API. When we revoke tokens revoke requests should go through this
+             API deployed in API gateway. Then it will do cache invalidations related to revoked tokens.
+             In distributed deployment we should configure this property in key manager node by pointing
+             gateway https( /http, we recommend users to use 'https' endpoints for security purpose) url.
+             Also please note that we should point gateway revoke service to key manager -->
+        <RevokeAPIURL>https://localhost:${https.nio.port}/revoke</RevokeAPIURL>
+        <!-- Whether to encrypt tokens when storing in the Database
+        Note: If changing this value to true, change the value of <TokenPersistenceProcessor> to
+        org.wso2.carbon.identity.oauth.tokenprocessor.EncryptionDecryptionPersistenceProcessor in the identity.xml -->
+        <EncryptPersistedTokens>false</EncryptPersistedTokens>
+        <!-- Whether to hash the tokens when storing in the Database
+        Note: If changing this value to true, change the value of <TokenPersistenceProcessor> to
+        org.wso2.carbon.identity.oauth.tokenprocessor.HashingPersistenceProcessor and change the value of
+        <EnableClientSecretHash> to true in the identity.xml -->
+        <EnableTokenHashMode>false</EnableTokenHashMode>
+    </OAuthConfigurations>
+
+    <!-- Settings related to managing API access tiers. -->
+    <TierManagement>
+        <!-- Enable the providers to expose their APIs over the special 'Unlimited' tier which
+             basically disables tier based throttling for the specified APIs. -->
+        <EnableUnlimitedTier>true</EnableUnlimitedTier>
+    </TierManagement>
+
+    <!-- API Store Related Configurations -->
+    <APIStore>
+        <!--GroupingExtractor>org.wso2.carbon.apimgt.impl.DefaultGroupIDExtractorImpl</GroupingExtractor-->
+        <!--This property is used to indicate how we do user name comparision for token generation https://wso2.org/jira/browse/APIMANAGER-2225-->
+        <CompareCaseInsensitively>true</CompareCaseInsensitively>
+        <DisplayURL>false</DisplayURL>
+        <URL>https://localhost:${mgt.transport.https.port}/store</URL>
+
+        <!-- Server URL of the API Store. -->
+        <ServerURL>https://localhost:${mgt.transport.https.port}${carbon.context}services/</ServerURL>
+        <!-- Admin username for API Store. -->
+        <Username>${admin.username}</Username>
+
+        <!-- Admin password for API Store. -->
+        <Password>${admin.password}</Password>
+        <!-- This parameter specifies whether to display multiple versions of same
+             API or only showing the latest version of an API. -->
+        <DisplayMultipleVersions>false</DisplayMultipleVersions>
+        <!-- This parameter specifies whether to display all the APIs
+             [which are having DEPRECATED/PUBLISHED status] or only display the APIs
+             with having their status is as 'PUBLISHED' -->
+        <DisplayAllAPIs>false</DisplayAllAPIs>
+        <!-- Uncomment this to limit the number of APIs in api the API Store -->
+        <!--APIsPerPage>5</APIsPerPage-->
+
+        <!-- This parameter specifies whether to display the comment editing facility or not.
+             Default is "true". If user wants to disable, he must set this param as "false" -->
+        <DisplayComments>true</DisplayComments>
+
+        <!-- This parameter specifies whether to display the ratings  or not.
+             Default is "true". If user wants to disable, he must set this param as "false" -->
+        <DisplayRatings>true</DisplayRatings>
+
+        <!--set isStoreForumEnabled to false for disable forum in store-->
+        <!--isStoreForumEnabled>false</isStoreForumEnabled-->
+
+        <!--
+        This is an optional parameter. If this parameter has a value, it will be shown in the token generation
+        cURL command under subscriptions section in API Store.
+        -->
+        <!--StoreTokenDisplayURL>https://${carbon.local.ip}:${https.nio.port}</StoreTokenDisplayURL-->
+    </APIStore>
+
+    <APIPublisher>
+        <DisplayURL>false</DisplayURL>
+        <URL>https://localhost:${mgt.transport.https.port}/publisher</URL>
+        <!-- This parameter specifies enabling the capability of setting API documentation level granular visibility levels.
+             By default any document associate with an API will have the same permissions set as the API.With enabling below
+             property,it will show two additional permission levels as visible only to all registered users in a particular
+             domain or only visible to API doc creator -->
+        <!--EnableAPIDocVisibilityLevels>true</EnableAPIDocVisibilityLevels-->
+        <!-- Uncomment this to limit the number of APIs in api the API Publisher -->
+        <!--APIsPerPage>30</APIsPerPage-->
+        <!-- This property need to be enabled to enable the publisher access control support -->
+        <EnableAccessControl>true</EnableAccessControl>
+    </APIPublisher>
+
+    <!-- Status observers can be registered against the API Publisher to listen for
+         API status update events. Each observer must implement the APIStatusObserver
+         interface. Multiple observers can be engaged if necessary and in such situations
+         they will be notified in the order they are defined here. 
+         This configuration is unused from API Manager version 1.10.0 -->
+    <!--StatusObservers>
+        <Observer>org.wso2.carbon.apimgt.impl.observers.SimpleLoggingObserver</Observer>
+    </StatusObservers-->
+
+    <!-- Configuration to enable/disable sending CORS headers in the Gateway response
+         and define the Access-Control-Allow-Origin header value.-->
+    <CORSConfiguration>
+        <!-- Configuration to enable/disable sending CORS headers from the Gateway-->
+        <Enabled>true</Enabled>
+
+        <!-- The value of the Access-Control-Allow-Origin header. Default values are
+             API Store addresses, which is needed for swagger to function. -->
+        <Access-Control-Allow-Origin>*</Access-Control-Allow-Origin>
+
+        <!-- Configure Access-Control-Allow-Methods -->
+        <Access-Control-Allow-Methods>GET,PUT,POST,DELETE,PATCH,OPTIONS</Access-Control-Allow-Methods>
+
+        <!-- Configure Access-Control-Allow-Headers -->
+        <Access-Control-Allow-Headers>authorization,Access-Control-Allow-Origin,Content-Type,SOAPAction,Test-Custom-Header</Access-Control-Allow-Headers>
+
+        <!-- Configure Access-Control-Allow-Credentials -->
+        <!-- Specifying this header to true means that the server allows cookies (or other user credentials) to be included on cross-origin requests.
+             It is false by default and if you set it to true then make sure that the Access-Control-Allow-Origin header does not contain the wildcard (*) -->
+        <Access-Control-Allow-Credentials>false</Access-Control-Allow-Credentials>
+    </CORSConfiguration>
+    
+    <!-- This property is there to configure velocity log output into existing Log4j carbon Logger.
+         You can enable this and set preferable Logger name. -->
+    <!-- VelocityLogger>VELOCITY</VelocityLogger -->
+
+    <RESTAPI>
+        <!--Configure white-listed URIs of REST API. Accessing white-listed URIs does not require credentials (does not require Authorization header). -->
+        <WhiteListedURIs>
+            <WhiteListedURI>
+                <URI>/api/am/publisher/{version}/swagger.json</URI>
+                <HTTPMethods>GET,HEAD</HTTPMethods>
+            </WhiteListedURI>
+            <WhiteListedURI>
+                <URI>/api/am/store/{version}/swagger.json</URI>
+                <HTTPMethods>GET,HEAD</HTTPMethods>
+            </WhiteListedURI>
+            <WhiteListedURI>
+                <URI>/api/am/admin/{version}/swagger.json</URI>
+                <HTTPMethods>GET,HEAD</HTTPMethods>
+            </WhiteListedURI>
+            <WhiteListedURI>
+                <URI>/api/am/store/{version}/apis</URI>
+                <HTTPMethods>GET,HEAD</HTTPMethods>
+            </WhiteListedURI>
+            <WhiteListedURI>
+                <URI>/api/am/store/{version}/apis/{apiId}</URI>
+                <HTTPMethods>GET,HEAD</HTTPMethods>
+            </WhiteListedURI>
+            <WhiteListedURI>
+                <URI>/api/am/store/{version}/apis/{apiId}/swagger</URI>
+                <HTTPMethods>GET,HEAD</HTTPMethods>
+            </WhiteListedURI>
+            <WhiteListedURI>
+                <URI>/api/am/store/{version}/apis/{apiId}/documents</URI>
+                <HTTPMethods>GET,HEAD</HTTPMethods>
+            </WhiteListedURI>
+            <WhiteListedURI>
+                <URI>/api/am/store/{version}/apis/{apiId}/documents/{documentId}</URI>
+                <HTTPMethods>GET,HEAD</HTTPMethods>
+            </WhiteListedURI>
+            <WhiteListedURI>
+                <URI>/api/am/store/{version}/apis/{apiId}/documents/{documentId}/content</URI>
+                <HTTPMethods>GET,HEAD</HTTPMethods>
+            </WhiteListedURI>
+            <WhiteListedURI>
+                <URI>/api/am/store/{version}/apis/{apiId}/thumbnail</URI>
+                <HTTPMethods>GET,HEAD</HTTPMethods>
+            </WhiteListedURI>
+            <WhiteListedURI>
+                <URI>/api/am/store/{version}/tags</URI>
+                <HTTPMethods>GET,HEAD</HTTPMethods>
+            </WhiteListedURI>
+            <WhiteListedURI>
+                <URI>/api/am/store/{version}/tiers/{tierLevel}</URI>
+                <HTTPMethods>GET,HEAD</HTTPMethods>
+            </WhiteListedURI>
+            <WhiteListedURI>
+                <URI>/api/am/store/{version}/tiers/{tierLevel}/{tierName}</URI>
+                <HTTPMethods>GET,HEAD</HTTPMethods>
+            </WhiteListedURI>
+            <WhiteListedURI>
+                <URI>/api/am/store/{version}/search</URI>
+                <HTTPMethods>GET</HTTPMethods>
+            </WhiteListedURI>
+        </WhiteListedURIs>
+        <ETagSkipList>
+            <ETagSkipURI>
+                <URI>/api/am/store/{version}/apis</URI>
+                <HTTPMethods>GET</HTTPMethods>
+            </ETagSkipURI>
+            <ETagSkipURI>
+                <URI>/api/am/store/{version}/apis/generate-sdk</URI>
+                <HTTPMethods>POST</HTTPMethods>
+            </ETagSkipURI>
+            <ETagSkipURI>
+                <URI>/api/am/store/{version}/apis/{apiId}/documents</URI>
+                <HTTPMethods>GET</HTTPMethods>
+            </ETagSkipURI>
+            <ETagSkipURI>
+                <URI>/api/am/store/{version}/applications</URI>
+                <HTTPMethods>GET</HTTPMethods>
+            </ETagSkipURI>
+            <ETagSkipURI>
+                <URI>/api/am/store/{version}/applications/generate-keys</URI>
+                <HTTPMethods>POST</HTTPMethods>
+            </ETagSkipURI>
+            <ETagSkipURI>
+                <URI>/api/am/store/{version}/subscriptions</URI>
+                <HTTPMethods>GET,POST</HTTPMethods>
+            </ETagSkipURI>
+            <ETagSkipURI>
+                <URI>/api/am/store/{version}/tags</URI>
+                <HTTPMethods>GET</HTTPMethods>
+            </ETagSkipURI>
+            <ETagSkipURI>
+                <URI>/api/am/store/{version}/tiers/{tierLevel}</URI>
+                <HTTPMethods>GET</HTTPMethods>
+            </ETagSkipURI>
+            <ETagSkipURI>
+                <URI>/api/am/store/{version}/tiers/{tierLevel}/{tierName}</URI>
+                <HTTPMethods>GET</HTTPMethods>
+            </ETagSkipURI>
+            <ETagSkipURI>
+                <URI>/api/am/publisher/{version}/apis</URI>
+                <HTTPMethods>GET,POST</HTTPMethods>
+            </ETagSkipURI>
+            <ETagSkipURI>
+                <URI>/api/am/publisher/{version}/apis/{apiId}</URI>
+                <HTTPMethods>GET,DELETE,PUT</HTTPMethods>
+            </ETagSkipURI>
+            <ETagSkipURI>
+                <URI>/api/am/publisher/{version}/apis/{apiId}/swagger</URI>
+                <HTTPMethods>GET,PUT</HTTPMethods>
+            </ETagSkipURI>
+            <ETagSkipURI>
+                <URI>/api/am/publisher/{version}/apis/{apiId}/thumbnail</URI>
+                <HTTPMethods>GET,POST</HTTPMethods>
+            </ETagSkipURI>
+            <ETagSkipURI>
+                <URI>/api/am/publisher/{version}/apis/{apiId}/change-lifecycle</URI>
+                <HTTPMethods>POST</HTTPMethods>
+            </ETagSkipURI>
+            <ETagSkipURI>
+                <URI>/api/am/publisher/{version}/apis/{apiId}/copy-api</URI>
+                <HTTPMethods>POST</HTTPMethods>
+            </ETagSkipURI>
+            <ETagSkipURI>
+                <URI>/api/am/publisher/{version}/applications/{applicationId}</URI>
+                <HTTPMethods>GET</HTTPMethods>
+            </ETagSkipURI>
+            <ETagSkipURI>
+                <URI>/api/am/publisher/{version}/apis/{apiId}/documents</URI>
+                <HTTPMethods>GET,POST</HTTPMethods>
+            </ETagSkipURI>
+            <ETagSkipURI>
+                <URI>/api/am/publisher/{version}/apis/{apiId}/documents/{documentId}/content</URI>
+                <HTTPMethods>GET,POST</HTTPMethods>
+            </ETagSkipURI>
+            <ETagSkipURI>
+                <URI>/api/am/publisher/{version}/apis/{apiId}/documents/{documentId}</URI>
+                <HTTPMethods>GET,PUT,DELETE</HTTPMethods>
+            </ETagSkipURI>
+            <ETagSkipURI>
+                <URI>/api/am/publisher/{version}/environments</URI>
+                <HTTPMethods>GET</HTTPMethods>
+            </ETagSkipURI>
+            <ETagSkipURI>
+                <URI>/api/am/publisher/{version}/subscriptions</URI>
+                <HTTPMethods>GET</HTTPMethods>
+            </ETagSkipURI>
+            <ETagSkipURI>
+                <URI>/api/am/publisher/{version}/subscriptions/block-subscription</URI>
+                <HTTPMethods>POST</HTTPMethods>
+            </ETagSkipURI>
+            <ETagSkipURI>
+                <URI>/api/am/publisher/{version}/subscriptions/{subscriptionId}</URI>
+                <HTTPMethods>GET</HTTPMethods>
+            </ETagSkipURI>
+            <ETagSkipURI>
+                <URI>/api/am/publisher/{version}/subscriptions/unblock-subscription</URI>
+                <HTTPMethods>POST</HTTPMethods>
+            </ETagSkipURI>
+            <ETagSkipURI>
+                <URI>/api/am/publisher/{version}/tiers/{tierLevel}</URI>
+                <HTTPMethods>GET,POST</HTTPMethods>
+            </ETagSkipURI>
+            <ETagSkipURI>
+                <URI>/api/am/publisher/{version}/tiers/{tierLevel}/{tierName}</URI>
+                <HTTPMethods>GET,PUT,DELETE</HTTPMethods>
+            </ETagSkipURI>
+            <ETagSkipURI>
+                <URI>/api/am/publisher/{version}/tiers/update-permission</URI>
+                <HTTPMethods>POST</HTTPMethods>
+            </ETagSkipURI>
+        </ETagSkipList>
+    </RESTAPI>
+    <ThrottlingConfigurations>
+        <EnableAdvanceThrottling>true</EnableAdvanceThrottling>
+        <TrafficManager>
+            <Type>Binary</Type>
+            <ReceiverUrlGroup>tcp://${carbon.local.ip}:${receiver.url.port}</ReceiverUrlGroup>
+            <AuthUrlGroup>ssl://${carbon.local.ip}:${auth.url.port}</AuthUrlGroup>
+            <Username>${admin.username}</Username>
+            <Password>${admin.password}</Password>
+        </TrafficManager>
+        <DataPublisher>
+            <Enabled>true</Enabled>
+            <DataPublisherPool>
+                <MaxIdle>1000</MaxIdle>
+                <InitIdleCapacity>200</InitIdleCapacity>
+            </DataPublisherPool>
+            <DataPublisherThreadPool>
+                <CorePoolSize>200</CorePoolSize>
+                <MaxmimumPoolSize>1000</MaxmimumPoolSize>
+                <KeepAliveTime>200</KeepAliveTime>
+            </DataPublisherThreadPool>
+        </DataPublisher>
+        <PolicyDeployer>
+            <Enabled>true</Enabled>
+            <ServiceURL>https://localhost:${mgt.transport.https.port}${carbon.context}services/</ServiceURL>
+            <Username>${admin.username}</Username>
+            <Password>${admin.password}</Password>
+        </PolicyDeployer>
+        <BlockCondition>
+            <Enabled>true</Enabled>
+            <!--InitDelay>300000</InitDelay>
+            <Period>3600000</Period-->
+        </BlockCondition>
+        <JMSConnectionDetails>
+            <Enabled>true</Enabled>
+            <Destination>throttleData</Destination>
+            <!--InitDelay>300000</InitDelay-->
+            <JMSConnectionParameters>
+                <transport.jms.ConnectionFactoryJNDIName>TopicConnectionFactory</transport.jms.ConnectionFactoryJNDIName>
+                <transport.jms.DestinationType>topic</transport.jms.DestinationType>
+                <java.naming.factory.initial>org.wso2.andes.jndi.PropertiesFileInitialContextFactory</java.naming.factory.initial>
+                <connectionfactory.TopicConnectionFactory>amqp://${admin.username}:${admin.password}@clientid/carbon?brokerlist='tcp://${carbon.local.ip}:${jms.port}'</connectionfactory.TopicConnectionFactory>
+            </JMSConnectionParameters>
+        </JMSConnectionDetails>
+
+        <!--DefaultLimits>
+            <SubscriptionTierLimits>
+                <Gold>5000</Gold>
+                <Silver>2000</Silver>
+                <Bronze>1000</Bronze>
+                <Unauthenticated>60</Unauthenticated>
+            </SubscriptionTierLimits>
+            <ApplicationTierLimits>
+                <50PerMin>50</50PerMin>
+                <20PerMin>20</20PerMin>
+                <10PerMin>10</10PerMin>
+            </ApplicationTierLimits>
+            <ResourceLevelTierLimits>
+                <50KPerMin>50000</50KPerMin>
+                <20KPerMin>20000</20KPerMin>
+                <10KPerMin>10000</10KPerMin>
+            </ResourceLevelTierLimits>
+        </DefaultLimits-->
+        <EnableUnlimitedTier>true</EnableUnlimitedTier>
+        <EnableHeaderConditions>false</EnableHeaderConditions>
+        <EnableJWTClaimConditions>false</EnableJWTClaimConditions>
+        <EnableQueryParamConditions>false</EnableQueryParamConditions>
+    </ThrottlingConfigurations>
+    
+    <WorkflowConfigurations>
+        <Enabled>false</Enabled>
+    	<ServerUrl>https://localhost:9445/bpmn</ServerUrl>   		
+    	<ServerUser>${admin.username}</ServerUser>
+    	<ServerPassword>${admin.password}</ServerPassword>
+    	<WorkflowCallbackAPI>https://localhost:${mgt.transport.https.port}/api/am/publisher/v0.14/workflows/update-workflow-status</WorkflowCallbackAPI>
+        <TokenEndPoint>https://localhost:${https.nio.port}/token</TokenEndPoint>
+        <DCREndPoint>https://localhost:${mgt.transport.https.port}/client-registration/v0.14/register</DCREndPoint>
+        <DCREndPointUser>${admin.username}</DCREndPointUser>
+        <DCREndPointPassword>${admin.password}</DCREndPointPassword>
+    </WorkflowConfigurations>
+
+    <SwaggerCodegen>
+        <ClientGeneration>
+            <GroupId>org.wso2</GroupId>
+            <ArtifactId>org.wso2.client.</ArtifactId>
+            <ModelPackage>org.wso2.client.model.</ModelPackage>
+            <ApiPackage>org.wso2.client.api.</ApiPackage>
+            <!-- Configure supported languages/Frameworks as comma separated values,
+             Supported Languages/Frameworks : android, java, scala, csharp, dart, flash, groovy, javascript, jmeter,
+             nodejs, perl, php, python, ruby, swift, clojure, asyncScala, csharpDotNet2-->
+            <SupportedLanguages>java,android</SupportedLanguages>
+        </ClientGeneration>
+    </SwaggerCodegen>
+
+    <OpenTracer>
+        <RemoteTracer>
+            <Enabled>false</Enabled>
+            <Name>zipkin</Name>
+            <Properties>
+                <HostName>localhost</HostName>
+                <Port>9411</Port>
+            </Properties>
+        </RemoteTracer>
+        <LogTracer>
+            <Enabled>false</Enabled>
+        </LogTracer>
+    </OpenTracer>
+
+</APIManager>


### PR DESCRIPTION
## Purpose
> Adding platform (integration) tests - 3.1.1.5, 3.1.1.14. These are related to configuring custom authorization header.
3.1.1.5 - An administrator should be able to set a custom Auth header for all APIs in the system.
3.1.1.14- When an administrator has set a custom auth header in the system named 'foo', a request made to an API which has been published providing the mandatory fields and defaults only should fail if a valid access token is sent using the 'Authorization' header.