### PR TITLE
Add tenant customizations for APIM login pages

### DIFF
--- a/modules/distribution/product/src/main/extensions/header.jsp
+++ b/modules/distribution/product/src/main/extensions/header.jsp
@@ -19,14 +19,80 @@
 
 <!-- localize.jsp MUST already be included in the calling script -->
 
+<%@ page import="java.io.FileReader" %>
+<%@ page import="org.json.simple.parser.JSONParser"%>
+<%@ page import="org.json.simple.JSONObject"%>
+<%@ page import="java.net.URI"%>
+
+<%
+    String tenant = request.getParameter("tenantDomain");
+    if (tenant == null) {
+        String cb = request.getParameter("callback");
+        if (cb != null) {
+            URI uri = new URI(cb);
+            String decodedValue = uri.getQuery();
+            String[] params = decodedValue.split("&");
+            for (String param : params) {
+                if (param.startsWith("tenantDomain=")) {
+                    String[] keyVal = param.split("=");
+                    tenant = keyVal[1];
+                }
+            }
+        }
+    }
+
+    String headerTitle = "API Manager";
+    String pageTitle = "WSO2 API Manager";
+    String footerText = "WSO2 API Manager";
+    String faviconSrc = "libs/theme/assets/images/favicon.ico";
+
+    if (tenant != null) {
+        String current = new File(".").getCanonicalPath();
+        String tenantConfLocation = "/repository/deployment/server/jaggeryapps/devportal/site/public/tenant_themes";
+        String tenantThemeDirectoryName = tenant;
+        String tenantThemeFile =  current + tenantConfLocation + "/" + tenantThemeDirectoryName + "/" + "loginTheme.json";
+        File directory = new File(current + tenantConfLocation + "/" + tenantThemeDirectoryName);
+        if (directory != null && directory.exists() && directory.isDirectory()) {
+            File themeFile = new File(tenantThemeFile);
+            if (themeFile != null && themeFile.exists() && themeFile.isFile()) {
+                FileReader fr = new FileReader(themeFile);
+                JSONParser parser = new JSONParser();
+                Object obj = parser.parse(fr);
+                JSONObject jsonObject = (JSONObject) obj;
+
+                pageTitle = (String)jsonObject.get("title") != null ? (String)jsonObject.get("title") : "WSO2 API Manager";
+
+                JSONObject headerThemeObj = (JSONObject)jsonObject.get("header");
+                if (headerThemeObj != null) {
+                    headerTitle = (String)(headerThemeObj.get("title")) != null ? (String)(headerThemeObj.get("title")) : "API Manager";
+                }
+
+                JSONObject footerThemeObj = (JSONObject)jsonObject.get("footer");
+                if (footerThemeObj != null) {
+                    footerText = (String)(footerThemeObj.get("name"));
+                }
+
+                JSONObject faviconThemeObj = (JSONObject)jsonObject.get("favicon");
+                if (faviconThemeObj != null) {
+                    faviconSrc = (String)(faviconThemeObj.get("src"));
+                }
+            }
+        }
+    }
+    request.setAttribute("headerTitle", headerTitle);
+    request.setAttribute("pageTitle", pageTitle);
+    request.setAttribute("footerText", footerText);
+    request.setAttribute("faviconSrc", faviconSrc);
+%>
+
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<link rel="icon" href="libs/theme/assets/images/favicon.ico" type="image/x-icon"/>
+<link rel="icon" href=<%=request.getAttribute("faviconSrc")%> type="image/x-icon"/>
 <link href="libs/theme/wso2-default.min.css" rel="stylesheet">
 
-<title>WSO2 API Manager</title>
+<title><%=request.getAttribute("pageTitle")%></title>
 
 <style>
     html, body {

--- a/modules/distribution/product/src/main/extensions/product-footer.jsp
+++ b/modules/distribution/product/src/main/extensions/product-footer.jsp
@@ -22,7 +22,7 @@
 <!-- footer -->
 <footer class="footer" style="text-align: center">
     <div class="container-fluid">
-        <p>WSO2 API Manager | &copy;
+        <p><%=request.getAttribute("footerText")%> | &copy;
             <script>document.write(new Date().getFullYear());</script>
         </p>
     </div>

--- a/modules/distribution/product/src/main/extensions/product-title.jsp
+++ b/modules/distribution/product/src/main/extensions/product-title.jsp
@@ -18,6 +18,7 @@
 
 <!-- localize.jsp MUST already be included in the calling script -->
 
+<% if ("API Manager".equals(request.getAttribute("headerTitle"))) { %>
 <div class="product-title">
     <div class="theme-icon inline auto transparent product-logo">
       <svg viewBox="29 -6.639 72 27.639">
@@ -29,3 +30,8 @@
       </div>
       <h1 class="product-title-text">API Manager</h1>
 </div>
+<% } else { %>
+<div class="product-title">
+    <h1 class="product-title-text"><%=request.getAttribute("headerTitle")%></h1>
+</div>
+<% } %>


### PR DESCRIPTION
NOTE
---------
Do not merge this PR until the per tenant SPs for APIM apps is done.

Feature Description
---------------------------
With this, users are able to customize texts and images in APIM login pages. A sample view would be like below.
 
![custom_account_recovery](https://user-images.githubusercontent.com/28379317/72869722-22bdfe00-3d0c-11ea-8725-0540afbec03d.png)


![custom_authend](https://user-images.githubusercontent.com/28379317/72869729-26518500-3d0c-11ea-8f4a-1b886354fd40.png)

How to use this feature
-------------------------------
1. Enable per tenant SP creation by adding 
```
"EnablePerTenantServiceProviderCreation" : "true" 
```
to tenant-conf.json.

2. Configure a custom store URL for tenant.

3. Create a loginTheme.json file containing the custom texts to be added to UI. A sample file would be like below.
```json
{
	"title" : "Test Company Title",
	"header" : {
		"title" : "Test Company" 	
	},
       "footer" : {
		"name" : "Test"
	},  
	"favicon" : {
		"src" : "libs/theme/assets/images/icon.ico"
	}
}
```
4. Zip this file along with defaultTheme.json(if you wish to apply a store tenant theme) and upload as a tenant theme via admin portal.

5. Copy the favicon icon to /libs/theme/assets/images in repository/deployment/server/webapps/accountrecoveryendpoint and repository/deployment/server/webapps/authenticationendpoint. 
