### PR TITLE
[2.x] API update support for import/export tool

### DIFF
--- a/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/APIService.java
+++ b/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/APIService.java
@@ -308,10 +308,10 @@ public class APIService {
                     RandomStringUtils.randomAlphanumeric(APIImportExportConstants.TEMP_FILENAME_LENGTH) +
                     File.separator;
             File importFolder = new File(currentDirectory + createdFolders);
-            boolean folderCreateStatus = importFolder.mkdirs();
+            boolean isImportDirCrated = importFolder.mkdirs();
 
             //API import process starts only if the required folder is created successfully
-            if (folderCreateStatus) {
+            if (isImportDirCrated) {
                 String uploadFileName = APIImportExportConstants.UPLOAD_FILE_NAME;
                 String absolutePath = currentDirectory + createdFolders;
                 APIImportUtil.transferFile(uploadedInputStream, uploadFileName, absolutePath);

--- a/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/APIService.java
+++ b/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/APIService.java
@@ -302,23 +302,23 @@ public class APIService {
             }
             APIImportUtil.initializeProvider(currentUser);
 
-            //Temporary directory is used to create the required folders
+            //Temporary directory is used to create the required directories
             String currentDirectory = System.getProperty(APIImportExportConstants.TEMP_DIR);
-            String createdFolders = File.separator +
+            String createdDirectories = File.separator +
                     RandomStringUtils.randomAlphanumeric(APIImportExportConstants.TEMP_FILENAME_LENGTH) +
                     File.separator;
-            File importFolder = new File(currentDirectory + createdFolders);
-            boolean isImportDirCrated = importFolder.mkdirs();
+            File importDirectory = new File(currentDirectory + createdDirectories);
+            boolean isImportDirectoryCreated = importDirectory.mkdirs();
 
-            //API import process starts only if the required folder is created successfully
-            if (isImportDirCrated) {
+            //API import process starts only if the required directory is created successfully
+            if (isImportDirectoryCreated) {
                 String uploadFileName = APIImportExportConstants.UPLOAD_FILE_NAME;
-                String absolutePath = currentDirectory + createdFolders;
+                String absolutePath = currentDirectory + createdDirectories;
                 APIImportUtil.transferFile(uploadedInputStream, uploadFileName, absolutePath);
 
-                String extractedFolderName;
+                String extractedDirName;
                 try {
-                    extractedFolderName = APIImportUtil.extractArchive(
+                    extractedDirName = APIImportUtil.extractArchive(
                             new File(absolutePath + uploadFileName), absolutePath);
                 } catch (APIImportException e) {
                     return Response.status(Status.BAD_REQUEST).entity(e.getMessage()).build();
@@ -330,8 +330,8 @@ public class APIService {
                     isTenantFlowStarted = true;
                 }
 
-                APIImportUtil.updateAPI(apiID, absolutePath + extractedFolderName, currentUser, isProviderPreserved);
-                importFolder.deleteOnExit();
+                APIImportUtil.updateAPI(apiID, absolutePath + extractedDirName, currentUser, isProviderPreserved);
+                importDirectory.deleteOnExit();
 
                 return Response.status(Status.CREATED).entity("API updated successfully.").build();
             } else {

--- a/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/APIService.java
+++ b/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/APIService.java
@@ -36,14 +36,21 @@ import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import java.io.File;
 import java.io.InputStream;
-import javax.ws.rs.*;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
-/**@QueryParam("preserveProvider") String defaultProviderStatus
+/**
  * This class provides JAX-RS services for exporting and importing APIs.
  * These services provides functionality for exporting and importing single API at a time.
  */
@@ -170,7 +177,7 @@ public class APIService {
 
     /**
      * This is the service which is used to import an API. All relevant API data will be included upon the creation of
-     * the API. Depending ohttp://localhost:n the choice of the user, provider of the imported API will be preserved or modified.
+     * the API. Depending on the choice of the user, provider of the imported API will be preserved or modified.
      *
      * @param uploadedInputStream uploadedInputStream input stream from the REST request
      * @param defaultProviderStatus     user choice to keep or replace the API provider

--- a/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/APIService.java
+++ b/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/APIService.java
@@ -288,7 +288,6 @@ public class APIService {
 
         try {
             Response authorizationResponse = AuthenticatorUtil.authorizeUser(httpHeaders);
-
             if (Response.Status.OK.getStatusCode() != authorizationResponse.getStatus()) {
                 return authorizationResponse;
             }

--- a/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/APIService.java
+++ b/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/APIService.java
@@ -333,8 +333,6 @@ public class APIService {
         } catch (APIExportException e) {
             return Response.status(Status.INTERNAL_SERVER_ERROR).entity("Error in initializing API provider.\n").build();
         } catch (APIImportException e) {
-            https:
-//www.nvidia.com/en-us/geforce/ron-ai-personal-assistant/?nvid=nv-int-pr-79934
             return Response.serverError().entity(e.getMessage()).build();
         } finally {
             if (isTenantFlowStarted) {

--- a/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/utils/APIImportUtil.java
+++ b/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/utils/APIImportUtil.java
@@ -34,11 +34,20 @@ import org.wso2.carbon.apimgt.api.APIDefinition;
 import org.wso2.carbon.apimgt.api.APIManagementException;
 import org.wso2.carbon.apimgt.api.APIProvider;
 import org.wso2.carbon.apimgt.api.FaultGatewaysException;
-import org.wso2.carbon.apimgt.api.model.*;
+import org.wso2.carbon.apimgt.api.model.API;
+import org.wso2.carbon.apimgt.api.model.APIIdentifier;
+import org.wso2.carbon.apimgt.api.model.Documentation;
+import org.wso2.carbon.apimgt.api.model.ResourceFile;
+import org.wso2.carbon.apimgt.api.model.Scope;
+import org.wso2.carbon.apimgt.api.model.Tier;
+import org.wso2.carbon.apimgt.api.model.URITemplate;
 import org.wso2.carbon.apimgt.impl.APIConstants;
 import org.wso2.carbon.apimgt.impl.definitions.APIDefinitionFromOpenAPISpec;
 import org.wso2.carbon.apimgt.impl.utils.APIUtil;
-import org.wso2.carbon.apimgt.importexport.*;
+import org.wso2.carbon.apimgt.importexport.APIExportException;
+import org.wso2.carbon.apimgt.importexport.APIImportException;
+import org.wso2.carbon.apimgt.importexport.APIImportExportConstants;
+import org.wso2.carbon.apimgt.importexport.APIService;
 import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.registry.api.Registry;
@@ -214,6 +223,7 @@ public final class APIImportUtil {
 
             // If the original provider is preserved,
             if (isDefaultProviderAllowed) {
+
                 if (!StringUtils.equals(prevTenantDomain, currentTenantDomain)) {
                     String errorMessage = "Tenant mismatch! Please enable preserveProvider property " +
                             "for cross tenant API Import ";

--- a/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/utils/APIImportUtil.java
+++ b/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/utils/APIImportUtil.java
@@ -463,7 +463,6 @@ public final class APIImportUtil {
             if (!APIConstants.APIType.WS.toString().equalsIgnoreCase(importedApi.getType())) {
                 String swaggerContent = FileUtils.readFileToString(
                         new File(pathToArchive + APIImportExportConstants.SWAGGER_DEFINITION_LOCATION));
-
                 addSwaggerDefinition(importedApi.getId(), swaggerContent);
 
                 //Load required properties from swagger to the API

--- a/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/utils/APIImportUtil.java
+++ b/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/utils/APIImportUtil.java
@@ -365,7 +365,6 @@ public final class APIImportUtil {
         API targetApi = null;
         String prevProvider;
         APIDefinition definitionFromOpenAPISpec = new APIDefinitionFromOpenAPISpec();
-        List<API> allMatchedApis;
         String apiTargetStatus;
 
         String pathToJSONFile = pathToArchive + APIImportExportConstants.JSON_FILE_LOCATION;
@@ -407,12 +406,11 @@ public final class APIImportUtil {
                 importedApi = SetCurrentProvidertoAPIProperties(importedApi, currentTenantDomain, prevTenantDomain);
             }
 
-            //Checking whether the API exists
+            // Checking whether the API exists
+            // If API exists set the imported API status to the target one
             targetApi = provider.getAPIbyUUID(apiID, currentTenantDomain);
             apiTargetStatus = targetApi.getStatus();
-
             importedApi.setStatus(apiTargetStatus);
-            importedApi.setUUID(targetApi.getUUID());
         } catch (IOException e) {
             String errorMessage = "Error in reading API definition. ";
             log.error(errorMessage, e);
@@ -478,9 +476,9 @@ public final class APIImportUtil {
                         }
                     }
                 }
-                // This is required to make url templates and scopes get effected.
-                provider.updateAPI(importedApi);
             }
+
+            provider.updateAPI(importedApi);
         } catch (APIManagementException e) {
             //Error is logged and APIImportException is thrown because adding API and swagger are mandatory steps
             String errorMessage = "Error in adding API to the provider. ";

--- a/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/utils/APIImportUtil.java
+++ b/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/utils/APIImportUtil.java
@@ -403,7 +403,6 @@ public final class APIImportUtil {
                 if (!StringUtils.equals(prevTenantDomain, currentTenantDomain)) {
                     String errorMessage = "Tenant mismatch! Please enable preserveProvider property " +
                             "for cross tenant API Import ";
-                    log.error(errorMessage);
                     throw new APIImportException(errorMessage);
                 }
                 importedApi = new Gson().fromJson(configElement, API.class);

--- a/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/utils/APIImportUtil.java
+++ b/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/utils/APIImportUtil.java
@@ -358,6 +358,15 @@ public final class APIImportUtil {
 
     }
 
+    /**
+     * This method updates an existing API. The state of the API is preserved in the update process
+     *
+     * @param apiID                    UUID of the API to be updated
+     * @param pathToArchive            Archive used to update the API
+     * @param currentUser              User for update operation
+     * @param isDefaultProviderAllowed Is default provider allowed to do the operation
+     * @throws APIImportException If there is an error the exception is thrown
+     */
     public static void updateAPI(String apiID, String pathToArchive, String currentUser, boolean isDefaultProviderAllowed)
             throws APIImportException {
 
@@ -365,7 +374,6 @@ public final class APIImportUtil {
         API targetApi = null;
         String prevProvider;
         APIDefinition definitionFromOpenAPISpec = new APIDefinitionFromOpenAPISpec();
-        String apiTargetStatus;
 
         String pathToJSONFile = pathToArchive + APIImportExportConstants.JSON_FILE_LOCATION;
 
@@ -409,8 +417,7 @@ public final class APIImportUtil {
             // Checking whether the API exists
             // If API exists set the imported API status to the target one
             targetApi = provider.getAPIbyUUID(apiID, currentTenantDomain);
-            apiTargetStatus = targetApi.getStatus();
-            importedApi.setStatus(apiTargetStatus);
+            importedApi.setStatus(targetApi.getStatus());
         } catch (IOException e) {
             String errorMessage = "Error in reading API definition. ";
             log.error(errorMessage, e);


### PR DESCRIPTION
## Purpose
This PR enables functionality to update existing APIs via import/export tool

## Goals
- To provide API update support for `apimcli` tool.

## Approach
- API updates are done through a PUT request `PUT <import-export-endpoint>/{apiId}` 
- APIM will check for the existence of `apiId` in the system.
- If API exists it will be updated using provided archive
- If API does not exist the operation is aborted

## User stories
For people who want to integrate API CI/CD to their workflow often need to update APIs using an automation server. This feature enables them to perform API updates easily 