### PR TITLE
Template the missing tomcat filter configs

### DIFF
--- a/modules/distribution/product/src/main/resources/conf/default.json
+++ b/modules/distribution/product/src/main/resources/conf/default.json
@@ -357,5 +357,19 @@
       "usedby": "soapservice,restservice,wsdl,endpoint"
     }
   ],
-  "apim.analytics.handler_impl": "org.wso2.carbon.apimgt.gateway.handlers.analytics.AnalyticsMetricsHandler"
+  "synapse_handlers.external_call_logger.name": "externalCallLogger",
+  "synapse_handlers.external_call_logger.class": "org.wso2.carbon.apimgt.gateway.handlers.LogsHandler",
+  "synapse_handlers.open_tracing.name": "open_tracing",
+  "synapse_handlers.open_tracing.class": "org.wso2.carbon.apimgt.gateway.handlers.common.APIMgtLatencySynapseHandler",
+  "apim.analytics.handler_impl": "org.wso2.carbon.apimgt.gateway.handlers.analytics.AnalyticsMetricsHandler",
+  "tomcat.header_security_filters" : [
+    {
+      "name": "hstsEnabled",
+      "value": false
+    },
+    {
+      "name": "antiClickJackingEnabled",
+      "value": false
+    }
+  ]
 }

--- a/modules/distribution/product/src/main/resources/conf/templates/repository/conf/tomcat/carbon/WEB-INF/web.xml.j2
+++ b/modules/distribution/product/src/main/resources/conf/templates/repository/conf/tomcat/carbon/WEB-INF/web.xml.j2
@@ -77,17 +77,15 @@
 
     <!-- Tomcat http header security filter -->
     <filter>
- <filter-name>HttpHeaderSecurityFilter</filter-name>
- <filter-class>org.apache.catalina.filters.HttpHeaderSecurityFilter</filter-class>
- <init-param>
- <param-name>hstsEnabled</param-name>
- <param-value>false</param-value>
- </init-param>
- <init-param>
- <param-name>antiClickJackingEnabled</param-name>
- <param-value>false</param-value>
- </init-param>
- </filter>
+        <filter-name>HttpHeaderSecurityFilter</filter-name>
+        <filter-class>org.apache.catalina.filters.HttpHeaderSecurityFilter</filter-class>
+        {% for init_param in tomcat.header_security_filters %}
+        <init-param>
+            <param-name>{{init_param.name}}</param-name>
+            <param-value>{{init_param.value}}</param-value>
+        </init-param>
+        {% endfor %}
+    </filter>
 
  <filter>
  <filter-name>HttpHeaderSecurityFilter_EnableAntiClickJacking</filter-name>

--- a/modules/distribution/product/src/main/resources/conf/templates/repository/conf/tomcat/carbon/WEB-INF/web.xml.j2
+++ b/modules/distribution/product/src/main/resources/conf/templates/repository/conf/tomcat/carbon/WEB-INF/web.xml.j2
@@ -87,6 +87,11 @@
         {% endfor %}
     </filter>
 
+    <filter>
+        <filter-name>URLBasedCachePreventionFilter</filter-name>
+        <filter-class>org.wso2.carbon.ui.filters.cache.URLBasedCachePreventionFilter</filter-class>
+    </filter>
+
  <filter>
  <filter-name>HttpHeaderSecurityFilter_EnableAntiClickJacking</filter-name>
  <filter-class>org.apache.catalina.filters.HttpHeaderSecurityFilter</filter-class>
@@ -113,6 +118,11 @@
  <filter-name>CharsetFilter</filter-name>
  <url-pattern>/*</url-pattern>
  </filter-mapping>
+
+     <filter-mapping>
+         <filter-name>URLBasedCachePreventionFilter</filter-name>
+         <url-pattern>*.jsp</url-pattern>
+     </filter-mapping>
 
  <filter-mapping>
  <filter-name>HttpHeaderSecurityFilter_EnableAntiClickJacking</filter-name>


### PR DESCRIPTION
This PR enables the HttpHeaderSecurityFilter to be configured via the deployment.toml file.

Add URLBasedCachePreventionFilter to the tomcat/WEB-INF/web.xml.j2 file.

Fixes https://github.com/wso2/product-apim/issues/9585