### PR TITLE
Revert "Bump swagger-parser from 2.0.14 to 2.0.19"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1386,7 +1386,7 @@
 
         <!-- Authenticator Properties -->
         <identity.outbound.auth.oidc.version>5.5.0</identity.outbound.auth.oidc.version>
-        <swagger-parser-version>2.0.19</swagger-parser-version>
+        <swagger-parser-version>2.0.14</swagger-parser-version>
         <nimbus.jwt.version>7.3.0.wso2v1</nimbus.jwt.version>
 
         <!-- CallHome version -->


### PR DESCRIPTION
Reverts wso2/product-apim#7867 due to OASTest failures. 