### PR TITLE
Add location header handler to the existing APIs

### DIFF
--- a/modules/distribution/product/src/main/conf/synapse-configs/default/api/_AuthenticationEPAPI_.xml
+++ b/modules/distribution/product/src/main/conf/synapse-configs/default/api/_AuthenticationEPAPI_.xml
@@ -21,5 +21,6 @@
     <handlers>
         <handler class="org.wso2.carbon.apimgt.gateway.handlers.ext.APIManagerCacheExtensionHandler"/>
         <handler class="org.wso2.carbon.apimgt.gateway.handlers.common.SynapsePropertiesHandler"/>
+        <handler class="org.wso2.carbon.apimgt.gateway.handlers.common.LocationHeaderHandler"/>
     </handlers>
 </api>

--- a/modules/distribution/product/src/main/conf/synapse-configs/default/api/_AuthorizeAPI_.xml
+++ b/modules/distribution/product/src/main/conf/synapse-configs/default/api/_AuthorizeAPI_.xml
@@ -20,5 +20,6 @@
     </resource>
     <handlers>
         <handler class="org.wso2.carbon.apimgt.gateway.handlers.common.SynapsePropertiesHandler"/>
+        <handler class="org.wso2.carbon.apimgt.gateway.handlers.common.LocationHeaderHandler"/>
     </handlers>
 </api>

--- a/modules/distribution/product/src/main/conf/synapse-configs/default/api/_CommonAuthAPI_.xml
+++ b/modules/distribution/product/src/main/conf/synapse-configs/default/api/_CommonAuthAPI_.xml
@@ -20,5 +20,6 @@
     </resource>
     <handlers>
         <handler class="org.wso2.carbon.apimgt.gateway.handlers.common.SynapsePropertiesHandler"/>
+        <handler class="org.wso2.carbon.apimgt.gateway.handlers.common.LocationHeaderHandler"/>
     </handlers>
 </api>

--- a/modules/distribution/product/src/main/conf/synapse-configs/default/api/_LoginContextAPI_.xml
+++ b/modules/distribution/product/src/main/conf/synapse-configs/default/api/_LoginContextAPI_.xml
@@ -20,5 +20,6 @@
     </resource>
     <handlers>
         <handler class="org.wso2.carbon.apimgt.gateway.handlers.common.SynapsePropertiesHandler"/>
+        <handler class="org.wso2.carbon.apimgt.gateway.handlers.common.LocationHeaderHandler"/>
     </handlers>
 </api>

--- a/modules/distribution/product/src/main/conf/synapse-configs/default/api/_OIDCAPI_.xml
+++ b/modules/distribution/product/src/main/conf/synapse-configs/default/api/_OIDCAPI_.xml
@@ -21,5 +21,6 @@
     <handlers>
         <handler class="org.wso2.carbon.apimgt.gateway.handlers.ext.APIManagerCacheExtensionHandler"/>
         <handler class="org.wso2.carbon.apimgt.gateway.handlers.common.SynapsePropertiesHandler"/>
+        <handler class="org.wso2.carbon.apimgt.gateway.handlers.common.LocationHeaderHandler"/>
     </handlers>
 </api>

--- a/modules/distribution/product/src/main/conf/synapse-configs/default/api/_OpenIDConfigAPI_.xml
+++ b/modules/distribution/product/src/main/conf/synapse-configs/default/api/_OpenIDConfigAPI_.xml
@@ -21,5 +21,6 @@
     </resource>
     <handlers>
         <handler class="org.wso2.carbon.apimgt.gateway.handlers.common.SynapsePropertiesHandler"/>
+        <handler class="org.wso2.carbon.apimgt.gateway.handlers.common.LocationHeaderHandler"/>
     </handlers>
 </api>

--- a/modules/distribution/product/src/main/conf/synapse-configs/default/api/_OpenService_.xml
+++ b/modules/distribution/product/src/main/conf/synapse-configs/default/api/_OpenService_.xml
@@ -10,5 +10,6 @@
     </resource>
     <handlers>
         <handler class="org.wso2.carbon.apimgt.gateway.handlers.common.SynapsePropertiesHandler"/>
+        <handler class="org.wso2.carbon.apimgt.gateway.handlers.common.LocationHeaderHandler"/>
     </handlers>
 </api>

--- a/modules/distribution/product/src/main/conf/synapse-configs/default/api/_RevokeAPI_.xml
+++ b/modules/distribution/product/src/main/conf/synapse-configs/default/api/_RevokeAPI_.xml
@@ -20,5 +20,6 @@
     </resource>
     <handlers>
         <handler class="org.wso2.carbon.apimgt.gateway.handlers.common.SynapsePropertiesHandler"/>
+        <handler class="org.wso2.carbon.apimgt.gateway.handlers.common.LocationHeaderHandler"/>
     </handlers>
 </api>

--- a/modules/distribution/product/src/main/conf/synapse-configs/default/api/_TokenAPI_.xml
+++ b/modules/distribution/product/src/main/conf/synapse-configs/default/api/_TokenAPI_.xml
@@ -21,5 +21,6 @@
     <handlers>
         <handler class="org.wso2.carbon.apimgt.gateway.handlers.ext.APIManagerCacheExtensionHandler"/>
         <handler class="org.wso2.carbon.apimgt.gateway.handlers.common.SynapsePropertiesHandler"/>
+        <handler class="org.wso2.carbon.apimgt.gateway.handlers.common.LocationHeaderHandler"/>
     </handlers>
 </api>

--- a/modules/distribution/product/src/main/conf/synapse-configs/default/api/_UserInfoAPI_.xml
+++ b/modules/distribution/product/src/main/conf/synapse-configs/default/api/_UserInfoAPI_.xml
@@ -20,5 +20,6 @@
     </resource>
     <handlers>
         <handler class="org.wso2.carbon.apimgt.gateway.handlers.common.SynapsePropertiesHandler"/>
+        <handler class="org.wso2.carbon.apimgt.gateway.handlers.common.LocationHeaderHandler"/>
     </handlers>
 </api>


### PR DESCRIPTION
This PR adds the location header handler to the existing APIs to be used when the is km reverse proxy is enabled.

Related issues: https://github.com/wso2/product-apim/issues/8758
Related PR: https://github.com/wso2/carbon-apimgt/pull/9579