### PR TITLE
Add parameters to set mount overwrite value from deployment.toml

### DIFF
--- a/modules/distribution/product/src/main/resources/conf/default.json
+++ b/modules/distribution/product/src/main/resources/conf/default.json
@@ -244,5 +244,7 @@
   "transport.client.https.properties.PROTOCOL": "HTTP/1.1",
   "transport.client.https.properties.Transfer-Encoding": "chunked",
   "transport.client.https.properties.SO_TIMEOUT": "60000",
-  "transport.client.https.properties.CONNECTION_TIMEOUT": "60000"
+  "transport.client.https.properties.CONNECTION_TIMEOUT": "60000",
+  "config_data.overwrite": "true",
+  "governance_data.overwrite": "true"
 }

--- a/modules/distribution/product/src/main/resources/conf/templates/repository/conf/registry.xml.j2
+++ b/modules/distribution/product/src/main/resources/conf/templates/repository/conf/registry.xml.j2
@@ -58,11 +58,11 @@
         <registryRoot>/</registryRoot>
     </remoteInstance>
 
-    <mount path="/_system/governance" overwrite="true">
+    <mount path="/_system/governance" overwrite="{{governance_data.overwrite}}">
         <instanceId>gov</instanceId>
         <targetPath>{{governance_data.path}}</targetPath>
     </mount>
-    <mount path="/_system/config" overwrite="true">
+    <mount path="/_system/config" overwrite="{{config_data.overwrite}}">
         <instanceId>conf</instanceId>
         <targetPath>{{config_data.path}}</targetPath>
     </mount>


### PR DESCRIPTION
Fix https://github.com/wso2/product-apim/issues/7709

Add two parameters to get the values from the deployment.toml

```
    <mount path="/_system/governance" overwrite="{{governance_data.overwrite}}">
        <instanceId>gov</instanceId>
        <targetPath>{{governance_data.path}}</targetPath>
    </mount>
    <mount path="/_system/config" overwrite="{{config_data.overwrite}}">
        <instanceId>conf</instanceId>
        <targetPath>{{config_data.path}}</targetPath>
    </mount>
```