### PR TITLE
Add improvements to tenant login themeing

### DIFF
--- a/modules/distribution/product/src/main/extensions/basicauth.jsp
+++ b/modules/distribution/product/src/main/extensions/basicauth.jsp
@@ -267,19 +267,44 @@
 
     <div class="ui divider hidden"></div>
 
-    <div class="ui visible warning message">
-        <%=AuthenticationEndpointUtil.i18n(resourceBundle, "privacy.policy.cookies.short.description")%>
-        <a href="cookie_policy.do" target="policy-pane">
-            <%=AuthenticationEndpointUtil.i18n(resourceBundle, "privacy.policy.cookies")%>
-        </a>
-        <%=AuthenticationEndpointUtil.i18n(resourceBundle, "privacy.policy.for.more.details")%>
-    </div>
-    <div class="ui visible warning message">
-        <%=AuthenticationEndpointUtil.i18n(resourceBundle, "privacy.policy.privacy.short.description")%>
-        <a href="privacy_policy.do" target="policy-pane">
-            <%=AuthenticationEndpointUtil.i18n(resourceBundle, "privacy.policy.general")%>
-        </a>
-    </div>
+    <%
+    boolean showCookiePolicy = (Boolean)request.getAttribute("showCookiePolicy");
+    if (showCookiePolicy) {
+    %>
+        <div class="ui visible warning message">
+            <%
+            String cookiePolicyText = (String)request.getAttribute("cookiePolicyText");
+            if (!StringUtils.isEmpty(cookiePolicyText)) {
+            %>
+                <%=cookiePolicyText%>
+            <% } else { %>
+                <%=AuthenticationEndpointUtil.i18n(resourceBundle, "privacy.policy.cookies.short.description")%>
+            <% } %>
+            <a href="cookie_policy.do" target="policy-pane">
+                <%=AuthenticationEndpointUtil.i18n(resourceBundle, "privacy.policy.cookies")%>
+            </a>
+            <%=AuthenticationEndpointUtil.i18n(resourceBundle, "privacy.policy.for.more.details")%>
+        </div>
+    <% } %>
+
+    <%
+    boolean showPrivacyPolicy = (Boolean)request.getAttribute("showPrivacyPolicy");
+    if (showPrivacyPolicy) {
+    %>
+        <div class="ui visible warning message">
+            <%
+            String privacyPolicyText = (String)request.getAttribute("privacyPolicyText");
+            if (!StringUtils.isEmpty(privacyPolicyText)) {
+            %>
+                <%=privacyPolicyText%>
+            <% } else { %>
+                <%=AuthenticationEndpointUtil.i18n(resourceBundle, "privacy.policy.privacy.short.description")%>
+            <% } %>
+            <a href="privacy_policy.do" target="policy-pane">
+                <%=AuthenticationEndpointUtil.i18n(resourceBundle, "privacy.policy.general")%>
+            </a>
+        </div>
+    <% } %>
     <div class="ui divider hidden"></div>
 
     <div class="ui two column stackable grid">

--- a/modules/distribution/product/src/main/extensions/header.jsp
+++ b/modules/distribution/product/src/main/extensions/header.jsp
@@ -46,17 +46,25 @@
     String pageTitle = "WSO2 API Manager";
     String footerText = "WSO2 API Manager";
     String faviconSrc = "libs/theme/assets/images/favicon.ico";
+    String logoSrc = null;
+    String logoHeight = "50";
+    String logoWidth = "50";
+    String logoAltText = "";
     File customCSSFile = null;
     String customCSS = "";
     String tenantThemeDirectoryName = "";
+    boolean showCookiePolicy = true;
+    boolean showPrivacyPolicy = true;
+    String cookiePolicyText = null;
+    String privacyPolicyText = null;
 
     if (tenant != null) {
         String current = new File(".").getCanonicalPath();
-        String tenantConfLocation = "/repository/deployment/server/jaggeryapps/devportal/site/public/tenant_themes";
+        String tenantConfLocation = "/repository/deployment/server/jaggeryapps/devportal/site/public/tenant_themes/";
         tenantThemeDirectoryName = tenant;
-        String tenantThemeFile =  current + tenantConfLocation + "/" + tenantThemeDirectoryName + "/" + "loginTheme.json";
-        customCSS = current + tenantConfLocation + "/" + tenantThemeDirectoryName + "/" + "loginTheme.css";
-        File directory = new File(current + tenantConfLocation + "/" + tenantThemeDirectoryName);
+        String tenantThemeFile =  current + tenantConfLocation + tenantThemeDirectoryName + "/login/" + "loginTheme.json";
+        customCSS = current + tenantConfLocation + tenantThemeDirectoryName + "/login/css/" + "loginTheme.css";
+        File directory = new File(current + tenantConfLocation + tenantThemeDirectoryName);
         if (directory != null && directory.exists() && directory.isDirectory()) {
             File themeFile = new File(tenantThemeFile);
             customCSSFile = new File(customCSS);
@@ -80,7 +88,35 @@
 
                 JSONObject faviconThemeObj = (JSONObject)jsonObject.get("favicon");
                 if (faviconThemeObj != null) {
-                    faviconSrc = (String)(faviconThemeObj.get("src"));
+                    String fileName = (String)(faviconThemeObj.get("src"));
+                    if (!StringUtils.isEmpty(fileName)) {
+                        faviconSrc = "/devportal/site/public/tenant_themes/" + tenantThemeDirectoryName + "/login/images/"
+                                  + fileName;
+                    }
+                }
+
+                JSONObject logoThemeObj = (JSONObject)jsonObject.get("logo");
+                if (logoThemeObj != null) {
+                    String fileName = (String)(logoThemeObj.get("src"));
+                    if (!StringUtils.isEmpty(fileName)) {
+                        logoSrc = "/devportal/site/public/tenant_themes/" + tenantThemeDirectoryName + "/login/images/"
+                                  + fileName;
+                    }
+                    logoHeight = (String)(logoThemeObj.get("height")) != null ? (String)(logoThemeObj.get("height")) : logoHeight;
+                    logoWidth = (String)(logoThemeObj.get("width")) != null ? (String)(logoThemeObj.get("width")) : logoWidth;
+                    logoAltText = (String)(logoThemeObj.get("alt"));
+                }
+
+                JSONObject cookiePolicyThemeObj = (JSONObject)jsonObject.get("cookie-policy");
+                if (cookiePolicyThemeObj != null) {
+                    showCookiePolicy = (Boolean)(cookiePolicyThemeObj.get("visible"));
+                    cookiePolicyText = (String)cookiePolicyThemeObj.get("text");
+                }
+
+                JSONObject privacyPolicyThemeObj = (JSONObject)jsonObject.get("privacy-policy");
+                if (privacyPolicyThemeObj != null) {
+                    showPrivacyPolicy = (Boolean)(privacyPolicyThemeObj.get("visible"));
+                    privacyPolicyText = (String)privacyPolicyThemeObj.get("text");
                 }
             }
         }
@@ -89,9 +125,17 @@
     request.setAttribute("pageTitle", pageTitle);
     request.setAttribute("footerText", footerText);
     request.setAttribute("faviconSrc", faviconSrc);
+    request.setAttribute("showCookiePolicy", showCookiePolicy);
+    request.setAttribute("showPrivacyPolicy", showPrivacyPolicy);
+    request.setAttribute("cookiePolicyText", cookiePolicyText);
+    request.setAttribute("privacyPolicyText", privacyPolicyText);
+    request.setAttribute("logoSrc", logoSrc);
+    request.setAttribute("logoHeight", logoHeight);
+    request.setAttribute("logoWidth", logoWidth);
+    request.setAttribute("logoAltText", logoAltText);
 
     if (customCSSFile != null && customCSSFile.exists() && customCSSFile.isFile()) {
-	String cssRelativePath = "/devportal/site/public/tenant_themes/" + tenantThemeDirectoryName + "/" + "loginTheme.css";
+	String cssRelativePath = "/devportal/site/public/tenant_themes/" + tenantThemeDirectoryName + "/login/css/" + "loginTheme.css";
         request.setAttribute("customCSS", cssRelativePath);
     } else {
         request.setAttribute("customCSS", "");

--- a/modules/distribution/product/src/main/extensions/product-title.jsp
+++ b/modules/distribution/product/src/main/extensions/product-title.jsp
@@ -18,6 +18,8 @@
 
 <!-- localize.jsp MUST already be included in the calling script -->
 
+<%@ page import="org.apache.commons.lang.StringUtils"%>
+
 <% if ("API Manager".equals(request.getAttribute("headerTitle"))) { %>
 <div class="product-title">
     <div class="theme-icon inline auto transparent product-logo">
@@ -30,8 +32,20 @@
       </div>
       <h1 class="product-title-text">API Manager</h1>
 </div>
-<% } else { %>
-<div class="product-title">
-    <h1 class="product-title-text"><%=request.getAttribute("headerTitle")%></h1>
-</div>
+<% } else {
+
+    String logoSrc = (String)request.getAttribute("logoSrc");
+    String logoHeight = (String)request.getAttribute("logoHeight");
+    String logoWidth = (String)request.getAttribute("logoWidth");
+    String logoAltText = (String)request.getAttribute("logoAltText");
+    if (!StringUtils.isEmpty(logoSrc)) {
+%>
+        <div class="product-title box">
+            <img src=<%=logoSrc%> alt=<%=logoAltText%> height=<%=logoHeight%> width=<%=logoWidth%>>
+        </div>
+<%  } else { %>
+        <div class="product-title box">
+            <h1 class="product-title-text" vertical-align="middle"><%=request.getAttribute("headerTitle")%></h1>
+        </div>
+<%  } %>
 <% } %>


### PR DESCRIPTION
tenant_theme directory structure for login theme customizations is modified as below with this PR. So the users are expected to upload a tenant theme complying with this standard in order to apply tenant login themes.

![tree](https://user-images.githubusercontent.com/28379317/74416694-851da080-4e6b-11ea-8bed-9300b5dcc3ac.png)

Sample loginTheme.json with all the customizable fields would look like below.

```
{
	"title" : "Test Company Title",
	"header" : {
		"title" : "Test Company" 	
	},
       "footer" : {
		"name" : "Test"
	},  
	"favicon" : {
		"src" : "icon.ico"
	},
	"logo" : {
		"src" : "logo.png",
		"alt" : "Company Logo",
                "height" : "60",
                "width" : "60"
	},
	"cookie-policy" : {
		"visible" : true,
		"text" : "custom cookie policy text "
	},
	"privacy-policy" : {
		"visible" : true,
		"text" : "custom privacy policy text "
	}
}
```