### PR TITLE
resolving startup issue in api-publisher profile

### DIFF
--- a/modules/p2-profile/product/pom.xml
+++ b/modules/p2-profile/product/pom.xml
@@ -2633,6 +2633,10 @@
                                     <version>${carbon.identity.version}</version>
                                 </feature>
                                 <feature>
+                                    <id>org.wso2.carbon.email.mgt.feature.group</id>
+                                    <version>${carbon.identity.event.handler.notification.version}</version>
+                                </feature>
+                                <feature>
                                     <id>org.wso2.carbon.um.ws.service.server.feature.group</id>
                                     <version>${carbon.identity-user-ws.version}</version>
                                 </feature>


### PR DESCRIPTION
## Issues
product-apim: wso2/product-apim#7161

## Methodology
adding the missing "org.wso2.carbon.email.mgt.feature.group" feature to the api-publisher profile in p2 profile generation pom.