### PR TITLE
Fix for scenario build failure

### DIFF
--- a/product-scenarios/scenarios-common/src/main/java/org/wso2/am/scenario/test/common/ScenarioTestBase.java
+++ b/product-scenarios/scenarios-common/src/main/java/org/wso2/am/scenario/test/common/ScenarioTestBase.java
@@ -603,8 +603,11 @@ public class ScenarioTestBase {
     }
 
     public String getBackendEndServiceEndPointHttps(String serviceName) {
-        String webAppURL = serviceEndpoint.replace("/services", "");
-        return webAppURL + "/" + serviceName;
+        String webAppURL = serviceEndpoint.replaceFirst("/services.*", "");
+
+        // Avoid adding extra '/' at the end
+        webAppURL = StringUtils.isEmpty(serviceName) ? webAppURL : webAppURL + '/' + serviceName;
+        return webAppURL;
     }
 
     /**


### PR DESCRIPTION
## Purpose
Having additional `/` in the url creates urls like below.
https://localhost:9443///APIStatusMonitor/webAppStatus/webappInfo/APIStatusMonitor.war
This causes issues when running scenario tests in TG.