### PR TITLE
[Streaming API] Add multi-tenant msg context properties for WebSockets

### DIFF
--- a/modules/distribution/product/src/main/assembly/bin.xml
+++ b/modules/distribution/product/src/main/assembly/bin.xml
@@ -1232,7 +1232,6 @@
             <source>src/main/conf/multitenant-msg-context.properties</source>
             <outputDirectory>wso2am-${pom.version}/repository/conf</outputDirectory>
             <destName>multitenant-msg-context.properties</destName>
-            <filtered>true</filtered>
         </file>
         <file>
             <source>src/main/conf/sec.policy</source>

--- a/modules/distribution/product/src/main/assembly/bin.xml
+++ b/modules/distribution/product/src/main/assembly/bin.xml
@@ -1229,6 +1229,12 @@
             <filtered>true</filtered>
         </file>
         <file>
+            <source>src/main/conf/multitenant-msg-context.properties</source>
+            <outputDirectory>wso2am-${pom.version}/repository/conf</outputDirectory>
+            <destName>multitenant-msg-context.properties</destName>
+            <filtered>true</filtered>
+        </file>
+        <file>
             <source>src/main/conf/sec.policy</source>
             <outputDirectory>wso2am-${pom.version}/repository/conf</outputDirectory>
             <destName>sec.policy</destName>

--- a/modules/distribution/product/src/main/conf/multitenant-msg-context.properties
+++ b/modules/distribution/product/src/main/conf/multitenant-msg-context.properties
@@ -1,0 +1,28 @@
+#
+# Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+inbound-response-worker=xx
+
+# WebSocket properties
+websocket.source.handler.context=xx
+websocket.text.frame.present=xx
+websocket.text.frame=xx
+websocket.binary.frame.present=xx
+websocket.binary.frame=xx
+websocket.source.handshake.present=xx
+websocket.target.handshake.present=xx


### PR DESCRIPTION
## Purpose
Addresses https://github.com/wso2/product-apim/issues/10250. 
When calling a WebSocket API from a tenant, the mentioned properties will be copied from axisContext, and as a result, the following line will be called:
https://github.com/wso2/wso2-synapse/blob/master/modules/core/src/main/java/org/apache/synapse/core/axis2/Axis2Sender.java#L205

**Note:** Only the keys of these properties are required.