### PR TITLE
Adding class mediator reference for OAuth 2.0 Endpoint Security in out-sequence

### DIFF
--- a/modules/distribution/resources/api_templates/api_product_template.xml
+++ b/modules/distribution/resources/api_templates/api_product_template.xml
@@ -250,6 +250,9 @@ $out_sequences.get("$resource.getUriTemplate()").get($uri)
 #if($responseCacheEnabled)
 <cache scope="per-host" collector="true"/>
 #end
+#if($endpointsecurity.type == "oauth" || $endpointsecurity.type == "OAUTH")
+<class name="org.wso2.carbon.apimgt.gateway.mediators.oauth.OAuthResponseMediator"/>
+#end
 <send/>
 </outSequence>
         </resource>

--- a/modules/distribution/resources/api_templates/velocity_template.xml
+++ b/modules/distribution/resources/api_templates/velocity_template.xml
@@ -257,6 +257,9 @@ $out_sequences.get("$resource.getUriTemplate()").get($uri)
 #if($responseCacheEnabled)
 <cache scope="per-host" collector="true"/>
 #end
+#if($endpointsecurity.type == "oauth" || $endpointsecurity.type == "OAUTH")
+<class name="org.wso2.carbon.apimgt.gateway.mediators.oauth.OAuthResponseMediator"/>
+#end
 <send/>
 </outSequence>
         </resource>


### PR DESCRIPTION
Adding class mediator reference for APIs with OAuth 2.0-secured endpoints in the out-sequence to handle 401 unauthorized error from the backend server.

**Please note**: Merge this PR along with [wso2/carbon-apimgt#8874](https://github.com/wso2/carbon-apimgt/pull/8874).