### PR TITLE
Un-set default api version when importing api via the api import export.

### DIFF
--- a/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/utils/APIImportUtil.java
+++ b/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/utils/APIImportUtil.java
@@ -309,7 +309,7 @@ public final class APIImportUtil {
         }
 
         try {
-
+            importedApi.setAsDefaultVersion(false);
             provider.addAPI(importedApi);
 
             //Swagger definition will only be available of API type HTTP. Web socket api does not have it.


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.
Fixes wso2/product-apim/issues/3610
