### PR TITLE
Remove X-JWT-Assertion from client response

### DIFF
--- a/modules/distribution/product/src/main/conf/synapse-configs/default/sequences/_threat_fault_.xml
+++ b/modules/distribution/product/src/main/conf/synapse-configs/default/sequences/_threat_fault_.xml
@@ -43,6 +43,7 @@
     <property name="Authorization" scope="transport" action="remove"/>
     <property name="Host" scope="transport" action="remove"/>
     <property name="Accept" scope="transport" action="remove"/>
+    <property name="X-JWT-Assertion" scope="transport" action="remove"/>
     <property name="HTTP_SC" scope="axis2" type="STRING" value="400"/>
     <sequence key="_cors_request_handler_"/>
     <send/>


### PR DESCRIPTION
As $subject, this will remove the X-JWT-Assertion header from the client response.

**Fixes**
https://github.com/wso2/product-apim/issues/9673