### PR TITLE
modify sp_name_regex to allow sp name with spaces

### DIFF
--- a/modules/distribution/product/src/main/conf/deployment.toml
+++ b/modules/distribution/product/src/main/conf/deployment.toml
@@ -220,3 +220,6 @@ allow_credentials = false
 [[event_handler]]
 name="userPostSelfRegistration"
 subscriptions=["POST_ADD_USER"]
+
+[service_provider]
+sp_name_regex = "^[\\sa-zA-Z0-9._-]*$"


### PR DESCRIPTION
This PR fixes https://github.com/wso2/product-apim/issues/5849