### PR TITLE
Update event-processing version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1177,7 +1177,7 @@
         <carbon.metrics.version>1.2.5</carbon.metrics.version>
         <!-- MB Features -->
         <carbon.messaging.version>3.2.70</carbon.messaging.version>
-        <carbon.event-processing.version>2.1.28</carbon.event-processing.version>
+        <carbon.event-processing.version>2.1.30</carbon.event-processing.version>
         <andes.version>3.2.99</andes.version>
         <orbit.version.geronimo-jms_1.1_spec>1.1.1.wso2v1</orbit.version.geronimo-jms_1.1_spec>
         <commons-digester.version>1.8.1</commons-digester.version>


### PR DESCRIPTION
This is to avoid packing two versions of commons-lang3