### PR TITLE
Fix api-manager.xml with new configs and remove asm duplicate jar

### DIFF
--- a/modules/distribution/product/src/main/assembly/bin.xml
+++ b/modules/distribution/product/src/main/assembly/bin.xml
@@ -108,7 +108,7 @@
                 <exclude>**/repository/components/plugins/org.wso2.carbon.identity.oauth.stub_6.0.103.jar</exclude>
                 <exclude>**/repository/components/plugins/org.antlr.antlr4-runtime-osgi_4.5.0.jar</exclude>
                 <exclude>**/repository/components/plugins/opensaml_2.6.4.wso2v3.jar</exclude>
-
+                <exclude>**/repository/components/plugins/org.objectweb.asm_5.2.0.jar</exclude>
 
                 <exclude>**/lib/endorsed/xalan*.jar</exclude>
                 <exclude>**/conf/thrift-authentication.xml</exclude>

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/apiManagerXmlWithoutAdvancedThrottling/api-manager.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/apiManagerXmlWithoutAdvancedThrottling/api-manager.xml
@@ -257,6 +257,18 @@
         <EncryptPersistedTokens>false</EncryptPersistedTokens>
     </OAuthConfigurations>
 
+    <TokenRevocationNotifiers class="org.wso2.carbon.apimgt.keymgt.events.TokenRevocationNotifierImpl">
+        <RealtimeNotifier>
+            <Property name="ttl">5000</Property>
+        </RealtimeNotifier>
+        <PersistentNotifier>
+            <Property name="hostname">https://localhost:2379/v2/keys/jti/</Property>
+            <Property name="ttl">5000</Property>
+            <Property name="username">root</Property>
+            <Property name="password">root</Property>
+        </PersistentNotifier>
+    </TokenRevocationNotifiers>
+
     <!-- Settings related to managing API access tiers. -->
     <TierManagement>
         <!-- Enable the providers to expose their APIs over the special 'Unlimited' tier which

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/apiManagerXmlWithoutAdvancedThrottlingUsingWSClient/api-manager.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/apiManagerXmlWithoutAdvancedThrottlingUsingWSClient/api-manager.xml
@@ -270,6 +270,18 @@
         <EncryptPersistedTokens>false</EncryptPersistedTokens>
     </OAuthConfigurations>
 
+    <TokenRevocationNotifiers class="org.wso2.carbon.apimgt.keymgt.events.TokenRevocationNotifierImpl">
+        <RealtimeNotifier>
+            <Property name="ttl">5000</Property>
+        </RealtimeNotifier>
+        <PersistentNotifier>
+            <Property name="hostname">https://localhost:2379/v2/keys/jti/</Property>
+            <Property name="ttl">5000</Property>
+            <Property name="username">root</Property>
+            <Property name="password">root</Property>
+        </PersistentNotifier>
+    </TokenRevocationNotifiers>
+
     <!-- Settings related to managing API access tiers. -->
     <TierManagement>
         <!-- Enable the providers to expose their APIs over the special 'Unlimited' tier which

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/applicationSharing/api-manager.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/applicationSharing/api-manager.xml
@@ -278,6 +278,18 @@
         <EnableTokenHashMode>false</EnableTokenHashMode>
     </OAuthConfigurations>
 
+    <TokenRevocationNotifiers class="org.wso2.carbon.apimgt.keymgt.events.TokenRevocationNotifierImpl">
+        <RealtimeNotifier>
+            <Property name="ttl">5000</Property>
+        </RealtimeNotifier>
+        <PersistentNotifier>
+            <Property name="hostname">https://localhost:2379/v2/keys/jti/</Property>
+            <Property name="ttl">5000</Property>
+            <Property name="username">root</Property>
+            <Property name="password">root</Property>
+        </PersistentNotifier>
+    </TokenRevocationNotifiers>
+
     <!-- Settings related to managing API access tiers. -->
     <TierManagement>
         <!-- Enable the providers to expose their APIs over the special 'Unlimited' tier which

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/common/api-manager.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/common/api-manager.xml
@@ -292,6 +292,18 @@
         <EncryptPersistedTokens>false</EncryptPersistedTokens>
     </OAuthConfigurations>
 
+    <TokenRevocationNotifiers class="org.wso2.carbon.apimgt.keymgt.events.TokenRevocationNotifierImpl">
+        <RealtimeNotifier>
+            <Property name="ttl">5000</Property>
+        </RealtimeNotifier>
+        <PersistentNotifier>
+            <Property name="hostname">https://localhost:2379/v2/keys/jti/</Property>
+            <Property name="ttl">5000</Property>
+            <Property name="username">root</Property>
+            <Property name="password">root</Property>
+        </PersistentNotifier>
+    </TokenRevocationNotifiers>
+
     <!-- Settings related to managing API access tiers. -->
     <TierManagement>
         <!-- Enable the providers to expose their APIs over the special 'Unlimited' tier which

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/corsACACTest/api-manager.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/corsACACTest/api-manager.xml
@@ -258,6 +258,18 @@
         <EncryptPersistedTokens>false</EncryptPersistedTokens>
     </OAuthConfigurations>
 
+    <TokenRevocationNotifiers class="org.wso2.carbon.apimgt.keymgt.events.TokenRevocationNotifierImpl">
+        <RealtimeNotifier>
+            <Property name="ttl">5000</Property>
+        </RealtimeNotifier>
+        <PersistentNotifier>
+            <Property name="hostname">https://localhost:2379/v2/keys/jti/</Property>
+            <Property name="ttl">5000</Property>
+            <Property name="username">root</Property>
+            <Property name="password">root</Property>
+        </PersistentNotifier>
+    </TokenRevocationNotifiers>
+
     <!-- Settings related to managing API access tiers. -->
     <TierManagement>
         <!-- Enable the providers to expose their APIs over the special 'Unlimited' tier which

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/corsACACTest/original/api-manager.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/corsACACTest/original/api-manager.xml
@@ -257,6 +257,18 @@
         <EncryptPersistedTokens>false</EncryptPersistedTokens>
     </OAuthConfigurations>
 
+    <TokenRevocationNotifiers class="org.wso2.carbon.apimgt.keymgt.events.TokenRevocationNotifierImpl">
+        <RealtimeNotifier>
+            <Property name="ttl">5000</Property>
+        </RealtimeNotifier>
+        <PersistentNotifier>
+            <Property name="hostname">https://localhost:2379/v2/keys/jti/</Property>
+            <Property name="ttl">5000</Property>
+            <Property name="username">root</Property>
+            <Property name="password">root</Property>
+        </PersistentNotifier>
+    </TokenRevocationNotifiers>
+
     <!-- Settings related to managing API access tiers. -->
     <TierManagement>
         <!-- Enable the providers to expose their APIs over the special 'Unlimited' tier which

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/corsACACTest/withOriginAny/api-manager.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/corsACACTest/withOriginAny/api-manager.xml
@@ -257,6 +257,18 @@
         <EncryptPersistedTokens>false</EncryptPersistedTokens>
     </OAuthConfigurations>
 
+    <TokenRevocationNotifiers class="org.wso2.carbon.apimgt.keymgt.events.TokenRevocationNotifierImpl">
+        <RealtimeNotifier>
+            <Property name="ttl">5000</Property>
+        </RealtimeNotifier>
+        <PersistentNotifier>
+            <Property name="hostname">https://localhost:2379/v2/keys/jti/</Property>
+            <Property name="ttl">5000</Property>
+            <Property name="username">root</Property>
+            <Property name="password">root</Property>
+        </PersistentNotifier>
+    </TokenRevocationNotifiers>
+
     <!-- Settings related to managing API access tiers. -->
     <TierManagement>
         <!-- Enable the providers to expose their APIs over the special 'Unlimited' tier which

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/customHeaderTest/api-manager.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/customHeaderTest/api-manager.xml
@@ -278,6 +278,18 @@
         <EnableTokenHashMode>false</EnableTokenHashMode>
     </OAuthConfigurations>
 
+    <TokenRevocationNotifiers class="org.wso2.carbon.apimgt.keymgt.events.TokenRevocationNotifierImpl">
+        <RealtimeNotifier>
+            <Property name="ttl">5000</Property>
+        </RealtimeNotifier>
+        <PersistentNotifier>
+            <Property name="hostname">https://localhost:2379/v2/keys/jti/</Property>
+            <Property name="ttl">5000</Property>
+            <Property name="username">root</Property>
+            <Property name="password">root</Property>
+        </PersistentNotifier>
+    </TokenRevocationNotifiers>
+
     <!-- Settings related to managing API access tiers. -->
     <TierManagement>
         <!-- Enable the providers to expose their APIs over the special 'Unlimited' tier which

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/emailusernamejwttest/api-manager.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/emailusernamejwttest/api-manager.xml
@@ -257,6 +257,19 @@
         <EncryptPersistedTokens>false</EncryptPersistedTokens>
     </OAuthConfigurations>
 
+
+    <TokenRevocationNotifiers class="org.wso2.carbon.apimgt.keymgt.events.TokenRevocationNotifierImpl">
+        <RealtimeNotifier>
+            <Property name="ttl">5000</Property>
+        </RealtimeNotifier>
+        <PersistentNotifier>
+            <Property name="hostname">https://localhost:2379/v2/keys/jti/</Property>
+            <Property name="ttl">5000</Property>
+            <Property name="username">root</Property>
+            <Property name="password">root</Property>
+        </PersistentNotifier>
+    </TokenRevocationNotifiers>
+
     <!-- Settings related to managing API access tiers. -->
     <TierManagement>
         <!-- Enable the providers to expose their APIs over the special 'Unlimited' tier which

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/emailusernametest/api-manager.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/emailusernametest/api-manager.xml
@@ -257,6 +257,30 @@
         <EncryptPersistedTokens>false</EncryptPersistedTokens>
     </OAuthConfigurations>
 
+    <TokenRevocationNotifiers class="org.wso2.carbon.apimgt.keymgt.events.TokenRevocationNotifierImpl">
+        <RealtimeNotifier>
+            <Property name="ttl">5000</Property>
+        </RealtimeNotifier>
+        <PersistentNotifier>
+            <Property name="hostname">https://localhost:2379/v2/keys/jti/</Property>
+            <Property name="ttl">5000</Property>
+            <Property name="username">root</Property>
+            <Property name="password">root</Property>
+        </PersistentNotifier>
+    </TokenRevocationNotifiers>
+
+    <TokenRevocationNotifiers class="org.wso2.carbon.apimgt.keymgt.events.TokenRevocationNotifierImpl">
+        <RealtimeNotifier>
+            <Property name="ttl">5000</Property>
+        </RealtimeNotifier>
+        <PersistentNotifier>
+            <Property name="hostname">https://localhost:2379/v2/keys/jti/</Property>
+            <Property name="ttl">5000</Property>
+            <Property name="username">root</Property>
+            <Property name="password">root</Property>
+        </PersistentNotifier>
+    </TokenRevocationNotifiers>
+
     <!-- Settings related to managing API access tiers. -->
     <TierManagement>
         <!-- Enable the providers to expose their APIs over the special 'Unlimited' tier which

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/hostobjecttest/api-manager.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/hostobjecttest/api-manager.xml
@@ -257,6 +257,18 @@
         <EncryptPersistedTokens>false</EncryptPersistedTokens>
     </OAuthConfigurations>
 
+    <TokenRevocationNotifiers class="org.wso2.carbon.apimgt.keymgt.events.TokenRevocationNotifierImpl">
+        <RealtimeNotifier>
+            <Property name="ttl">5000</Property>
+        </RealtimeNotifier>
+        <PersistentNotifier>
+            <Property name="hostname">https://localhost:2379/v2/keys/jti/</Property>
+            <Property name="ttl">5000</Property>
+            <Property name="username">root</Property>
+            <Property name="password">root</Property>
+        </PersistentNotifier>
+    </TokenRevocationNotifiers>
+
     <!-- Settings related to managing API access tiers. -->
     <TierManagement>
         <!-- Enable the providers to expose their APIs over the special 'Unlimited' tier which

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/osgi/api-manager.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/osgi/api-manager.xml
@@ -258,6 +258,18 @@
         <EncryptPersistedTokens>false</EncryptPersistedTokens>
     </OAuthConfigurations>
 
+    <TokenRevocationNotifiers class="org.wso2.carbon.apimgt.keymgt.events.TokenRevocationNotifierImpl">
+        <RealtimeNotifier>
+            <Property name="ttl">5000</Property>
+        </RealtimeNotifier>
+        <PersistentNotifier>
+            <Property name="hostname">https://localhost:2379/v2/keys/jti/</Property>
+            <Property name="ttl">5000</Property>
+            <Property name="username">root</Property>
+            <Property name="password">root</Property>
+        </PersistentNotifier>
+    </TokenRevocationNotifiers>
+
     <!-- Settings related to managing API access tiers. -->
     <TierManagement>
         <!-- Enable the providers to expose their APIs over the special 'Unlimited' tier which

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/soapwithmultiplegateways/api-manager.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/soapwithmultiplegateways/api-manager.xml
@@ -283,6 +283,18 @@
         <EncryptPersistedTokens>false</EncryptPersistedTokens>
     </OAuthConfigurations>
 
+    <TokenRevocationNotifiers class="org.wso2.carbon.apimgt.keymgt.events.TokenRevocationNotifierImpl">
+        <RealtimeNotifier>
+            <Property name="ttl">5000</Property>
+        </RealtimeNotifier>
+        <PersistentNotifier>
+            <Property name="hostname">https://localhost:2379/v2/keys/jti/</Property>
+            <Property name="ttl">5000</Property>
+            <Property name="username">root</Property>
+            <Property name="password">root</Property>
+        </PersistentNotifier>
+    </TokenRevocationNotifiers>
+
     <!-- Settings related to managing API access tiers. -->
     <TierManagement>
         <!-- Enable the providers to expose their APIs over the special 'Unlimited' tier which

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/stats/api-manager.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/stats/api-manager.xml
@@ -256,6 +256,18 @@
         <EncryptPersistedTokens>false</EncryptPersistedTokens>
     </OAuthConfigurations>
 
+    <TokenRevocationNotifiers class="org.wso2.carbon.apimgt.keymgt.events.TokenRevocationNotifierImpl">
+        <RealtimeNotifier>
+            <Property name="ttl">5000</Property>
+        </RealtimeNotifier>
+        <PersistentNotifier>
+            <Property name="hostname">https://localhost:2379/v2/keys/jti/</Property>
+            <Property name="ttl">5000</Property>
+            <Property name="username">root</Property>
+            <Property name="password">root</Property>
+        </PersistentNotifier>
+    </TokenRevocationNotifiers>
+
     <!-- Settings related to managing API access tiers. -->
     <TierManagement>
         <!-- Enable the providers to expose their APIs over the special 'Unlimited' tier which

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/stats/tokenEncryptionEnabled/api-manager.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/stats/tokenEncryptionEnabled/api-manager.xml
@@ -257,6 +257,18 @@
         <EncryptPersistedTokens>true</EncryptPersistedTokens>
     </OAuthConfigurations>
 
+    <TokenRevocationNotifiers class="org.wso2.carbon.apimgt.keymgt.events.TokenRevocationNotifierImpl">
+        <RealtimeNotifier>
+            <Property name="ttl">5000</Property>
+        </RealtimeNotifier>
+        <PersistentNotifier>
+            <Property name="hostname">https://localhost:2379/v2/keys/jti/</Property>
+            <Property name="ttl">5000</Property>
+            <Property name="username">root</Property>
+            <Property name="password">root</Property>
+        </PersistentNotifier>
+    </TokenRevocationNotifiers>
+
     <!-- Settings related to managing API access tiers. -->
     <TierManagement>
         <!-- Enable the providers to expose their APIs over the special 'Unlimited' tier which

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/throttling/api-manager.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/throttling/api-manager.xml
@@ -258,6 +258,18 @@
         <EncryptPersistedTokens>false</EncryptPersistedTokens>
     </OAuthConfigurations>
 
+    <TokenRevocationNotifiers class="org.wso2.carbon.apimgt.keymgt.events.TokenRevocationNotifierImpl">
+        <RealtimeNotifier>
+            <Property name="ttl">5000</Property>
+        </RealtimeNotifier>
+        <PersistentNotifier>
+            <Property name="hostname">https://localhost:2379/v2/keys/jti/</Property>
+            <Property name="ttl">5000</Property>
+            <Property name="username">root</Property>
+            <Property name="password">root</Property>
+        </PersistentNotifier>
+    </TokenRevocationNotifiers>
+
     <!-- Settings related to managing API access tiers. -->
     <TierManagement>
         <!-- Enable the providers to expose their APIs over the special 'Unlimited' tier which

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/tokenTest/api-manager.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/tokenTest/api-manager.xml
@@ -276,6 +276,18 @@
         <EncryptPersistedTokens>false</EncryptPersistedTokens>
     </OAuthConfigurations>
 
+    <TokenRevocationNotifiers class="org.wso2.carbon.apimgt.keymgt.events.TokenRevocationNotifierImpl">
+        <RealtimeNotifier>
+            <Property name="ttl">5000</Property>
+        </RealtimeNotifier>
+        <PersistentNotifier>
+            <Property name="hostname">https://localhost:2379/v2/keys/jti/</Property>
+            <Property name="ttl">5000</Property>
+            <Property name="username">root</Property>
+            <Property name="password">root</Property>
+        </PersistentNotifier>
+    </TokenRevocationNotifiers>
+
     <!-- Settings related to managing API access tiers. -->
     <TierManagement>
         <!-- Enable the providers to expose their APIs over the special 'Unlimited' tier which

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/tokenTest/urlSafeTokenTest/api-manager.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/tokenTest/urlSafeTokenTest/api-manager.xml
@@ -275,6 +275,18 @@
         <EncryptPersistedTokens>false</EncryptPersistedTokens>
     </OAuthConfigurations>
 
+    <TokenRevocationNotifiers class="org.wso2.carbon.apimgt.keymgt.events.TokenRevocationNotifierImpl">
+        <RealtimeNotifier>
+            <Property name="ttl">5000</Property>
+        </RealtimeNotifier>
+        <PersistentNotifier>
+            <Property name="hostname">https://localhost:2379/v2/keys/jti/</Property>
+            <Property name="ttl">5000</Property>
+            <Property name="username">root</Property>
+            <Property name="password">root</Property>
+        </PersistentNotifier>
+    </TokenRevocationNotifiers>
+
     <!-- Settings related to managing API access tiers. -->
     <TierManagement>
         <!-- Enable the providers to expose their APIs over the special 'Unlimited' tier which

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/token_encryption/api-manager.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/token_encryption/api-manager.xml
@@ -257,6 +257,18 @@
         <EncryptPersistedTokens>true</EncryptPersistedTokens>
     </OAuthConfigurations>
 
+    <TokenRevocationNotifiers class="org.wso2.carbon.apimgt.keymgt.events.TokenRevocationNotifierImpl">
+        <RealtimeNotifier>
+            <Property name="ttl">5000</Property>
+        </RealtimeNotifier>
+        <PersistentNotifier>
+            <Property name="hostname">https://localhost:2379/v2/keys/jti/</Property>
+            <Property name="ttl">5000</Property>
+            <Property name="username">root</Property>
+            <Property name="password">root</Property>
+        </PersistentNotifier>
+    </TokenRevocationNotifiers>
+
     <!-- Settings related to managing API access tiers. -->
     <TierManagement>
         <!-- Enable the providers to expose their APIs over the special 'Unlimited' tier which

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/token_encryption/default_configs/api-manager.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/token_encryption/default_configs/api-manager.xml
@@ -257,6 +257,18 @@
         <EncryptPersistedTokens>false</EncryptPersistedTokens>
     </OAuthConfigurations>
 
+    <TokenRevocationNotifiers class="org.wso2.carbon.apimgt.keymgt.events.TokenRevocationNotifierImpl">
+        <RealtimeNotifier>
+            <Property name="ttl">5000</Property>
+        </RealtimeNotifier>
+        <PersistentNotifier>
+            <Property name="hostname">https://localhost:2379/v2/keys/jti/</Property>
+            <Property name="ttl">5000</Property>
+            <Property name="username">root</Property>
+            <Property name="password">root</Property>
+        </PersistentNotifier>
+    </TokenRevocationNotifiers>
+
     <!-- Settings related to managing API access tiers. -->
     <TierManagement>
         <!-- Enable the providers to expose their APIs over the special 'Unlimited' tier which

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/usagemonitortest/api-manager.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/usagemonitortest/api-manager.xml
@@ -257,6 +257,18 @@
         <EncryptPersistedTokens>false</EncryptPersistedTokens>
     </OAuthConfigurations>
 
+    <TokenRevocationNotifiers class="org.wso2.carbon.apimgt.keymgt.events.TokenRevocationNotifierImpl">
+        <RealtimeNotifier>
+            <Property name="ttl">5000</Property>
+        </RealtimeNotifier>
+        <PersistentNotifier>
+            <Property name="hostname">https://localhost:2379/v2/keys/jti/</Property>
+            <Property name="ttl">5000</Property>
+            <Property name="username">root</Property>
+            <Property name="password">root</Property>
+        </PersistentNotifier>
+    </TokenRevocationNotifiers>
+
     <!-- Settings related to managing API access tiers. -->
     <TierManagement>
         <!-- Enable the providers to expose their APIs over the special 'Unlimited' tier which

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/webSocketTest/api-manager.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/webSocketTest/api-manager.xml
@@ -257,6 +257,18 @@
         <EncryptPersistedTokens>false</EncryptPersistedTokens>
     </OAuthConfigurations>
 
+    <TokenRevocationNotifiers class="org.wso2.carbon.apimgt.keymgt.events.TokenRevocationNotifierImpl">
+        <RealtimeNotifier>
+            <Property name="ttl">5000</Property>
+        </RealtimeNotifier>
+        <PersistentNotifier>
+            <Property name="hostname">https://localhost:2379/v2/keys/jti/</Property>
+            <Property name="ttl">5000</Property>
+            <Property name="username">root</Property>
+            <Property name="password">root</Property>
+        </PersistentNotifier>
+    </TokenRevocationNotifiers>
+
     <!-- Settings related to managing API access tiers. -->
     <TierManagement>
         <!-- Enable the providers to expose their APIs over the special 'Unlimited' tier which

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/workflowapistatechange/api-manager.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/workflowapistatechange/api-manager.xml
@@ -257,6 +257,18 @@ StreamProcessor<APIManager>
         <EncryptPersistedTokens>false</EncryptPersistedTokens>
     </OAuthConfigurations>
 
+    <TokenRevocationNotifiers class="org.wso2.carbon.apimgt.keymgt.events.TokenRevocationNotifierImpl">
+        <RealtimeNotifier>
+            <Property name="ttl">5000</Property>
+        </RealtimeNotifier>
+        <PersistentNotifier>
+            <Property name="hostname">https://localhost:2379/v2/keys/jti/</Property>
+            <Property name="ttl">5000</Property>
+            <Property name="username">root</Property>
+            <Property name="password">root</Property>
+        </PersistentNotifier>
+    </TokenRevocationNotifiers>
+
     <!-- Settings related to managing API access tiers. -->
     <TierManagement>
         <!-- Enable the providers to expose their APIs over the special 'Unlimited' tier which

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/lifecycletest/api-manager.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/lifecycletest/api-manager.xml
@@ -270,6 +270,18 @@
         <EncryptPersistedTokens>false</EncryptPersistedTokens>
     </OAuthConfigurations>
 
+    <TokenRevocationNotifiers class="org.wso2.carbon.apimgt.keymgt.events.TokenRevocationNotifierImpl">
+        <RealtimeNotifier>
+            <Property name="ttl">5000</Property>
+        </RealtimeNotifier>
+        <PersistentNotifier>
+            <Property name="hostname">https://localhost:2379/v2/keys/jti/</Property>
+            <Property name="ttl">5000</Property>
+            <Property name="username">root</Property>
+            <Property name="password">root</Property>
+        </PersistentNotifier>
+    </TokenRevocationNotifiers>
+
     <!-- Settings related to managing API access tiers. -->
     <TierManagement>
         <!-- Enable the providers to expose their APIs over the special 'Unlimited' tier which

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/lifecycletest/mutualssl/api-manager.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/lifecycletest/mutualssl/api-manager.xml
@@ -278,6 +278,18 @@
         <EnableTokenHashMode>false</EnableTokenHashMode>
     </OAuthConfigurations>
 
+    <TokenRevocationNotifiers class="org.wso2.carbon.apimgt.keymgt.events.TokenRevocationNotifierImpl">
+        <RealtimeNotifier>
+            <Property name="ttl">5000</Property>
+        </RealtimeNotifier>
+        <PersistentNotifier>
+            <Property name="hostname">https://localhost:2379/v2/keys/jti/</Property>
+            <Property name="ttl">5000</Property>
+            <Property name="username">root</Property>
+            <Property name="password">root</Property>
+        </PersistentNotifier>
+    </TokenRevocationNotifiers>
+
     <!-- Settings related to managing API access tiers. -->
     <TierManagement>
         <!-- Enable the providers to expose their APIs over the special 'Unlimited' tier which

--- a/modules/integration/tests-integration/tests-jmeter/src/test/resources/artifacts/AM/configFiles/jwt_wsclient_config/api-manager.xml
+++ b/modules/integration/tests-integration/tests-jmeter/src/test/resources/artifacts/AM/configFiles/jwt_wsclient_config/api-manager.xml
@@ -257,6 +257,18 @@
         <EncryptPersistedTokens>false</EncryptPersistedTokens>
     </OAuthConfigurations>
 
+    <TokenRevocationNotifiers class="org.wso2.carbon.apimgt.keymgt.events.TokenRevocationNotifierImpl">
+        <RealtimeNotifier>
+            <Property name="ttl">5000</Property>
+        </RealtimeNotifier>
+        <PersistentNotifier>
+            <Property name="hostname">https://localhost:2379/v2/keys/jti/</Property>
+            <Property name="ttl">5000</Property>
+            <Property name="username">root</Property>
+            <Property name="password">root</Property>
+        </PersistentNotifier>
+    </TokenRevocationNotifiers>
+
     <!-- Settings related to managing API access tiers. -->
     <TierManagement>
         <!-- Enable the providers to expose their APIs over the special 'Unlimited' tier which

--- a/modules/integration/tests-platform/src/test/resources/artifacts/AM/configFiles/emailusernametest/api-manager.xml
+++ b/modules/integration/tests-platform/src/test/resources/artifacts/AM/configFiles/emailusernametest/api-manager.xml
@@ -257,6 +257,18 @@
         <EncryptPersistedTokens>false</EncryptPersistedTokens>
     </OAuthConfigurations>
 
+    <TokenRevocationNotifiers class="org.wso2.carbon.apimgt.keymgt.events.TokenRevocationNotifierImpl">
+        <RealtimeNotifier>
+            <Property name="ttl">5000</Property>
+        </RealtimeNotifier>
+        <PersistentNotifier>
+            <Property name="hostname">https://localhost:2379/v2/keys/jti/</Property>
+            <Property name="ttl">5000</Property>
+            <Property name="username">root</Property>
+            <Property name="password">root</Property>
+        </PersistentNotifier>
+    </TokenRevocationNotifiers>
+
     <!-- Settings related to managing API access tiers. -->
     <TierManagement>
         <!-- Enable the providers to expose their APIs over the special 'Unlimited' tier which

--- a/modules/integration/tests-platform/src/test/resources/artifacts/AM/configFiles/hostobjecttest/api-manager.xml
+++ b/modules/integration/tests-platform/src/test/resources/artifacts/AM/configFiles/hostobjecttest/api-manager.xml
@@ -258,6 +258,18 @@
         <EncryptPersistedTokens>false</EncryptPersistedTokens>
     </OAuthConfigurations>
 
+    <TokenRevocationNotifiers class="org.wso2.carbon.apimgt.keymgt.events.TokenRevocationNotifierImpl">
+        <RealtimeNotifier>
+            <Property name="ttl">5000</Property>
+        </RealtimeNotifier>
+        <PersistentNotifier>
+            <Property name="hostname">https://localhost:2379/v2/keys/jti/</Property>
+            <Property name="ttl">5000</Property>
+            <Property name="username">root</Property>
+            <Property name="password">root</Property>
+        </PersistentNotifier>
+    </TokenRevocationNotifiers>
+
     <!-- Settings related to managing API access tiers. -->
     <TierManagement>
         <!-- Enable the providers to expose their APIs over the special 'Unlimited' tier which

--- a/modules/integration/tests-platform/src/test/resources/artifacts/AM/configFiles/statistics/api-manager.xml
+++ b/modules/integration/tests-platform/src/test/resources/artifacts/AM/configFiles/statistics/api-manager.xml
@@ -258,6 +258,18 @@
         <EncryptPersistedTokens>false</EncryptPersistedTokens>
     </OAuthConfigurations>
 
+    <TokenRevocationNotifiers class="org.wso2.carbon.apimgt.keymgt.events.TokenRevocationNotifierImpl">
+        <RealtimeNotifier>
+            <Property name="ttl">5000</Property>
+        </RealtimeNotifier>
+        <PersistentNotifier>
+            <Property name="hostname">https://localhost:2379/v2/keys/jti/</Property>
+            <Property name="ttl">5000</Property>
+            <Property name="username">root</Property>
+            <Property name="password">root</Property>
+        </PersistentNotifier>
+    </TokenRevocationNotifiers>
+
     <!-- Settings related to managing API access tiers. -->
     <TierManagement>
         <!-- Enable the providers to expose their APIs over the special 'Unlimited' tier which

--- a/modules/integration/tests-platform/src/test/resources/artifacts/AM/configFiles/tokenTest/api-manager.xml
+++ b/modules/integration/tests-platform/src/test/resources/artifacts/AM/configFiles/tokenTest/api-manager.xml
@@ -258,6 +258,18 @@
         <EncryptPersistedTokens>false</EncryptPersistedTokens>
     </OAuthConfigurations>
 
+    <TokenRevocationNotifiers class="org.wso2.carbon.apimgt.keymgt.events.TokenRevocationNotifierImpl">
+        <RealtimeNotifier>
+            <Property name="ttl">5000</Property>
+        </RealtimeNotifier>
+        <PersistentNotifier>
+            <Property name="hostname">https://localhost:2379/v2/keys/jti/</Property>
+            <Property name="ttl">5000</Property>
+            <Property name="username">root</Property>
+            <Property name="password">root</Property>
+        </PersistentNotifier>
+    </TokenRevocationNotifiers>
+
     <!-- Settings related to managing API access tiers. -->
     <TierManagement>
         <!-- Enable the providers to expose their APIs over the special 'Unlimited' tier which

--- a/modules/integration/tests-platform/src/test/resources/artifacts/AM/configFiles/usagemonitortest/api-manager.xml
+++ b/modules/integration/tests-platform/src/test/resources/artifacts/AM/configFiles/usagemonitortest/api-manager.xml
@@ -257,6 +257,18 @@
         <EncryptPersistedTokens>false</EncryptPersistedTokens>
     </OAuthConfigurations>
 
+    <TokenRevocationNotifiers class="org.wso2.carbon.apimgt.keymgt.events.TokenRevocationNotifierImpl">
+        <RealtimeNotifier>
+            <Property name="ttl">5000</Property>
+        </RealtimeNotifier>
+        <PersistentNotifier>
+            <Property name="hostname">https://localhost:2379/v2/keys/jti/</Property>
+            <Property name="ttl">5000</Property>
+            <Property name="username">root</Property>
+            <Property name="password">root</Property>
+        </PersistentNotifier>
+    </TokenRevocationNotifiers>
+
     <!-- Settings related to managing API access tiers. -->
     <TierManagement>
         <!-- Enable the providers to expose their APIs over the special 'Unlimited' tier which


### PR DESCRIPTION
## Purpose

ASM classes were being exposed by two jars. This introduced web app deployment issues. Therefore removing one jar via bin.xml for now.

JWT token revocation feature has introduced new configs. This PR updates the integration test api-manager.xml with those.