### PR TITLE
Add default subscriber claims to default.json

### DIFF
--- a/modules/distribution/product/src/main/resources/conf/default.json
+++ b/modules/distribution/product/src/main/resources/conf/default.json
@@ -178,6 +178,7 @@
   "apim.wss.keystore.password" : "$ref{keystore.tls.password}",
   "apim.wss.keystore.key_password" : "$ref{keystore.tls.key_password}",
   "apim.wss.ssl_enabled_protocols" : "TLSv1.1,TLSv1.2",
+  "apim.publisher.subscriber_claims": "http://wso2.org/claims/givenname,http://wso2.org/claims/lastname,http://wso2.org/claims/emailaddress,http://wso2.org/claims/organization",
   "keystore.ssl_profile.default.servers": "*",
   "keystore.listener_profile.ssl_verify_client" : "optional",
   "broker.transport.amqp.enabled" : true,


### PR DESCRIPTION
This PR adds default subscriber claims that returned when calling the REST API - `/subscriptions/{subscription-id}/subscriber or subscriber-info`

Related PR - https://github.com/wso2/carbon-apimgt/pull/8405
Related Issue - https://github.com/wso2/product-apim/issues/7873