### PR TITLE
Fixing RESTApiCreationUsingOASDocTestCase test failure

### DIFF
--- a/product-scenarios/1-manage-public-partner-private-apis/1.1-expose-service-as-rest-api/1.1.2-create-rest-api-by-import-oas-document/src/test/java/org/wso2/am/scenario/tests/rest/api/creation/RESTApiCreationUsingOASDocTestCase.java
+++ b/product-scenarios/1-manage-public-partner-private-apis/1.1-expose-service-as-rest-api/1.1.2-create-rest-api-by-import-oas-document/src/test/java/org/wso2/am/scenario/tests/rest/api/creation/RESTApiCreationUsingOASDocTestCase.java
@@ -311,8 +311,8 @@ public class RESTApiCreationUsingOASDocTestCase extends ScenarioTestBase {
         Assert.assertEquals(updatedResponse.get("version"), apiVersion, "API version was not imported correctly");
 
         //Assert resources
-        JSONObject resourceGET = (JSONObject) resources.get(0);
-        JSONObject resourcePOST = (JSONObject) resources.get(1);
+        JSONObject resourcePOST = (JSONObject) resources.get(0);
+        JSONObject resourceGET = (JSONObject) resources.get(1);
         assertPOSTResource(resourcePOST);
         assertGETResource(resourceGET);
 

--- a/product-scenarios/1-manage-public-partner-private-apis/1.1-expose-service-as-rest-api/1.1.2-create-rest-api-by-import-oas-document/src/test/java/org/wso2/am/scenario/tests/rest/api/creation/RESTApiCreationUsingOASDocTestCase.java
+++ b/product-scenarios/1-manage-public-partner-private-apis/1.1-expose-service-as-rest-api/1.1.2-create-rest-api-by-import-oas-document/src/test/java/org/wso2/am/scenario/tests/rest/api/creation/RESTApiCreationUsingOASDocTestCase.java
@@ -202,10 +202,9 @@ public class RESTApiCreationUsingOASDocTestCase extends ScenarioTestBase {
         }
         Assert.assertEquals(updatedResponse.get("version"), apiVersion, "API version was not imported correctly");
 
-
         //Assert resources
-        JSONObject resourceGET = (JSONObject) resources.get(0);
-        JSONObject resourcePOST = (JSONObject) resources.get(1);
+        JSONObject resourcePOST = (JSONObject) resources.get(0);
+        JSONObject resourceGET = (JSONObject) resources.get(1);
         assertPOSTResource(resourcePOST);
         assertGETResource(resourceGET);
 


### PR DESCRIPTION
This PR will fix the test failure in RESTApiCreationUsingOASDocTestCase#createApiWithValidOAS3DocumentAsJSONFile test case


