### PR TITLE
Adding an integration test to validate JsonStreamFormatter error while sending GET request with messageType property

### DIFF
--- a/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/utils/base/APIMIntegrationConstants.java
+++ b/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/utils/base/APIMIntegrationConstants.java
@@ -162,4 +162,8 @@ public class APIMIntegrationConstants {
         public static final String CREATOR = "Internal/creator";
         public static final String EVERYONE = "Internal/everyone";
     }
+
+    public static final String ADMIN_USERNAME = "admin";
+    public static final String ADMIN_PASSWORD = "admin";
+    public static final String LOCAL_HOST_NAME = "localhost";
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/APIInvocationWithMessageTypeProperty.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/APIInvocationWithMessageTypeProperty.java
@@ -54,7 +54,6 @@ public class APIInvocationWithMessageTypeProperty extends APIMIntegrationBaseTes
         OMElement synapseConfig = APIMTestCaseUtils.loadResource(file);
         APIMTestCaseUtils.updateSynapseConfiguration(synapseConfig, gatewayContextMgt.getContextUrls().getBackEndUrl(),
                 session);
-        Thread.sleep(5000);
     }
 
     @SetEnvironment(executionEnvironments = {ExecutionEnvironment.STANDALONE})

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/APIInvocationWithMessageTypeProperty.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/APIInvocationWithMessageTypeProperty.java
@@ -70,7 +70,7 @@ public class APIInvocationWithMessageTypeProperty extends APIMIntegrationBaseTes
     }
 
     @AfterClass(alwaysRun = true)
-    public void stop() throws Exception {
-        cleanUp();
+    public void destroy() throws Exception {
+
     }
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/APIInvocationWithMessageTypeProperty.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/APIInvocationWithMessageTypeProperty.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.am.integration.tests.other;
+
+import org.apache.axiom.om.OMElement;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.am.integration.test.utils.base.APIMIntegrationBaseTest;
+import org.wso2.am.integration.test.utils.generic.APIMTestCaseUtils;
+import org.wso2.am.integration.test.utils.monitor.utils.WireMonitorServer;
+import org.wso2.carbon.automation.engine.annotations.ExecutionEnvironment;
+import org.wso2.carbon.automation.engine.annotations.SetEnvironment;
+import org.wso2.carbon.automation.test.utils.http.client.HttpRequestUtil;
+import org.wso2.carbon.automation.test.utils.http.client.HttpResponse;
+import org.wso2.carbon.integration.common.admin.client.AuthenticatorClient;
+
+import java.io.File;
+import java.util.HashMap;
+
+/**
+ * When we have an API with an in-sequence with messageType property
+ * check whether the GET request behaves as expected.
+ */
+public class APIInvocationWithMessageTypeProperty extends APIMIntegrationBaseTest {
+
+    private WireMonitorServer wireServer;
+
+    @BeforeClass(alwaysRun = true)
+    public void setEnvironment() throws Exception {
+        super.init();
+        wireServer = new WireMonitorServer(8991);
+        AuthenticatorClient login = new AuthenticatorClient(gatewayContextMgt.getContextUrls().getBackEndUrl());
+        String session = login.login("admin", "admin", "localhost");
+        // Upload the synapse
+        String file = "artifacts" + File.separator + "AM" + File.separator + "synapseconfigs" + File.separator
+                + "property" + File.separator + "dummy_api_with_in_sequence.xml";
+        OMElement synapseConfig = APIMTestCaseUtils.loadResource(file);
+        APIMTestCaseUtils.updateSynapseConfiguration(synapseConfig, gatewayContextMgt.getContextUrls().getBackEndUrl(),
+                session);
+        Thread.sleep(5000);
+    }
+
+    @SetEnvironment(executionEnvironments = {ExecutionEnvironment.STANDALONE})
+    @Test(groups = "wso2.am", description = "Test for GET request for an API with in-sequence with messageType "
+            + "property")
+    public void testInovkeAPIWithMessageTypePropertyInSequence() throws Exception {
+        wireServer.start();
+        HttpResponse response = HttpRequestUtil
+                .doGet(gatewayUrlsWrk.getWebAppURLNhttp() + "msgtypeproperty", new HashMap<String, String>());
+        Assert.assertNotNull(response, "Error invoking API with in-sequence with messageType property");
+        Assert.assertTrue(response.getResponseMessage().contains("Accepted"),
+                "Error invoking API with in-sequence with messageType property");
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void stop() throws Exception {
+        cleanUp();
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/APIInvocationWithMessageTypeProperty.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/APIInvocationWithMessageTypeProperty.java
@@ -23,6 +23,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.am.integration.test.utils.base.APIMIntegrationBaseTest;
+import org.wso2.am.integration.test.utils.base.APIMIntegrationConstants;
 import org.wso2.am.integration.test.utils.generic.APIMTestCaseUtils;
 import org.wso2.am.integration.test.utils.monitor.utils.WireMonitorServer;
 import org.wso2.carbon.automation.engine.annotations.ExecutionEnvironment;
@@ -47,7 +48,8 @@ public class APIInvocationWithMessageTypeProperty extends APIMIntegrationBaseTes
         super.init();
         wireServer = new WireMonitorServer(8991);
         AuthenticatorClient login = new AuthenticatorClient(gatewayContextMgt.getContextUrls().getBackEndUrl());
-        String session = login.login("admin", "admin", "localhost");
+        String session = login.login(APIMIntegrationConstants.ADMIN_USERNAME, APIMIntegrationConstants.ADMIN_PASSWORD,
+                APIMIntegrationConstants.LOCAL_HOST_NAME);
         // Upload the synapse
         String file = "artifacts" + File.separator + "AM" + File.separator + "synapseconfigs" + File.separator
                 + "property" + File.separator + "dummy_api_with_in_sequence.xml";

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/synapseconfigs/property/dummy_api_with_in_sequence.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/synapseconfigs/property/dummy_api_with_in_sequence.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://ws.apache.org/ns/synapse">
+    <api context="/msgtypeproperty" name="MessageTypePropertyAPI" xmlns="http://ws.apache.org/ns/synapse">
+        <resource methods="GET" url-mapping="/*">
+            <inSequence>
+                <property name="messageType" scope="axis2" type="STRING" value="application/json"/>
+                <call>
+                    <endpoint>
+                        <http uri-template="http://localhost:8991/am/sample/calculator/v1/api/multiply"/>
+                    </endpoint>
+                </call>
+                <respond/>
+            </inSequence>
+            <outSequence/>
+            <faultSequence/>
+        </resource>
+    </api>
+</definitions>

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -32,6 +32,7 @@
             <class name="org.wso2.am.integration.tests.jwt.JWTRevocationTestCase"/>
             <class name="org.wso2.am.integration.tests.oas.OASTestCase"/>
             <class name="org.wso2.am.integration.tests.api.revision.APIRevisionTestCase"/>
+            <class name="org.wso2.am.integration.tests.other.APIInvocationWithMessageTypeProperty"/>
         </classes>
     </test>
 


### PR DESCRIPTION
## Purpose
Adding the test for the fix for [1] which is done by [2].

## Goals
Add a new integration test to validate JsonStreamFormatter error while sending GET request with messageType property.

## Approach
After writing the integration test, I have run all the integration tests locally as shown below and all are passed.
![image](https://user-images.githubusercontent.com/25246848/107610793-7a593f80-6c68-11eb-8345-6cfb234dfe73.png)

[1] https://github.com/wso2/product-ei/issues/5348
[2] https://github.com/wso2-support/wso2-synapse/pull/1055