### PR TITLE
Add test suite configuration to scenarios-common

### DIFF
--- a/product-scenarios/scenarios-common/pom.xml
+++ b/product-scenarios/scenarios-common/pom.xml
@@ -19,6 +19,9 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.12.4</version>
                 <configuration>
+                    <suiteXmlFiles>
+                        <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
+                    </suiteXmlFiles>
                     <systemPropertyVariables>
                         <test.resource.location>${project.basedir}/src/test/resources/</test.resource.location>
                         <framework.resource.location>${project.basedir}/src/main/resources/</framework.resource.location>


### PR DESCRIPTION
## Purpose
Since there are valid tests running in scenarios-common module now, we need to define suiteXml configuration to get the coverage report generation working.