### PR TITLE
Fix test failures due to REST API validation

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/publisher/APIM514CreateAnAPIWithoutProvidingMandatoryFieldsTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/publisher/APIM514CreateAnAPIWithoutProvidingMandatoryFieldsTestCase.java
@@ -99,7 +99,7 @@ public class APIM514CreateAnAPIWithoutProvidingMandatoryFieldsTestCase extends
             APIDTO apiDto = createAndPublishAPI(apiCreationRequestBean, restAPIPublisher, false);
             assertFalse(StringUtils.isNotEmpty(apiDto.getId()), "Api is not created without proving API Name");
         } catch (ApiException e) {
-            assertEquals(e.getCode(), HttpStatus.SC_INTERNAL_SERVER_ERROR, "Internal Server Error " );
+            assertEquals(e.getCode(), HttpStatus.SC_BAD_REQUEST, "Required Parameter name is not provided " );
         }
 //        Need to uncomment this after resolving https://github.com/wso2/product-apim/issues/6172
 //        JSONObject apiResponse = new JSONObject(apiId);
@@ -122,8 +122,7 @@ public class APIM514CreateAnAPIWithoutProvidingMandatoryFieldsTestCase extends
             APIDTO apiDto = createAndPublishAPI(apiCreationRequestBean, restAPIPublisher, false);
             assertFalse(StringUtils.isNotEmpty(apiDto.getId()), "Api is not created without proving Context");
         } catch (ApiException e) {
-            assertEquals(e.getCode(), HttpStatus.SC_INTERNAL_SERVER_ERROR,
-                    "Internal Server Error " );
+            assertEquals(e.getCode(), HttpStatus.SC_BAD_REQUEST, "Required Parameter context is not provided " );
         }
 //        Need to uncomment this after resolving https://github.com/wso2/product-apim/issues/6172
 //        JSONObject apiResponse = new JSONObject(apiId);
@@ -150,7 +149,7 @@ public class APIM514CreateAnAPIWithoutProvidingMandatoryFieldsTestCase extends
             APIDTO apiDto = createAndPublishAPI(apiCreationRequestBean, restAPIPublisher, false);
             assertFalse(StringUtils.isNotEmpty(apiDto.getId()), "Api is not created without proving Version");
         } catch (ApiException e) {
-            assertEquals(e.getCode(), HttpStatus.SC_INTERNAL_SERVER_ERROR, "Internal Server Error " );
+            assertEquals(e.getCode(), HttpStatus.SC_BAD_REQUEST, "Required Parameter version is not provided " );
         }
 //        Need to uncomment this after resolving https://github.com/wso2/product-apim/issues/6172
 //        JSONObject apiResponse = new JSONObject(apiId);

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/oas/v2/apiData.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/oas/v2/apiData.json
@@ -48,8 +48,8 @@
     "accessControlAllowMethods": ["GET", "PUT", "POST", "DELETE", "PATCH", "OPTIONS"]
   },
   "workflowStatus": null,
-  "createdTime": "2019-09-17 17:49:55.251",
-  "lastUpdatedTime": "2019-09-17 17:49:55.251",
+  "createdTime": "2019-09-17T17:49:55.251",
+  "lastUpdatedTime": "2019-09-17T17:49:55.251",
   "endpointConfig": {
     "endpoint_type": "http",
     "sandbox_endpoints": {

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/oas/v2/apiData.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/oas/v2/apiData.json
@@ -48,8 +48,6 @@
     "accessControlAllowMethods": ["GET", "PUT", "POST", "DELETE", "PATCH", "OPTIONS"]
   },
   "workflowStatus": null,
-  "createdTime": "2019-09-17T17:49:55.251",
-  "lastUpdatedTime": "2019-09-17T17:49:55.251",
   "endpointConfig": {
     "endpoint_type": "http",
     "sandbox_endpoints": {

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/oas/v3/apiData.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/oas/v3/apiData.json
@@ -48,8 +48,8 @@
     "accessControlAllowMethods": ["GET", "PUT", "POST", "DELETE", "PATCH", "OPTIONS"]
   },
   "workflowStatus": null,
-  "createdTime": "2019-09-17 17:49:55.251",
-  "lastUpdatedTime": "2019-09-17 17:49:55.251",
+  "createdTime": "2019-09-17T17:49:55.251",
+  "lastUpdatedTime": "2019-09-17T17:49:55.251",
   "endpointConfig": {
     "endpoint_type": "http",
     "sandbox_endpoints": {

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/oas/v3/apiData.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/oas/v3/apiData.json
@@ -48,8 +48,6 @@
     "accessControlAllowMethods": ["GET", "PUT", "POST", "DELETE", "PATCH", "OPTIONS"]
   },
   "workflowStatus": null,
-  "createdTime": "2019-09-17T17:49:55.251",
-  "lastUpdatedTime": "2019-09-17T17:49:55.251",
   "endpointConfig": {
     "endpoint_type": "http",
     "sandbox_endpoints": {


### PR DESCRIPTION
Fix test failures due to changes introduced in the PR -https://github.com/wso2/carbon-apimgt/pull/9313, to validate the request parameters in REST API level