### PR TITLE
Add ConfigurableLoggerAccessLogValve to product config template

### DIFF
--- a/modules/distribution/product/src/main/resources/conf/templates/repository/conf/tomcat/catalina-server.xml.j2
+++ b/modules/distribution/product/src/main/resources/conf/templates/repository/conf/tomcat/catalina-server.xml.j2
@@ -63,9 +63,13 @@
                 <Valve className="org.wso2.carbon.tomcat.ext.valves.RequestCorrelationIdValve"
                        headerToCorrelationIdMapping="{'activityid':'Correlation-ID'}" queryToCorrelationIdMapping="{'RelayState':'Correlation-ID'}"/>
                 <Valve className="org.wso2.carbon.tomcat.ext.valves.CarbonContextCreatorValve"/>
+                {% if http_access_log.useLogger is sameas true %}
+                <Valve className="org.wso2.carbon.tomcat.ext.valves.ConfigurableLoggerAccessLogValve"
+                        pattern="{{http_access_log.pattern}}"/>
+                {% else %}
                 <Valve className="org.apache.catalina.valves.AccessLogValve" directory="{{http_access_log.directory}}"
                        prefix="{{http_access_log.prefix}}" suffix="{{http_access_log.suffix}}" pattern="{{http_access_log.pattern}}"/>
-
+                {% endif %}
                 <Valve className="org.wso2.carbon.tomcat.ext.valves.CarbonStuckThreadDetectionValve" threshold="600"/>
                 <Valve className="org.wso2.carbon.tomcat.ext.valves.CompositeValve"/>
 


### PR DESCRIPTION
This PR adds ConfigurableLoggerAccessLogValve to product config template.

Related PR - https://github.com/wso2/carbon-kernel/pull
Related issue - https://github.com/wso2/carbon-kernel/issues/2660