### PR TITLE
Remove the ability to enable artifact storing from configs

### DIFF
--- a/modules/distribution/product/src/main/resources/conf/templates/repository/conf/synapse.properties.j2
+++ b/modules/distribution/product/src/main/resources/conf/templates/repository/conf/synapse.properties.j2
@@ -17,7 +17,7 @@
 {% for key,value in synapse_properties.items() %}
 {{key}}={{value}}
 {% endfor %}
-{% if apim.sync_runtime_artifacts.gateway.save_artifacts_locally is defined %}
-synapse.artifacts.file.storage.enabled={{apim.sync_runtime_artifacts.gateway.save_artifacts_locally}}
+{% if apim.sync_runtime_artifacts.gateway is defined %}
+synapse.artifacts.file.storage.enabled=false
 {% endif %}
 


### PR DESCRIPTION
### Purpose

Related to https://github.com/wso2/product-apim/issues/8246

### Approach

- Removes `saveArtifactsLocally `Config element (We are not providing the ability to configure the storing of synapse artifacts in the filesystem. Instead,  if `apim.sync_runtime_artifacts.gateway`  config element is defined then the synapse artifacts will not be saved to the file system and vice versa)