### PR TITLE
Upgrade analytics event publisher version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1468,7 +1468,7 @@
         <auth0.keymanager.feature.version>1.0.1</auth0.keymanager.feature.version>
         <pingfederate.keymanager.feature.version>1.0.3</pingfederate.keymanager.feature.version>
         <forgerock.keymanager.feature.version>1.0.2</forgerock.keymanager.feature.version>
-        <apim.analytics.publisher.version>1.0.0-ALPHA2</apim.analytics.publisher.version>
+        <apim.analytics.publisher.version>1.0.0-BETA2</apim.analytics.publisher.version>
     </properties>
 
 </project>


### PR DESCRIPTION
- Upgrade analytics event publisher version to 1.0.0-BETA2