### PR TITLE
Fixing test failure due to 'oauth.extensions.token_generator' alias change from identity upgrade

### DIFF
--- a/modules/distribution/product/src/main/resources/conf/default.json
+++ b/modules/distribution/product/src/main/resources/conf/default.json
@@ -1,5 +1,5 @@
 {
-  "oauth.extension.token_generator": "org.wso2.carbon.apimgt.keymgt.issuers.APIMTokenIssuer",
+  "oauth.extensions.token_generator": "org.wso2.carbon.apimgt.keymgt.issuers.APIMTokenIssuer",
   "server.base_path,": "${carbon.protocol}://${carbon.host}:${carbon.management.port}",
   "server.default_cache_timeout": "15",
   "default_cache_timeout.force_local_cache": false,

--- a/pom.xml
+++ b/pom.xml
@@ -1157,7 +1157,7 @@
         <carbon.analytics.common.version>5.2.11</carbon.analytics.common.version>
 
         <!-- APIM Component Version -->
-        <carbon.apimgt.version>6.5.129</carbon.apimgt.version>
+        <carbon.apimgt.version>6.5.137</carbon.apimgt.version>
         <carbon.apimgt.imp.pkg.version>[6.5.0, 7.0.0)</carbon.apimgt.imp.pkg.version>
 
         <!-- Carbon Registry -->


### PR DESCRIPTION
Fixed the issue introduced from https://github.com/wso2/carbon-identity-framework/pull/2425