### PR TITLE
Remove spaces from test suite name

### DIFF
--- a/product-scenarios/scenarios-common/src/test/resources/testng.xml
+++ b/product-scenarios/scenarios-common/src/test/resources/testng.xml
@@ -17,8 +17,8 @@
   -->
 
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
-<suite name="Scenario Test Initializer">
-    <test name="Deploy webApps" verbose="2" parallel="false">
+<suite name="Scenario-Test-Initializer">
+    <test name="Deploy-WebApps" verbose="2" parallel="false">
         <classes>
             <class name="org.wso2.am.scenario.tests.common.DeploymentInitializerTestCase"/>
         </classes>


### PR DESCRIPTION
## Purpose
This is a possible fix for a build failure. We assume spaces in test suite name causes issues in jacoco report generation.