### PR TITLE
Remove support to import resources from ResourceAdminClient

### DIFF
--- a/modules/integration/tests-common/admin-clients/src/main/java/org/wso2/am/admin/clients/registry/ResourceAdminServiceClient.java
+++ b/modules/integration/tests-common/admin-clients/src/main/java/org/wso2/am/admin/clients/registry/ResourceAdminServiceClient.java
@@ -123,22 +123,6 @@ public class ResourceAdminServiceClient {
 				.addResource("/" + fileName, MEDIA_TYPE_WADL, description, dh, null, null);
 	}
 
-	public void addWSDL(String resourceName, String description,
-	                    String fetchURL)
-			throws ResourceAdminServiceExceptionException, RemoteException {
-
-		resourceAdminServiceStub.importResource("/", resourceName, MEDIA_TYPE_WSDL,
-		                                        description, fetchURL, null, null);
-	}
-
-	public void addWADL(String resourceName, String description,
-	                    String fetchURL)
-			throws ResourceAdminServiceExceptionException, RemoteException {
-
-		resourceAdminServiceStub.importResource("/", resourceName, MEDIA_TYPE_WADL,
-		                                        description, fetchURL, null, null);
-	}
-
 	public void addSchema(String description, DataHandler dh)
 			throws ResourceAdminServiceExceptionException, RemoteException {
 		String fileName;
@@ -147,29 +131,12 @@ public class ResourceAdminServiceClient {
 		                                     description, dh, null, null);
 	}
 
-	public void addSchema(String resourceName, String description,
-	                      String fetchURL) throws ResourceAdminServiceExceptionException,
-	                                              RemoteException {
-
-		resourceAdminServiceStub.importResource("/", resourceName, MEDIA_TYPE_SCHEMA,
-		                                        description, fetchURL, null, null);
-
-	}
-
 	public void addPolicy(String description, DataHandler dh)
 			throws ResourceAdminServiceExceptionException, RemoteException {
 		String fileName;
 		fileName = dh.getName().substring(dh.getName().lastIndexOf('/') + 1);
 		resourceAdminServiceStub.addResource("/" + fileName, MEDIA_TYPE_POLICY,
 		                                     description, dh, null, null);
-	}
-
-	public void addPolicy(String resourceName, String description,
-	                      String fetchURL)
-			throws ResourceAdminServiceExceptionException, RemoteException {
-
-		resourceAdminServiceStub.importResource("/", resourceName, MEDIA_TYPE_POLICY,
-		                                        description, fetchURL, null, null);
 	}
 
 	public void uploadArtifact(String description, DataHandler dh)
@@ -482,25 +449,6 @@ public class ResourceAdminServiceClient {
 
 		} catch (ResourceAdminServiceExceptionException e) {
 			String msg = "Unable to retrieve content download bean - " + path;
-			log.error(msg, e);
-			throw new RegistryExceptionException(msg, e);
-		}
-	}
-
-	public boolean importResource(String parentPath, String resourceName, String mediaType,
-	                              String description, String fetchURL, String symLink)
-			throws RemoteException, RegistryExceptionException {
-		try {
-			return resourceAdminServiceStub
-					.importResource(parentPath, resourceName, mediaType, description, fetchURL,
-					                symLink, null);
-		} catch (RemoteException e) {
-			String msg = "Unable to import resource";
-			log.error(msg, e);
-			throw new RemoteException(msg, e);
-
-		} catch (ResourceAdminServiceExceptionException e) {
-			String msg = "Unable to import resource";
 			log.error(msg, e);
 			throw new RegistryExceptionException(msg, e);
 		}


### PR DESCRIPTION
This PR removes import resource functionality from Resource Admin Client as the support to import registry resources from URL is removed in https://github.com/wso2/carbon-registry/pull/349