### PR TITLE
Remove forgot username link from APIM login pages

### DIFF
--- a/modules/distribution/product/src/main/extensions/basicauth.jsp
+++ b/modules/distribution/product/src/main/extensions/basicauth.jsp
@@ -268,12 +268,6 @@
         <% if (isRecoveryEPAvailable) { %>
         <div class="field">
             <%=AuthenticationEndpointUtil.i18n(resourceBundle, "forgot.username.password")%>
-            <% if (!isIdentifierFirstLogin(inputType)) { %>
-                <a id="usernameRecoverLink" tabindex="5" href="<%=getRecoverAccountUrl(identityMgtEndpointContext, urlEncodedURL, true, urlParameters)%>">
-                    <%=AuthenticationEndpointUtil.i18n(resourceBundle, "forgot.username")%>
-                </a>
-                <%=AuthenticationEndpointUtil.i18n(resourceBundle, "forgot.username.password.or")%>
-            <% } %>
             <a id="passwordRecoverLink" tabindex="6" href="<%=getRecoverAccountUrl(identityMgtEndpointContext, urlEncodedURL, false, urlParameters)%>">
                 <%=AuthenticationEndpointUtil.i18n(resourceBundle, "forgot.password")%>
             </a>


### PR DESCRIPTION
This PR removes 'forgot username' link from APIM login pages since the feature is not supported in APIM. (fixes https://github.com/wso2/product-apim/issues/7727)

After the change :
![after_the_change](https://user-images.githubusercontent.com/28379317/76726602-9f52e300-6777-11ea-8ebd-d50582060d6b.png)
