### PR TITLE
Add missing configs in J2 files

### DIFF
--- a/modules/distribution/product/src/main/resources/conf/default.json
+++ b/modules/distribution/product/src/main/resources/conf/default.json
@@ -5,7 +5,6 @@
   "server.enableMTOM": false,
   "server.enableSwA": false,
   "server.discard_empty_caches": false,
-  "everyone.rolename": "everyone",
   "identity.data_source": "jdbc/WSO2AM_DB",
   "database.apim_db.url": "jdbc:h2:./repository/database/WSO2AM_DB;DB_CLOSE_ON_EXIT=FALSE;AUTO_SERVER=TRUE;LOCK_TIMEOUT=60000;MVCC=TRUE",
   "database.apim_db.driver": "org.h2.Driver",

--- a/modules/distribution/product/src/main/resources/conf/default.json
+++ b/modules/distribution/product/src/main/resources/conf/default.json
@@ -5,6 +5,7 @@
   "server.enableMTOM": false,
   "server.enableSwA": false,
   "server.discard_empty_caches": false,
+  "everyone.rolename": "everyone",
   "identity.data_source": "jdbc/WSO2AM_DB",
   "database.apim_db.url": "jdbc:h2:./repository/database/WSO2AM_DB;DB_CLOSE_ON_EXIT=FALSE;AUTO_SERVER=TRUE;LOCK_TIMEOUT=60000;MVCC=TRUE",
   "database.apim_db.driver": "org.h2.Driver",

--- a/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/axis2.xml.j2
+++ b/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/axis2.xml.j2
@@ -87,6 +87,9 @@
     <!-- Synapse Server name parameter -->
     <parameter name="SynapseConfig.ServerName" locked="false">localhost</parameter>
 
+    <!-- Configuration to include full Security Exception Message -->
+    <parameter name="includeFullWSSecurityExceptionMessage" locked="false">true</parameter>
+
     <!-- To override repository/services you need to uncomment following parameter and value -->
     <!-- SHOULD be absolute file path. -->
     <!--<parameter name="ServicesDirectory" locked="false">service</parameter>-->


### PR DESCRIPTION
### Purpose
Add support to `<parameter name="includeFullWSSecurityExceptionMessage" locked="false">true</parameter>`
 property in axis2.xml files.

### Goal

Fixes https://github.com/wso2/product-apim/issues/9585