### PR TITLE
Add missing 'default' server_role for deployment.toml

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/originalFile/deployment.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/originalFile/deployment.toml
@@ -4,6 +4,7 @@ node_ip = "127.0.0.1"
 #offset=0
 mode = "single" #single or ha
 base_path = "${carbon.protocol}://${carbon.host}:${carbon.management.port}"
+server_role = "default"
 
 [super_admin]
 username = "admin"

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/toml_config/case1/deployment.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/toml_config/case1/deployment.toml
@@ -4,6 +4,7 @@ node_ip = "127.0.0.1"
 #offset=0
 mode = "single" #single or ha
 base_path = "${carbon.protocol}://${carbon.host}:${carbon.management.port}"
+server_role = "default"
 
 [super_admin]
 username = "admin"


### PR DESCRIPTION
Fixing https://github.com/wso2/product-apim/issues/6300