### PR TITLE
Deploy an API revision before publishing APIs to have endpoints

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/APIM720GetAllEndPointsTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/APIM720GetAllEndPointsTestCase.java
@@ -121,6 +121,7 @@ public class APIM720GetAllEndPointsTestCase extends APIMIntegrationBaseTest {
         assertEquals(getAPIResponse.getResponseCode(), Response.Status.OK.getStatusCode(),
                 "Error when retrieving API: " + apiName);
 
+        createAPIRevisionAndDeployUsingRest(apiID, restAPIPublisher);
         //publish API
         HttpResponse changeLCStatusResponse = restAPIPublisher.changeAPILifeCycleStatus(apiID,
                 APILifeCycleAction.PUBLISH.getAction(), null);


### PR DESCRIPTION
## Description
$subject
Since there are no endpoints if, no revision of API is deployed to an environment.