### PR TITLE
Removing unused variable

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/ChangeEndPointSecurityOfAPITestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/ChangeEndPointSecurityOfAPITestCase.java
@@ -62,7 +62,6 @@ public class ChangeEndPointSecurityOfAPITestCase extends APIManagerLifecycleBase
     private HashMap<String, String> requestHeadersGet;
     private String providerName;
     private String apiEndPointUrl;
-    private APIIdentifier apiIdentifier;
     private String applicationID;
     private String apiID;
 
@@ -79,7 +78,6 @@ public class ChangeEndPointSecurityOfAPITestCase extends APIManagerLifecycleBase
         requestHeadersGet = new HashMap<String, String>();
         requestHeadersGet.put("accept", "text/plain");
         requestHeadersGet.put("Content-Type", "text/plain");
-        apiIdentifier = new APIIdentifier(providerName, API_NAME, API_VERSION_1_0_0);
         //Create application
         ApplicationDTO dto = restAPIStore.addApplication(APPLICATION_NAME,
                 APIMIntegrationConstants.APPLICATION_TIER.UNLIMITED, "", "");


### PR DESCRIPTION
Class variable `private APIIdentifier apiIdentifier` is created, assigned and never accessed in the test class.