### PR TITLE
[Streaming API] Reorder Websub handlers

### DIFF
--- a/modules/distribution/resources/api_templates/websub_api_template.xml
+++ b/modules/distribution/resources/api_templates/websub_api_template.xml
@@ -102,10 +102,6 @@
         </inSequence>
     </resource>
     <handlers>
-        <handler class="org.wso2.carbon.apimgt.gateway.handlers.streaming.webhook.WebhookApiHandler">
-            <property name="subscriptionResourcePath" value="/webhooks_events_receiver_resource"/>
-            <property name="topicQueryParamName" value="hub.secret"/>
-        </handler>
         #foreach($handler in $handlers)
         <handler class="$handler.className">
             #if($handler.hasProperties())
@@ -116,5 +112,9 @@
             #end
         </handler>
         #end
+        <handler class="org.wso2.carbon.apimgt.gateway.handlers.streaming.webhook.WebhookApiHandler">
+            <property name="subscriptionResourcePath" value="/webhooks_events_receiver_resource"/>
+            <property name="topicQueryParamName" value="hub.secret"/>
+        </handler>
     </handlers>
 </api>


### PR DESCRIPTION
Reorder websub handlers, to appear in the following order:
```xml
<handlers>
   <handler class="org.wso2.carbon.apimgt.gateway.handlers.security.CORSRequestHandler">...</handler>
   <handler class="org.wso2.carbon.apimgt.gateway.handlers.security.APIAuthenticationHandler">...</handler>
   <handler class="org.wso2.carbon.apimgt.gateway.handlers.streaming.webhook.WebhookApiHandler">...</handler>
</handlers>
```