### PR TITLE
Fix IS-KM workflow test failures

### DIFF
--- a/modules/is-km/pom.xml
+++ b/modules/is-km/pom.xml
@@ -316,6 +316,7 @@
                         <phase>install</phase>
                         <configuration>
                             <tasks>
+                                <delete file="${basedir}/${is_folder_name}/repository/components/plugins/wsdl4j.wso2_${wsdl4j.version}.jar"/>
                                 <delete file="${basedir}/${is_folder_name}/repository/resources/conf/org.wso2.carbon.apimgt.core.default.json"/>
                                 <delete file="${basedir}/${is_folder_name}/repository/resources/conf/org.wso2.carbon.apimgt.core.unit-resolve.json"/>
                                 <delete file="${basedir}/${is_folder_name}/repository/resources/conf/default-merged.json"/>

--- a/pom.xml
+++ b/pom.xml
@@ -1394,6 +1394,9 @@
         <swagger-parser-version>2.0.14</swagger-parser-version>
         <swagger.inflector.oas3.version>2.0.5</swagger.inflector.oas3.version>
         <nimbus.jwt.version>7.3.0.wso2v1</nimbus.jwt.version>
+
+        <!-- WSDL4J dependencies -->
+        <wsdl4j.version>1.6.3.wso2v3</wsdl4j.version>
     </properties>
 
 </project>


### PR DESCRIPTION
remove wsdl4j 1.6.3.wso2v3 from is-km, as wsdl4j 1.6.2.wso2v4 is packing from carbon-kernel and when both dependencies are present BPEL deployment throws AbstractMethodError.

This fixes the IS tests,

1. org.wso2.identity.integration.test.rest.api.user.approval.v1.UserMeApprovalTest.testListTasksWhenAvailable

2. org.wso2.identity.integration.test.workflow.mgt.WorkflowManagementTestCase.testRemoveWorkflow