### PR TITLE
Hybrid endpoint support when invoking APIs secured with ApiKey only or BasicAuth only 

### DIFF
--- a/modules/distribution/resources/api_templates/api_product_template.xml
+++ b/modules/distribution/resources/api_templates/api_product_template.xml
@@ -193,7 +193,7 @@ $in_sequences.get("$resource.getUriTemplate()").get($uri)
 #else
 #set( $filterRegex = "PRODUCTION" )
 #end
-#if($apiStatus != 'PROTOTYPED' && $apiIsOauthProtected)
+#if($apiStatus != 'PROTOTYPED' && ($apiIsOauthProtected || $apiIsApiKeyProtected || $apiIsBasicAuthProtected))
 <filter source="$ctx:AM_KEY_TYPE" regex="$filterRegex">
     <then>
         #end
@@ -202,7 +202,7 @@ $in_sequences.get("$resource.getUriTemplate()").get($uri)
         #else
         #draw_endpoint( "production" $endpoint_json $endpointSecurity)
         #end
-        #if($apiStatus != 'PROTOTYPED' && $apiIsOauthProtected)
+        #if($apiStatus != 'PROTOTYPED' && ($apiIsOauthProtected || $apiIsApiKeyProtected || $apiIsBasicAuthProtected))
     </then>
     <else>
         #if($environmentType !='hybrid')

--- a/modules/distribution/resources/api_templates/velocity_template.xml
+++ b/modules/distribution/resources/api_templates/velocity_template.xml
@@ -200,7 +200,7 @@ $in_sequences.get("$resource.getUriTemplate()").get($uri)
 <loopback />
 ## AWS Lambda: end
 #else
-#if($apiStatus != 'PROTOTYPED' && $apiIsOauthProtected)
+#if($apiStatus != 'PROTOTYPED' && ($apiIsOauthProtected || $apiIsApiKeyProtected || $apiIsBasicAuthProtected))
 <filter source="$ctx:AM_KEY_TYPE" regex="$filterRegex">
     <then>
         #end
@@ -209,7 +209,7 @@ $in_sequences.get("$resource.getUriTemplate()").get($uri)
         #else
         #draw_endpoint( "production" $endpoint_config )
         #end
-        #if($apiStatus != 'PROTOTYPED' && $apiIsOauthProtected)
+        #if($apiStatus != 'PROTOTYPED' && ($apiIsOauthProtected || $apiIsApiKeyProtected || $apiIsBasicAuthProtected))
     </then>
     <else>
         #if($environmentType !='hybrid')


### PR DESCRIPTION
### Purpose
After configuring an API to use only API Key security or Basic Auth security type, when invoking the API using the sandbox API Key, the request is directed to the production endpoint. This PR will solve that issue.

### Goal 
Fixes https://github.com/wso2/product-apim/issues/8483 

### Approach
The velocity template was not checking for `apiKey authenticated` property and `basic_aut authenticated`  property. It only checks `oauth2 authenticated` property when mapping hybrid endpoints. Therefore, the api.xml resources are generated without both endpoint types(SandBox and Production). This fix will check for the missing properties and make the validation and templating will be done after that.

