### PR TITLE
Remove UMA grant type from identity.xml

### DIFF
--- a/modules/distribution/product/identity_config_change.xml
+++ b/modules/distribution/product/identity_config_change.xml
@@ -3,7 +3,10 @@
    causes several scope validator elements to be added--> 	
    <remove>
         <name>//s:Server/s:OAuth/s:OAuthScopeValidator</name>
-   </remove>	   
+   </remove>
+   <remove>
+      <name>//s:Server/s:OAuth/s:SupportedGrantTypes/s:SupportedGrantType[s:GrantTypeName='urn:ietf:params:oauth:grant-type:uma-ticket']</name>
+   </remove>
    <!-- Add the scope validator config element -->
    <add> 
       <after>//s:Server/s:OAuth/s:OAuthCallbackHandlers</after>


### PR DESCRIPTION
Latest identity versions have added UMA grant to the identity.xml. Since APIM distribution doesn't have these jars, this causes issues. Hence we are removing UMA grant type from identity.xml when building the APIM distribution. 