### PR TITLE
Add Proxies to the Synapse-Configs to Support Authentication Flow when using Gateway as a Proxy

### DIFF
--- a/modules/distribution/product/src/main/conf/synapse-configs/default/api/_AuthenticationEPAPI_.xml
+++ b/modules/distribution/product/src/main/conf/synapse-configs/default/api/_AuthenticationEPAPI_.xml
@@ -1,11 +1,11 @@
-<api xmlns="http://ws.apache.org/ns/synapse" name="_WSO2AMAuthorizeAPI_" context="/authorize">
-    <resource methods="GET POST" url-mapping="/*" faultSequence="_token_fault_">
+<?xml version="1.0" encoding="UTF-8"?><api xmlns="http://ws.apache.org/ns/synapse" name="_WSO2AMAuthenticationEPAPI_" context="/authenticationendpoint">
+    <resource methods="GET" url-mapping="/*" faultSequence="_token_fault_">
         <inSequence>
             <property name="uri.var.portnum" expression="get-property('keyManager.port')"/>
 	    <property name="uri.var.hostname" expression="get-property('keyManager.hostname')"/>
             <send>
                 <endpoint>
-                    <http uri-template="https://{uri.var.hostname}:{uri.var.portnum}/oauth2/authorize">
+                    <http uri-template="https://{uri.var.hostname}:{uri.var.portnum}/authenticationendpoint">
                         <timeout>
                             <duration>60000</duration>
                             <responseAction>fault</responseAction>
@@ -19,6 +19,7 @@
         </outSequence>
     </resource>
     <handlers>
+        <handler class="org.wso2.carbon.apimgt.gateway.handlers.ext.APIManagerCacheExtensionHandler"/>
         <handler class="org.wso2.carbon.apimgt.gateway.handlers.common.SynapsePropertiesHandler"/>
     </handlers>
 </api>

--- a/modules/distribution/product/src/main/conf/synapse-configs/default/api/_CommonAuthAPI_.xml
+++ b/modules/distribution/product/src/main/conf/synapse-configs/default/api/_CommonAuthAPI_.xml
@@ -1,11 +1,11 @@
-<api xmlns="http://ws.apache.org/ns/synapse" name="_WSO2AMAuthorizeAPI_" context="/authorize">
-    <resource methods="GET POST" url-mapping="/*" faultSequence="_token_fault_">
+<api xmlns="http://ws.apache.org/ns/synapse" name="_WSO2AMCommonAuthAPI_" context="/commonauth">
+    <resource methods="POST" url-mapping="/*" faultSequence="_token_fault_">
         <inSequence>
             <property name="uri.var.portnum" expression="get-property('keyManager.port')"/>
 	    <property name="uri.var.hostname" expression="get-property('keyManager.hostname')"/>
             <send>
                 <endpoint>
-                    <http uri-template="https://{uri.var.hostname}:{uri.var.portnum}/oauth2/authorize">
+                    <http uri-template="https://{uri.var.hostname}:{uri.var.portnum}/commonauth">
                         <timeout>
                             <duration>60000</duration>
                             <responseAction>fault</responseAction>

--- a/modules/distribution/product/src/main/conf/synapse-configs/default/api/_LoginContextAPI_.xml
+++ b/modules/distribution/product/src/main/conf/synapse-configs/default/api/_LoginContextAPI_.xml
@@ -1,11 +1,11 @@
-<api xmlns="http://ws.apache.org/ns/synapse" name="_WSO2AMAuthorizeAPI_" context="/authorize">
-    <resource methods="GET POST" url-mapping="/*" faultSequence="_token_fault_">
+<api xmlns="http://ws.apache.org/ns/synapse" name="_WSO2AMLoginContextAPI_" context="/logincontext">
+    <resource methods="GET" url-mapping="/*" faultSequence="_token_fault_">
         <inSequence>
             <property name="uri.var.portnum" expression="get-property('keyManager.port')"/>
 	    <property name="uri.var.hostname" expression="get-property('keyManager.hostname')"/>
             <send>
                 <endpoint>
-                    <http uri-template="https://{uri.var.hostname}:{uri.var.portnum}/oauth2/authorize">
+                    <http uri-template="https://{uri.var.hostname}:{uri.var.portnum}/logincontext">
                         <timeout>
                             <duration>60000</duration>
                             <responseAction>fault</responseAction>

--- a/modules/distribution/product/src/main/conf/synapse-configs/default/api/_OIDCAPI_.xml
+++ b/modules/distribution/product/src/main/conf/synapse-configs/default/api/_OIDCAPI_.xml
@@ -1,11 +1,11 @@
-<api xmlns="http://ws.apache.org/ns/synapse" name="_WSO2AMAuthorizeAPI_" context="/authorize">
+<api xmlns="http://ws.apache.org/ns/synapse" name="_WSO2OIDCAPI_" context="/oidc">
     <resource methods="GET POST" url-mapping="/*" faultSequence="_token_fault_">
         <inSequence>
             <property name="uri.var.portnum" expression="get-property('keyManager.port')"/>
 	    <property name="uri.var.hostname" expression="get-property('keyManager.hostname')"/>
             <send>
                 <endpoint>
-                    <http uri-template="https://{uri.var.hostname}:{uri.var.portnum}/oauth2/authorize">
+                     <http uri-template="https://{uri.var.hostname}:{uri.var.portnum}/oidc">
                         <timeout>
                             <duration>60000</duration>
                             <responseAction>fault</responseAction>
@@ -19,6 +19,7 @@
         </outSequence>
     </resource>
     <handlers>
+        <handler class="org.wso2.carbon.apimgt.gateway.handlers.ext.APIManagerCacheExtensionHandler"/>
         <handler class="org.wso2.carbon.apimgt.gateway.handlers.common.SynapsePropertiesHandler"/>
     </handlers>
 </api>


### PR DESCRIPTION
## Purpose
- This PR adds relevant proxies to the synapse-configs which are required for the authentication flow when using Gateway as a proxy.

## Approach
- Added the following proxies to the synapse-configs
1. AuthenticationEPAPI.xml
2. CommonAuthAPI.xml
3. LoginContextAPI.xml
4. OIDCAPI.xml

- Modified the AuthorizeAPI.xml by adding a POST resource

## Related PRs
- https://github.com/wso2/carbon-apimgt/pull/9391

Related Issue: wso2/product-apim#8758