### PR TITLE
Add TransportHeaderHandler specific details to synapse-handlers.xml.j2

### DIFF
--- a/modules/distribution/product/src/main/resources/conf/templates/repository/conf/synapse-handlers.xml.j2
+++ b/modules/distribution/product/src/main/resources/conf/templates/repository/conf/synapse-handlers.xml.j2
@@ -2,4 +2,22 @@
 {% for handler_key in enabled_global_handlers %}
     <handler name="{{synapse_handlers[handler_key].name}}" class="{{synapse_handlers[handler_key].class}}"/>
 {% endfor %}
+{% if apim.transport_headers is defined %}
+{% if apim.transport_headers.enable %}
+    <handler name="TransportHeaderHandler" class="org.wso2.carbon.apimgt.gateway.handlers.common.TransportHeaderHandler">
+    {% if apim.transport_headers.removeRequestHeaders is defined %}
+        <parameter name="removeRequestHeaders" value="{{apim.transport_headers.removeRequestHeaders}}"/>
+    {% endif %}
+    {% if apim.transport_headers.preserveRequestHeaders is defined %}
+        <parameter name="preserveRequestHeaders" value="{{apim.transport_headers.preserveRequestHeaders}}"/>
+    {% endif %}
+    {% if apim.transport_headers.excludeRequestHeaders is defined %}
+        <parameter name="excludeRequestHeaders" value="{{apim.transport_headers.excludeRequestHeaders}}"/>
+    {% endif %}
+    {% if apim.transport_headers.excludeResponseHeaders is defined %}
+        <parameter name="excludeResponseHeaders" value="{{apim.transport_headers.excludeResponseHeaders}}"/>
+    {% endif %}
+    </handler>
+{% endif %}
+{% endif %}
 </handlers>


### PR DESCRIPTION
This PR adds required templating configs to synapse-handlers.xml.j2 file to enable TransportHeaderHandler introduced in https://github.com/wso2/carbon-apimgt/pull/9524

The configs need to be added in the deployment.toml are as follows with the change.

```
[apim.transport_headers]
enable = false
removeRequestHeaders = "true"
preserveRequestHeaders = ""
excludeRequestHeaders = ""
excludeResponseHeaders = ""
```

Since this is a specific case, the configs are added separately giving the option to enable/disable the feature.