### PR TITLE
Update the build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ---
 
 
-[![Build Status](https://wso2.org/jenkins/job/products/job/product-apim/badge/icon)](https://wso2.org/jenkins/view/products/job/products/job/product-apim/)
+[![Build Status](https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fwso2.org%2Fjenkins%2Fview%2Fproducts%2Fjob%2Fproducts%2Fjob%2Fproduct-apim%2F)](https://wso2.org/jenkins/view/products/job/products/job/product-apim/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![stackoverflow](https://img.shields.io/badge/stackoverflow-wso2am-orange)](https://stackoverflow.com/tags/wso2-am/)
 [![slack](https://img.shields.io/badge/slack-wso2--apim-blueviolet)](https://join.slack.com/t/wso2-apim/shared_invite/enQtNzEzMzk5Njc5MzM0LTgwODI3NmQ1MjI0ZDQyMGNmZGI4ZjdkZmI1ZWZmMjNkY2E0NmY3ZmExYjkxYThjNzNkOTU2NWJmYzM4YzZiOWU?src=sidebar)


### PR DESCRIPTION
**Description**:
- Updated the build status badge which was not showing the status.

**Previously**:
![Screenshot from 2020-06-23 18-21-23](https://user-images.githubusercontent.com/33062368/85405719-744e0b80-b57e-11ea-969a-af0234166e9f.png)

**With the fix**:
![Screenshot from 2020-06-23 18-23-36](https://user-images.githubusercontent.com/33062368/85405902-abbcb800-b57e-11ea-8b65-3b4c76e44295.png)
