### PR TITLE
change test resource w.r.t changes in carbon-apimgt/pull/9087

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/toml_config/case1/deployment.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/toml_config/case1/deployment.toml
@@ -132,7 +132,7 @@ enable_user_claims = true
 [apim.oauth_config]
 enable_outbound_auth_header = true
 default_app_scope = "am_custom_application_scope"
-white_listed_scopes = ["^device_.*","openid","custom_device"]
+allowed_scopes = ["^device_.*","openid","custom_device"]
 auth_header = "X-Authorization"
 revoke_endpoint = "https://localhost:8243/revoke"
 enable_token_encryption = true

--- a/modules/integration/tests-integration/tests-config/src/test/resources/artifacts/AM/fullConfigurations/scenario1/deployment.toml
+++ b/modules/integration/tests-integration/tests-config/src/test/resources/artifacts/AM/fullConfigurations/scenario1/deployment.toml
@@ -130,7 +130,7 @@ enable_user_claims = true
 [apim.oauth_config]
 enable_outbound_auth_header = true
 default_app_scope = "am_custom_application_scope"
-white_listed_scopes = ["^device_.*","openid","custom_device"]
+allowed_scopes = ["^device_.*","openid","custom_device"]
 auth_header = "X-Authorization"
 revoke_endpoint = "https://localhost:8243/revoke"
 enable_token_encryption = true

--- a/modules/integration/tests-integration/tests-config/src/test/resources/artifacts/AM/individualConfigurations/scenario1/deployment.toml
+++ b/modules/integration/tests-integration/tests-config/src/test/resources/artifacts/AM/individualConfigurations/scenario1/deployment.toml
@@ -130,7 +130,7 @@ enable_user_claims = true
 [apim.oauth_config]
 enable_outbound_auth_header = true
 default_app_scope = "am_custom_application_scope"
-white_listed_scopes = ["^device_.*","openid","custom_device"]
+allowed_scopes = ["^device_.*","openid","custom_device"]
 auth_header = "X-Authorization"
 revoke_endpoint = "https://localhost:8243/revoke"
 enable_token_encryption = true


### PR DESCRIPTION
With this change, if one wants to specify some additional scope that are needed to skip validating while scope validation below config should be added in deployment.toml

[apim.oauth_config]
allowed_scopes = ["^device_.*", "some_random_scope"]