### PR TITLE
Remove timeout response action for WS endpoints

### DIFF
--- a/modules/distribution/resources/api_templates/endpoint_template.xml
+++ b/modules/distribution/resources/api_templates/endpoint_template.xml
@@ -53,8 +53,8 @@
 #print_if_exist_only("duration" $config.get("actionDuration"))
 #print_if_exist_only("responseAction" $config.get("actionSelect"))
 </timeout>
-#else
-        ##add default timeout config
+#elseif( $endpointClass != "ws" )
+        ##add default timeout config for non WS endpoints
 <timeout>
      <responseAction>fault</responseAction>
 </timeout>


### PR DESCRIPTION
## Purpose
$subject. This is to avoid WS frames being returned to the sender after the timeout.

**WS Endpoint**
- Before this change:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<endpoint xmlns="http://ws.apache.org/ns/synapse" name="WS--v1.0.0_APIproductionEndpoint_mapping__notifications">
    <http uri-template="ws://localhost:8080/notifications">
       <timeout>
            <responseAction>fault</responseAction>
        </timeout>
    </http>
    <property name="ENDPOINT_ADDRESS" value="ws://localhost:8080/notifications"/>
</endpoint>
```

- With this change:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<endpoint xmlns="http://ws.apache.org/ns/synapse" name="WS--v1.0.0_APIproductionEndpoint_mapping__notifications">
    <http uri-template="ws://localhost:8080/notifications"/>
    <property name="ENDPOINT_ADDRESS" value="ws://localhost:8080/notifications"/>
</endpoint>
```