### PR TITLE
Comment out copying of APILIfecycle.xml to jaggeryapps

### DIFF
--- a/modules/distribution/product/src/main/assembly/bin.xml
+++ b/modules/distribution/product/src/main/assembly/bin.xml
@@ -106,7 +106,7 @@
                 <exclude>**/conf/email/email-admin-config.xml</exclude>
                 <exclude>**/repository/components/features/org.wso2.carbon.apimgt.store_${carbon.apimgt.version}/store/**</exclude>
                 <exclude>**/repository/components/features/org.wso2.carbon.apimgt.store_${carbon.apimgt.version}/admin/**</exclude>
-                <exclude>**/repository/components/features/org.wso2.carbon.apimgt.publisher_${carbon.apimgt.version}/publisher/**</exclude>
+                <exclude>**/repository/components/features/org.wso2.carbon.apimgt.publisher_${carbon.apimgt.version}/publisher-new/**</exclude>
                 <exclude>**/repository/components/features/org.wso2.carbon.apimgt.core_${carbon.apimgt.version}/libs/**</exclude>
 
                 <exclude>**/repository/deployment/server/webapps/api#identity#entitlement.war</exclude>
@@ -1100,13 +1100,13 @@
             <outputDirectory>wso2am-${pom.version}/repository/conf/tomcat/</outputDirectory>
             <fileMode>644</fileMode>
         </file>
-	    <file>
-            <source>
-                ../../p2-profile/product/target/wso2carbon-core-${carbon.kernel.version}/repository/resources/lifecycles/APILifeCycle.xml
-            </source>
-            <outputDirectory>wso2am-${pom.version}/repository/resources/lifecycles</outputDirectory>
-            <filtered>true</filtered>
-        </file>
+	    <!--<file>-->
+            <!--<source>-->
+                <!--../../p2-profile/product/target/wso2carbon-core-${carbon.kernel.version}/repository/resources/lifecycles/APILifeCycle.xml-->
+            <!--</source>-->
+            <!--<outputDirectory>wso2am-${pom.version}/repository/resources/lifecycles</outputDirectory>-->
+            <!--<filtered>true</filtered>-->
+        <!--</file>-->
         <file>
             <source>../../p2-profile/product/target/wso2carbon-core-${carbon.kernel.version}/repository/conf/multitenancy/tenant-mgt.xml</source>
             <outputDirectory>wso2am-${pom.version}/repository/conf</outputDirectory>


### PR DESCRIPTION
## Purpose
This PR comments out copying of APILifeCycle.xml because this file is no longer copied into the publisher folder in the new sample react app.

