### PR TITLE
Add J2 template for Registry Handlers

### DIFF
--- a/modules/distribution/product/src/main/resources/conf/templates/repository/conf/registry.xml.j2
+++ b/modules/distribution/product/src/main/resources/conf/templates/repository/conf/registry.xml.j2
@@ -124,6 +124,27 @@
          </filter>
     </handler>
 
+    <!--Config for custom registry handlers.-->
+    {% for handler in registry_handler %}
+    <handler class="{{handler.class}}" {% if handler.method is defined %} method="{{handler.method}}" {% endif %}>
+        {% for propKey,propValue in handler.properties.items() %}
+        <property name="{{propKey}}">{{propValue}}</property>
+        {% endfor %}
+        {% if handler.nested_property.enable %}
+        <property name="{{handler.nested_property.name}}" type="{{handler.nested_property.type}}">
+            {% for prop in nested_properties[handler.nested_property.name] %}
+                <{{prop.tag}} {% if prop.key is defined %} key="{{prop.key}}" {% endif %}>{{prop.value}}</{{prop.tag}}>
+            {% endfor %}
+        </property>
+        {% endif %}
+        <filter class="{{handler.filter_class}}">
+            {% for filterPropKey,filterPropValue in handler.filter_properties.items() %}
+            <property name="{{filterPropKey}}">{{filterPropValue}}</property>
+            {% endfor %}
+        </filter>
+    </handler>
+    {% endfor %}
+
     <!--This handler clears the caches when tenant-config is updated.-->
    <handler class="org.wso2.carbon.apimgt.impl.handlers.TenantConfigMediaTypeHandler" methods="PUT,DELETE">
       <filter class="org.wso2.carbon.registry.core.jdbc.handlers.filters.MediaTypeMatcher">


### PR DESCRIPTION
This PR introduces J2 template to configure Registry Handlers in the registry.xml artifact.
Fixes https://github.com/wso2/product-apim/issues/9932

A sample `toml` configuration will be as follows.

```toml
# Define a registry handler
[[registry_handler]]
class = "RegistryHandlerClass"
method = "PUT,GET"
filter_class = "RegistryFilterClass"

# Define registry handler property elements
[registry_handler.properties]
propertyOne = "propertyOneVlaue"

# Define registry handler filter elements
[registry_handler.filter_properties]
filterProperty = "filterPropertyValue"

# Define custom property elements
[registry_handler.nested_property]
enable = true
name = "RegistryNestedPropertyName"
type = "xml"

# The key should be as nested_properies.'<name defined in registry_handler.nested_property>'
[[nested_properties.RegistryNestedPropertyName]]
tag = 'Tag'
key = 'key'
value = 'value'
[[nested_properties.RegistryNestedPropertyName]]
tag = 'Tag'
key = 'AnotherKey'
value = 'Anothervalue'
```

