### PR TITLE
Adding the property entityExpansionLimit to xml_validator.xml

### DIFF
--- a/modules/distribution/resources/customsequences/in/xml_validator.xml
+++ b/modules/distribution/resources/customsequences/in/xml_validator.xml
@@ -10,6 +10,7 @@
     <property name="maxAttributeCount" value="100"/>
     <property name="maxAttributeLength" value="100"/>
     <property name="maxChildrenPerElement" value="100"/>
+    <property name="entityExpansionLimit" value="100"/>
     <property name="schemaValidation" value="false"/>
     <switch source="get-property('To')">
         <!--<case regex=".*/addResource.*">-->


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim/issues/8569

## Goals
Add the property **entityExpansionLimit** to xml_validator.xml

## Approach
Added **<property name="entityExpansionLimit" value="100"/>** to xml_validator.xml (where the default value is 100, as initialized for the other properties in the same file)

## User stories
When you perform steps 1 to 8 in https://github.com/wso2/product-apim/issues/8569, you will get expected response as shown below.
```
<am:fault xmlns:am="http://wso2.org/apimanager">
  <am:code>400</am:code>
  <am:message>Bad Request</am:message>
  <am:description>XML Validation Failed: due to Maximum Element Count Exceeded</am:description>
</am:fault>
```

## Documentation
Documentation changes were done with https://github.com/wso2/docs-apim/pull/1468