### PR TITLE
Removed optional scope validator from identity.xml

### DIFF
--- a/modules/distribution/product/identity_config_change.xml
+++ b/modules/distribution/product/identity_config_change.xml
@@ -12,6 +12,11 @@
       <after>//s:Server/s:OAuth/s:OAuthCallbackHandlers</after>
       <value><![CDATA[<OAuthScopeValidator class="org.wso2.carbon.identity.oauth2.validators.JDBCScopeValidator"/>]]></value>
    </add>
+
+    <remove>
+        <name>//s:Server/s:OAuth/s:ScopeValidators</name>
+    </remove>
+
    <!-- Add the ntlm grant type validator config element -->
    <add>
       <after>//s:Server/s:OAuth/s:SupportedGrantTypes/s:SupportedGrantType[s:GrantTypeName='iwa:ntlm']/s:GrantTypeName</after>


### PR DESCRIPTION
## Purpose
Removed Optional Scope Validations (<ScopeValidators>) from identity.xml because by default APIM use  <OAuthScopeValidator> to validate scopes


