### PR TITLE
resolving gateway-worker profile startup issue

### DIFF
--- a/modules/p2-profile/product/pom.xml
+++ b/modules/p2-profile/product/pom.xml
@@ -1731,6 +1731,10 @@
                                     <id>org.wso2.carbon.identity.context.rewrite.server.feature.group</id>
                                     <version>${carbon.identity.auth.version}</version>
                                 </feature>
+                                <feature>
+                                    <id>org.wso2.carbon.email.mgt.feature.group</id>
+                                    <version>${carbon.identity.event.handler.notification.version}</version>
+                                </feature>
                             </features>
                         </configuration>
                     </execution>


### PR DESCRIPTION
## Issues

product-apim: wso2/product-apim#7161

## Methodology

adding the missing "org.wso2.carbon.email.mgt.feature.group" feature to the gateway-worker profile in p2 profile generation pom.