### PR TITLE
Adding global handler defining in toml support

### DIFF
--- a/modules/distribution/product/src/main/resources/conf/default.json
+++ b/modules/distribution/product/src/main/resources/conf/default.json
@@ -353,5 +353,9 @@
       "depends": "soapservice,restservice,wsdl",
       "usedby": "soapservice,restservice,wsdl,endpoint"
     }
-  ]
+  ],
+  "synapse_handlers.external_call_logger.name": "externalCallLogger",
+  "synapse_handlers.external_call_logger.class": "org.wso2.carbon.apimgt.gateway.handlers.LogsHandler",
+  "synapse_handlers.open_tracing.name": "open_tracing",
+  "synapse_handlers.open_tracing.class": "org.wso2.carbon.apimgt.gateway.handlers.common.APIMgtLatencySynapseHandler"
 }

--- a/modules/distribution/product/src/main/resources/conf/infer.json
+++ b/modules/distribution/product/src/main/resources/conf/infer.json
@@ -7,14 +7,8 @@
       "apim.throttling.enable_blacklist_condition": true,
       "indexing.enable": false,
       "system.parameter.profile": "gateway-worker",
-      "enabled_global_handlers": [
-        "external_call_logger",
-        "open_tracing"
-      ],
-      "synapse_handlers.external_call_logger.name": "externalCallLogger",
-      "synapse_handlers.external_call_logger.class": "org.wso2.carbon.apimgt.gateway.handlers.LogsHandler",
-      "synapse_handlers.open_tracing.name": "open_tracing",
-      "synapse_handlers.open_tracing.class": "org.wso2.carbon.apimgt.gateway.handlers.common.APIMgtLatencySynapseHandler",
+      "synapse_handlers.external_call_logger.enabled": true,
+      "synapse_handlers.open_tracing.enabled": true,
       "apim.key_manager.enable_registration": false
     },
     "api-key-manager": {
@@ -63,14 +57,8 @@
     },
     "default": {
       "oauth.extensions.token_generator": "org.wso2.carbon.identity.oauth2.token.OauthTokenIssuerImpl",
-      "enabled_global_handlers": [
-        "external_call_logger",
-        "open_tracing"
-      ],
-      "synapse_handlers.external_call_logger.name": "externalCallLogger",
-      "synapse_handlers.external_call_logger.class": "org.wso2.carbon.apimgt.gateway.handlers.LogsHandler",
-      "synapse_handlers.open_tracing.name": "open_tracing",
-      "synapse_handlers.open_tracing.class": "org.wso2.carbon.apimgt.gateway.handlers.common.APIMgtLatencySynapseHandler"
+      "synapse_handlers.external_call_logger.enabled": true,
+      "synapse_handlers.open_tracing.enabled": true
     }
   },
   "apim.jwt.encoding": {

--- a/modules/distribution/product/src/main/resources/conf/templates/repository/conf/synapse-handlers.xml.j2
+++ b/modules/distribution/product/src/main/resources/conf/templates/repository/conf/synapse-handlers.xml.j2
@@ -1,7 +1,7 @@
 <handlers xmlns:svns="http://org.wso2.securevault/configuration">
-{% for item in synapse_handlers %}
-    {% if item.enabled %}
-    <handler name="{{item.name}}" class="{{item.class}}"/>
+{% for key,value in synapse_handlers.items() %}
+    {% if value.enabled %}
+    <handler name="{{key}}" class="{{value.class}}"/>
     {% endif %}
 {% endfor %}
 

--- a/modules/distribution/product/src/main/resources/conf/templates/repository/conf/synapse-handlers.xml.j2
+++ b/modules/distribution/product/src/main/resources/conf/templates/repository/conf/synapse-handlers.xml.j2
@@ -1,7 +1,10 @@
 <handlers xmlns:svns="http://org.wso2.securevault/configuration">
-{% for handler_key in enabled_global_handlers %}
-    <handler name="{{synapse_handlers[handler_key].name}}" class="{{synapse_handlers[handler_key].class}}"/>
+{% for item in synapse_handlers %}
+    {% if item.enabled %}
+    <handler name="{{item.name}}" class="{{item.class}}"/>
+    {% endif %}
 {% endfor %}
+
 {% if apim.transport_headers is defined %}
 {% if apim.transport_headers.enable %}
     <handler name="TransportHeaderHandler" class="org.wso2.carbon.apimgt.gateway.handlers.common.TransportHeaderHandler">


### PR DESCRIPTION
- Use new config for global synapse handler config
- Support defines only the required handler(earlier had to define all the handler that are use by default)

ex:
```
deployment.toml

[synapse_handlers.custom_handler_one]
enabled=true
class="org.wso2.carbon.apimgt.gateway.handlers.custom.customer_handler_one"

[synapse_handlers.custom_handler_two]
enabled=true
class="org.wso2.carbon.apimgt.gateway.handlers.custom.customer_handler_two"

[synapse_handlers.custom_handler_three]
enabled=false
class="org.wso2.carbon.apimgt.gateway.handlers.custom.customer_handler_three"
```