### PR TITLE
[2.x] Feature/Preserve API state on export/import and update

### DIFF
--- a/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/APIService.java
+++ b/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/APIService.java
@@ -74,7 +74,11 @@ public class APIService {
     @Path("/export-api")
     @Produces("application/zip")
     public Response exportAPI(@QueryParam("name") String name, @QueryParam("version") String version,
-            @QueryParam("provider") String providerName, @Context HttpHeaders httpHeaders) {
+            @QueryParam("provider") String providerName, @QueryParam("preserveStatus") String preserveStatus, @Context HttpHeaders httpHeaders) {
+        boolean isStatusPreserved = true;
+        if(APIImportExportConstants.STATUS_FALSE.equals(preserveStatus)){
+            isStatusPreserved = false;
+        }
 
         if (name == null || version == null || providerName == null) {
             log.error("Invalid API Information ");
@@ -87,7 +91,6 @@ public class APIService {
         boolean isTenantFlowStarted = false;
 
         try {
-
             Response authorizationResponse = AuthenticatorUtil.authorizeUser(httpHeaders);
             if (Response.Status.OK.getStatusCode() != authorizationResponse.getStatus()) {
                 return authorizationResponse;
@@ -146,7 +149,7 @@ public class APIService {
                 isTenantFlowStarted = true;
             }
 
-            Response apiResourceRetrievalResponse = APIExportUtil.retrieveApiToExport(apiIdentifier, userName);
+            Response apiResourceRetrievalResponse = APIExportUtil.retrieveApiToExport(apiIdentifier, userName, isStatusPreserved);
 
             //Retrieve resources : thumbnail, meta information, wsdl, sequences and documents
             // available for the exporting API

--- a/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/lifecycle/LifeCycle.java
+++ b/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/lifecycle/LifeCycle.java
@@ -1,0 +1,56 @@
+/*
+ *
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ * /
+ */
+
+package org.wso2.carbon.apimgt.importexport.lifecycle;
+
+import java.util.HashMap;
+
+/**
+ * Represent lifecycle of an API
+ */
+public class LifeCycle {
+    private HashMap<String, LifeCycleTransition> stateHashMap;
+
+    /**
+     * Initialize lifecycle
+     */
+    public LifeCycle() {
+        this.stateHashMap = new HashMap<String, LifeCycleTransition>();
+    }
+
+    /**
+     * Adds a state for a lifecycle
+     * @param state State to be added
+     * @param transition Transition associated with state
+     */
+    public void addLifeCycleState(String state, LifeCycleTransition transition){
+        stateHashMap.put(state, transition);
+    }
+
+    /**
+     * Returns the transition associated with state
+     * @param state State to get transitions
+     * @return Transition associated with state
+     */
+    public LifeCycleTransition getTransition(String state){
+        if (!stateHashMap.containsKey(state)){
+            return null;
+        }
+        return stateHashMap.get(state);
+    }
+}

--- a/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/lifecycle/LifeCycleTransition.java
+++ b/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/lifecycle/LifeCycleTransition.java
@@ -1,0 +1,56 @@
+/*
+ *
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ * /
+ */
+
+package org.wso2.carbon.apimgt.importexport.lifecycle;
+
+import java.util.HashMap;
+
+/**
+ * This class represents lifecycle transition
+ */
+public class LifeCycleTransition {
+    private HashMap<String, String> transitions;
+
+    /**
+     * Initialize class
+     */
+    public LifeCycleTransition() {
+        this.transitions = new HashMap<String, String>();
+    }
+
+    /**
+     * Returns action required to transit to state
+     * @param state State to get action
+     * @return lifecycle action associated or null if not found
+     */
+    public String getAction(String state){
+        if (!transitions.containsKey(state)){
+            return null;
+        }
+        return transitions.get(state);
+    }
+
+    /**
+     * Adds a transition
+     * @param targetStatus target status
+     * @param action action associated with target
+     */
+    public void addTransition(String targetStatus, String action) {
+        transitions.put(targetStatus, action);
+    }
+}

--- a/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/utils/APIExportUtil.java
+++ b/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/utils/APIExportUtil.java
@@ -243,11 +243,13 @@ public class APIExportUtil {
             apiToReturn.setStatus(APIConstants.CREATED);
         }
 
+        // export certificates
+        exportEndpointCertificates(apiToReturn, tenantId, provider);
+
         //export meta information
         exportMetaInformation(apiToReturn, registry);
 
         return Response.ok().build();
-
     }
 
     /**

--- a/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/utils/APIExportUtil.java
+++ b/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/utils/APIExportUtil.java
@@ -187,7 +187,7 @@ public class APIExportUtil {
      * @return HttpResponse indicating whether resource retrieval got succeed or not
      * @throws APIExportException If an error occurs while retrieving API related resources
      */
-    public static Response retrieveApiToExport(APIIdentifier apiID, String userName) throws APIExportException {
+    public static Response retrieveApiToExport(APIIdentifier apiID, String userName, boolean isStatusPreserved) throws APIExportException {
 
         API apiToReturn;
         String archivePath = archiveBasePath.concat(File.separator + apiID.getApiName() + "-" +
@@ -238,8 +238,10 @@ public class APIExportUtil {
         //export sequences
         exportSequences(apiToReturn, apiID, registry);
 
-        //set API status to created
-        apiToReturn.setStatus(APIConstants.CREATED);
+        //set API status to created if status is not preserved
+        if (!isStatusPreserved) {
+            apiToReturn.setStatus(APIConstants.CREATED);
+        }
 
         //export meta information
         exportMetaInformation(apiToReturn, registry);

--- a/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/utils/APIImportUtil.java
+++ b/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/utils/APIImportUtil.java
@@ -458,6 +458,7 @@ public final class APIImportUtil {
         addAPISequences(pathToArchive, importedApi);
         addAPISpecificSequences(pathToArchive, importedApi);
         addAPIWsdl(pathToArchive, importedApi);
+        addEndpointCertificates(pathToArchive, importedApi);
     }
 
     /**
@@ -621,6 +622,7 @@ public final class APIImportUtil {
         addAPISequences(pathToArchive, importedApi);
         addAPISpecificSequences(pathToArchive, importedApi);
         addAPIWsdl(pathToArchive, importedApi);
+        addEndpointCertificates(pathToArchive, importedApi);
     }
 
     /**

--- a/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/utils/APIImportUtil.java
+++ b/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/utils/APIImportUtil.java
@@ -206,7 +206,7 @@ public final class APIImportUtil {
         // Parse DOM of APILifeCycle
         try {
             String data = provider.getLifecycleConfiguration(tenantDomain);
-            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            DocumentBuilderFactory factory = APIUtil.getSecuredDocumentBuilder();
             DocumentBuilder builder = factory.newDocumentBuilder();
             ByteArrayInputStream inputStream = new ByteArrayInputStream(data.getBytes("UTF-8"));
             Document doc = builder.parse(inputStream);

--- a/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/utils/APIImportUtil.java
+++ b/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/utils/APIImportUtil.java
@@ -430,12 +430,12 @@ public final class APIImportUtil {
                 }
                 // This is required to make url templates and scopes get effected.
                 provider.updateAPI(importedApi);
+            }
 
-                // Change API lifecycle if state transition is required
-                if (lifecycleAction != null && !lifecycleAction.isEmpty()) {
-                    log.info("Changing lifecycle from " + currentStatus + " to " + targetStatus);
-                    provider.changeLifeCycleStatus(importedApi.getId(), lifecycleAction);
-                }
+            // Change API lifecycle if state transition is required
+            if (lifecycleAction != null && !lifecycleAction.isEmpty()) {
+                log.info("Changing lifecycle from " + currentStatus + " to " + targetStatus);
+                provider.changeLifeCycleStatus(importedApi.getId(), lifecycleAction);
             }
         } catch (APIManagementException e) {
             //Error is logged and APIImportException is thrown because adding API and swagger are mandatory steps

--- a/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/utils/APIImportUtil.java
+++ b/modules/api-import-export/src/main/java/org/wso2/carbon/apimgt/importexport/utils/APIImportUtil.java
@@ -66,7 +66,17 @@ import org.xml.sax.SAXException;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-import java.io.*;
+import java.io.BufferedInputStream;
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
@@ -433,7 +443,7 @@ public final class APIImportUtil {
             }
 
             // Change API lifecycle if state transition is required
-            if (lifecycleAction != null && !lifecycleAction.isEmpty()) {
+            if (StringUtils.isEmpty(lifecycleAction)) {
                 log.info("Changing lifecycle from " + currentStatus + " to " + targetStatus);
                 provider.changeLifeCycleStatus(importedApi.getId(), lifecycleAction);
             }


### PR DESCRIPTION
## Purpose
- Preserve status on exporting APIs
- Importing/Updating APIs allows changing the status(from current state upto 1 step)

## Goals
Allow smooth state transitions in CI/CD pipelines

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
- Users now can export APIs with status(using a flag in CLI tool)
- Users can import/update APIs with status transitions

## Release note
- Allows preserving the status of an API on export
- Allows import/update APIs while preserving API status(Please note that this only supported from current status up to 1 reachable status)
