### PR TITLE
[Do not merge] Fix APIVisibilityWithDirectURLTestCase 

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/APIVisibilityWithDirectURLTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/APIVisibilityWithDirectURLTestCase.java
@@ -136,7 +136,7 @@ public class APIVisibilityWithDirectURLTestCase extends APIManagerLifecycleBaseT
             ApiResponse<org.wso2.am.integration.clients.store.api.v1.dto.APIDTO> apiResponse =
                     anonymousRestAPIStore.apIsApi.apisApiIdGetWithHttpInfo(apidto.getId(), user.getUserDomain(), null);
         } catch (ApiException e) {
-            Assert.assertEquals(HttpStatus.SC_NOT_FOUND, e.getCode());
+            Assert.assertEquals(e.getCode(), HttpStatus.SC_FORBIDDEN);
         }
     }
 
@@ -157,7 +157,7 @@ public class APIVisibilityWithDirectURLTestCase extends APIManagerLifecycleBaseT
         try {
             ApiResponse<?> apiResponse = apiStore.apIsApi.apisApiIdGetWithHttpInfo(apiID, user.getUserDomain(), null);
         } catch (ApiException e) {
-            Assert.assertEquals(HttpStatus.SC_NOT_FOUND, e.getCode());
+            Assert.assertEquals(e.getCode(), HttpStatus.SC_FORBIDDEN);
         }
     }
 


### PR DESCRIPTION
Fix APIVisibilityWithDirectURLTestCase to cope with the implemenation done in the PR [https://github.com/wso2/carbon-apimgt/pull/9361/](https://github.com/wso2/carbon-apimgt/pull/9361/). As per the current implementation when an anonymous user is trying to access a registry resource it will respond with 404(not found) but with the above PR it was changes to return 403(Forbidden). 