### PR TITLE
Remove CacheExtensionHandler from RevokeAPI

### DIFF
--- a/modules/distribution/product/src/main/conf/synapse-configs/default/api/_RevokeAPI_.xml
+++ b/modules/distribution/product/src/main/conf/synapse-configs/default/api/_RevokeAPI_.xml
@@ -19,7 +19,6 @@
         </outSequence>
     </resource>
     <handlers>
-        <handler class="org.wso2.carbon.apimgt.gateway.handlers.ext.APIManagerCacheExtensionHandler"/>
         <handler class="org.wso2.carbon.apimgt.gateway.handlers.common.SynapsePropertiesHandler"/>
     </handlers>
 </api>


### PR DESCRIPTION
We no longer need the cacheExtensionHandler to invalidate the cache when a revocation happens. We now have a new mechanism to do this and hence removing the handler.