### PR TITLE
Remove internal grant handlers from infer.json

### DIFF
--- a/modules/distribution/product/src/main/resources/conf/infer.json
+++ b/modules/distribution/product/src/main/resources/conf/infer.json
@@ -28,19 +28,7 @@
       "oauth.extensions.token_generator": "org.wso2.carbon.identity.oauth2.token.OauthTokenIssuerImpl",
       "system.parameter.profile": "api-key-manager",
       "apim.key_manager.enable_registration": false,
-      "apim.key_manager.enable_retriever": false,
-      "oauth.grant_type.authorization_code.grant_handler": "org.wso2.is.key.manager.core.tokenmgt.handlers.ExtendedAuthorizationCodeGrantHandler",
-      "oauth.grant_type.password.grant_handler": "org.wso2.is.key.manager.core.tokenmgt.handlers.ExtendedPasswordGrantHandler",
-      "oauth.grant_type.refresh_token.grant_handler": "org.wso2.carbon.identity.oauth2.token.handlers.grant.RefreshGrantHandler",
-      "oauth.grant_type.client_credentials.grant_handler": "org.wso2.is.key.manager.core.tokenmgt.handlers.ExtendedClientCredentialsGrantHandler",
-      "oauth.grant_type.saml_bearer.grant_handler": "org.wso2.is.key.manager.core.tokenmgt.handlers.ExtendedSAML2BearerGrantHandler",
-      "oauth.grant_type.iwa_ntlm.grant_handler": "org.wso2.carbon.identity.oauth2.token.handlers.grant.iwa.ntlm.NTLMAuthenticationGrantHandlerWithHandshake",
-      "oauth.grant_type.jwt_bearer.grant_handler": "org.wso2.is.key.manager.core.tokenmgt.token.ExtendedJWTBearerGrantHandler",
-      "oauth.extensions.callback_handlers": [
-        {
-          "class": "org.wso2.is.key.manager.core.tokenmgt.util.APIManagerOAuthCallbackHandler"
-        }
-      ]
+      "apim.key_manager.enable_retriever": false
     },
     "api-publisher": {
       "apim.throttling.enable_policy_deploy": true,
@@ -51,19 +39,7 @@
       "transport.wss.sender.enable": false,
       "system.parameter.profile": "api-publisher",
       "apim.key_manager.enable_registration": false,
-      "apim.key_manager.enable_retriever": true,
-      "oauth.grant_type.authorization_code.grant_handler": "org.wso2.is.key.manager.core.tokenmgt.handlers.ExtendedAuthorizationCodeGrantHandler",
-      "oauth.grant_type.password.grant_handler": "org.wso2.is.key.manager.core.tokenmgt.handlers.ExtendedPasswordGrantHandler",
-      "oauth.grant_type.refresh_token.grant_handler": "org.wso2.carbon.identity.oauth2.token.handlers.grant.RefreshGrantHandler",
-      "oauth.grant_type.client_credentials.grant_handler": "org.wso2.is.key.manager.core.tokenmgt.handlers.ExtendedClientCredentialsGrantHandler",
-      "oauth.grant_type.saml_bearer.grant_handler": "org.wso2.is.key.manager.core.tokenmgt.handlers.ExtendedSAML2BearerGrantHandler",
-      "oauth.grant_type.iwa_ntlm.grant_handler": "org.wso2.carbon.identity.oauth2.token.handlers.grant.iwa.ntlm.NTLMAuthenticationGrantHandlerWithHandshake",
-      "oauth.grant_type.jwt_bearer.grant_handler": "org.wso2.is.key.manager.core.tokenmgt.token.ExtendedJWTBearerGrantHandler",
-      "oauth.extensions.callback_handlers": [
-        {
-          "class": "org.wso2.is.key.manager.core.tokenmgt.util.APIManagerOAuthCallbackHandler"
-        }
-      ]
+      "apim.key_manager.enable_retriever": true
     },
     "api-devportal": {
       "apim.throttling.enable_policy_deploy": false,
@@ -74,19 +50,7 @@
       "transport.wss.sender.enable": false,
       "system.parameter.profile": "api-devportal",
       "apim.key_manager.enable_registration": false,
-      "apim.key_manager.enable_retriever": true,
-      "oauth.grant_type.authorization_code.grant_handler": "org.wso2.is.key.manager.core.tokenmgt.handlers.ExtendedAuthorizationCodeGrantHandler",
-      "oauth.grant_type.password.grant_handler": "org.wso2.is.key.manager.core.tokenmgt.handlers.ExtendedPasswordGrantHandler",
-      "oauth.grant_type.refresh_token.grant_handler": "org.wso2.carbon.identity.oauth2.token.handlers.grant.RefreshGrantHandler",
-      "oauth.grant_type.client_credentials.grant_handler": "org.wso2.is.key.manager.core.tokenmgt.handlers.ExtendedClientCredentialsGrantHandler",
-      "oauth.grant_type.saml_bearer.grant_handler": "org.wso2.is.key.manager.core.tokenmgt.handlers.ExtendedSAML2BearerGrantHandler",
-      "oauth.grant_type.iwa_ntlm.grant_handler": "org.wso2.carbon.identity.oauth2.token.handlers.grant.iwa.ntlm.NTLMAuthenticationGrantHandlerWithHandshake",
-      "oauth.grant_type.jwt_bearer.grant_handler": "org.wso2.is.key.manager.core.tokenmgt.token.ExtendedJWTBearerGrantHandler",
-      "oauth.extensions.callback_handlers": [
-        {
-          "class": "org.wso2.is.key.manager.core.tokenmgt.util.APIManagerOAuthCallbackHandler"
-        }
-      ]
+      "apim.key_manager.enable_retriever": true
     },
     "traffic-manager": {
       "system.parameter.profile": "traffic-manager",
@@ -106,19 +70,7 @@
       "synapse_handlers.external_call_logger.name": "externalCallLogger",
       "synapse_handlers.external_call_logger.class": "org.wso2.carbon.apimgt.gateway.handlers.LogsHandler",
       "synapse_handlers.open_tracing.name": "open_tracing",
-      "synapse_handlers.open_tracing.class": "org.wso2.carbon.apimgt.gateway.handlers.common.APIMgtLatencySynapseHandler",
-      "oauth.grant_type.authorization_code.grant_handler": "org.wso2.is.key.manager.core.tokenmgt.handlers.ExtendedAuthorizationCodeGrantHandler",
-      "oauth.grant_type.password.grant_handler": "org.wso2.is.key.manager.core.tokenmgt.handlers.ExtendedPasswordGrantHandler",
-      "oauth.grant_type.refresh_token.grant_handler": "org.wso2.carbon.identity.oauth2.token.handlers.grant.RefreshGrantHandler",
-      "oauth.grant_type.client_credentials.grant_handler": "org.wso2.is.key.manager.core.tokenmgt.handlers.ExtendedClientCredentialsGrantHandler",
-      "oauth.grant_type.saml_bearer.grant_handler": "org.wso2.is.key.manager.core.tokenmgt.handlers.ExtendedSAML2BearerGrantHandler",
-      "oauth.grant_type.iwa_ntlm.grant_handler": "org.wso2.carbon.identity.oauth2.token.handlers.grant.iwa.ntlm.NTLMAuthenticationGrantHandlerWithHandshake",
-      "oauth.grant_type.jwt_bearer.grant_handler": "org.wso2.is.key.manager.core.tokenmgt.token.ExtendedJWTBearerGrantHandler",
-      "oauth.extensions.callback_handlers": [
-        {
-          "class": "org.wso2.is.key.manager.core.tokenmgt.util.APIManagerOAuthCallbackHandler"
-        }
-      ]
+      "synapse_handlers.open_tracing.class": "org.wso2.carbon.apimgt.gateway.handlers.common.APIMgtLatencySynapseHandler"
     }
   },
   "apim.jwt.encoding": {

--- a/pom.xml
+++ b/pom.xml
@@ -1432,7 +1432,7 @@
 
         <!-- WSDL4J dependencies -->
         <wsdl4j.version>1.6.3.wso2v3</wsdl4j.version>
-        <wso2is.km.version>1.0.18</wso2is.km.version>
+        <wso2is.km.version>1.2.1</wso2is.km.version>
         <okta.keymanager.feature.version>3.0.5</okta.keymanager.feature.version>
         <keycloak.keymanager.feature.version>2.0.4</keycloak.keymanager.feature.version>
         <auth0.keymanager.feature.version>1.0.0</auth0.keymanager.feature.version>


### PR DESCRIPTION
The internal grant handlers configured in the infer.json are removed as all the grants will be handled by classes in identity components itself.