### PR TITLE
Remove rest.api.util jar from web-apps lib directory

### DIFF
--- a/modules/distribution/product/pom.xml
+++ b/modules/distribution/product/pom.xml
@@ -353,6 +353,22 @@
                             <goal>run</goal>
                         </goals>
                     </execution>
+                    <execution>
+                        <id>move-rest-api-util-jar</id>
+                        <phase>prepare-package</phase>
+                        <configuration>
+                            <target>
+                                <copy todir="../../p2-profile/product/target/wso2carbon-core-${carbon.kernel.version}/lib/runtimes/cxf3/">
+                                    <fileset dir="../../p2-profile/product/target/wso2carbon-core-${carbon.kernel.version}/repository/components/plugins/">
+                                        <include name="org.wso2.carbon.apimgt.rest.api.util_*.jar"/>
+                                    </fileset>
+                                </copy>
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
                 </executions>
             </plugin>
 

--- a/modules/distribution/product/src/main/assembly/bin.xml
+++ b/modules/distribution/product/src/main/assembly/bin.xml
@@ -105,7 +105,7 @@
                 <exclude>**/repository/components/plugins/cassandra-thrift_1.2.13.wso2v4.jar</exclude>
 
                 <exclude>**/repository/components/plugins/netty-all_4.0.23.wso2v1.jar</exclude>
-
+                <exclude>**/repository/components/plugins/org.wso2.carbon.apimgt.rest.api.util_*.jar</exclude>
                 <exclude>
                     **/repository/components/plugins/org.wso2.carbon.event.output.adapter.sms_${carbon.analytics.common.version}.jar
                 </exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -1151,7 +1151,7 @@
         <carbon.analytics.common.version>5.2.1</carbon.analytics.common.version>
 
         <!-- APIM Component Version -->
-        <carbon.apimgt.version>6.5.56-SNAPSHOT</carbon.apimgt.version>
+        <carbon.apimgt.version>6.5.56</carbon.apimgt.version>
         <carbon.apimgt.imp.pkg.version>[6.5.0, 7.0.0)</carbon.apimgt.imp.pkg.version>
 
         <!-- Carbon Registry -->

--- a/pom.xml
+++ b/pom.xml
@@ -1151,7 +1151,7 @@
         <carbon.analytics.common.version>5.2.1</carbon.analytics.common.version>
 
         <!-- APIM Component Version -->
-        <carbon.apimgt.version>6.5.56</carbon.apimgt.version>
+        <carbon.apimgt.version>6.5.56-SNAPSHOT</carbon.apimgt.version>
         <carbon.apimgt.imp.pkg.version>[6.5.0, 7.0.0)</carbon.apimgt.imp.pkg.version>
 
         <!-- Carbon Registry -->

--- a/pom.xml
+++ b/pom.xml
@@ -1151,7 +1151,7 @@
         <carbon.analytics.common.version>5.2.1</carbon.analytics.common.version>
 
         <!-- APIM Component Version -->
-        <carbon.apimgt.version>6.5.34</carbon.apimgt.version>
+        <carbon.apimgt.version>6.5.56-SNAPSHOT</carbon.apimgt.version>
         <carbon.apimgt.imp.pkg.version>[6.5.0, 7.0.0)</carbon.apimgt.imp.pkg.version>
 
         <!-- Carbon Registry -->


### PR DESCRIPTION
This PR removes the org.wso2.carbon.apimgt.rest.api.util jar from each web-app's lib directory and adds the same jar into /lib/runtimes/cxf3/ directory, so that it will be picked in the runtime.

Relevant PRs - https://github.com/wso2/carbon-apimgt/pull/6793