### PR TITLE
Fix axis2.xml.j2 template file to support custom globally engaged modules

### DIFF
--- a/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/axis2.xml.j2
+++ b/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/axis2.xml.j2
@@ -366,6 +366,10 @@
     <!-- Comment this out to disable Addressing -->
     <module ref="addressing"/>
 
+    {% for module in server.globally_engaged_modules %}
+    <module ref="{{module}}"/>
+    {% endfor %}
+
     <!--
     Uncomment out the following entry if SOAP (text/xml and application/soap+xml) messages
     are processed through the message relay.


### PR DESCRIPTION
Axis2.xml.j2 template doesn't support adding custom modules under globally engaged modules.
This fix will update the template to add custom globally engaged modules.
(This fix is required by open banking solution)

Usage of the new config in the deployment.toml :
```
[server]
globally_engaged_modules = ["<custom module name>"]
```
