### PR TITLE
Fix API Product related integration test failures.

### DIFF
--- a/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/impl/ApiProductTestHelper.java
+++ b/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/impl/ApiProductTestHelper.java
@@ -48,10 +48,12 @@ import java.util.stream.Collectors;
  * A collection of helper methods to aid in setting up and testing APIProducts
  */
 public class ApiProductTestHelper {
+
     private RestAPIPublisherImpl restAPIPublisher;
     private RestAPIStoreImpl restAPIStore;
 
     public ApiProductTestHelper(RestAPIPublisherImpl restAPIPublisher, RestAPIStoreImpl restAPIStore) {
+
         this.restAPIPublisher = restAPIPublisher;
         this.restAPIStore = restAPIStore;
     }
@@ -82,8 +84,6 @@ public class ApiProductTestHelper {
             Assert.assertEquals(responseData.getContext(),
                     String.format("/t/%s%s", restAPIPublisher.tenantDomain, context));
         }
-
-
 
         return responseData;
     }
@@ -126,10 +126,11 @@ public class ApiProductTestHelper {
 
         // Validate APIProduct by Id
         APIProductDTO returnedProduct = restAPIPublisher.getApiProduct(responseData.getId());
-        verifyAPIProductDTOFromPublisher(returnedProduct,responseData);
+        verifyAPIProductDTOFromPublisher(returnedProduct, responseData);
     }
 
     private void verifyAPIProductDTOFromPublisher(APIProductDTO returnedProduct, APIProductDTO responseData) {
+
         Assert.assertEquals(returnedProduct.getId(), responseData.getId());
         Assert.assertEquals(returnedProduct.getName(), responseData.getName());
         Assert.assertEquals(returnedProduct.getContext(), responseData.getContext());
@@ -163,7 +164,7 @@ public class ApiProductTestHelper {
         Assert.assertEquals(returnedProduct.getCreatedTime(), responseData.getCreatedTime());
         Assert.assertEquals(returnedProduct.getLastUpdatedTime(), responseData.getLastUpdatedTime());
         Assert.assertEquals(returnedProduct.getScopes(), responseData.getScopes());
-        verifyProductAPIDto(returnedProduct.getApis(),responseData.getApis());
+        verifyProductAPIDto(returnedProduct.getApis(), responseData.getApis());
     }
 
     private void verifyProductAPIDto(List<ProductAPIDTO> actual, List<ProductAPIDTO> expected) {
@@ -183,6 +184,7 @@ public class ApiProductTestHelper {
     }
 
     private void verifyOperations(List<APIOperationsDTO> actual, List<APIOperationsDTO> expected) {
+
         Assert.assertEquals(actual.size(), expected.size());
         for (APIOperationsDTO actualOperation : actual) {
             APIOperationsDTO matchedOperation = null;
@@ -207,28 +209,30 @@ public class ApiProductTestHelper {
 
     public org.wso2.am.integration.clients.store.api.v1.dto.APIDTO verifyApiProductInPortal(APIProductDTO apiProductDTO)
             throws org.wso2.am.integration.clients.store.api.ApiException, InterruptedException {
+
         org.wso2.am.integration.clients.store.api.v1.dto.APIDTO responseData = restAPIStore.getAPI(apiProductDTO.getId());
 
         // Validate mandatory fields returned in response data
         verifyApiDtoWithApiProduct(responseData, apiProductDTO);
 
-        APIListDTO apiList = restAPIStore.getAllAPIs();
-
-        List<APIInfoDTO> apiInfos = apiList.getList();
-
         boolean isAPIProductInListing = false;
         int productCount = 0;
-        int retries = 0;
-        while(productCount==0 && retries<5){
-            Thread.sleep(5000);
+        int tries = 0;
+        while (productCount == 0 && tries < 5) {
+            APIListDTO apiList = restAPIStore.getAllAPIs();
+            List<APIInfoDTO> apiInfos = apiList.getList();
             for (APIInfoDTO apiInfo : apiInfos) {
                 if (apiInfo.getId().equals(apiProductDTO.getId())) {
                     isAPIProductInListing = true;
                     ++productCount;
                     verifyApiInfoDtoWithApiProduct(apiInfo, apiProductDTO);
+                    break;
                 }
             }
-            retries++;
+            tries++;
+            if (productCount == 0) {
+                Thread.sleep(5000);
+            }
         }
 
         Assert.assertTrue(isAPIProductInListing);
@@ -245,6 +249,7 @@ public class ApiProductTestHelper {
      * @return Collection of API resources to be included in an APIProduct
      */
     private List<ProductAPIDTO> getResourcesForProduct(List<APIDTO> apiDTOs) {
+
         Map<APIDTO, Set<APIOperationsDTO>> selectedApiResourceMapping = new HashMap<>();
 
         // Pick two operations from each API to be used to create the APIProduct.
@@ -259,10 +264,11 @@ public class ApiProductTestHelper {
      * Select all resources from a given API. Resources will be picked sequentially, where the
      * resources itself will be unordered.
      *
-     * @param apiDto API
+     * @param apiDto                     API
      * @param selectedApiResourceMapping Collection for storing the selected resources against the respective API
      */
     private void selectOperationsFromAPI(APIDTO apiDto, Map<APIDTO, Set<APIOperationsDTO>> selectedApiResourceMapping) {
+
         List<APIOperationsDTO> operations = apiDto.getOperations();
 
         Set<APIOperationsDTO> selectedOperations = new HashSet<>();
@@ -278,6 +284,7 @@ public class ApiProductTestHelper {
      * @return Collection of APIProduct resources
      */
     private List<ProductAPIDTO> convertToProductApiResources(Map<APIDTO, Set<APIOperationsDTO>> selectedResources) {
+
         List<ProductAPIDTO> apiResources = new ArrayList<>();
 
         for (Map.Entry<APIDTO, Set<APIOperationsDTO>> entry : selectedResources.entrySet()) {
@@ -294,6 +301,7 @@ public class ApiProductTestHelper {
     }
 
     private void verifyApiProductInfoWithApiProductDto(APIProductInfoDTO apiProductInfoDTO, APIProductDTO apiProductDTO) {
+
         Assert.assertEquals(apiProductInfoDTO.getName(), apiProductDTO.getName());
         Assert.assertEquals(apiProductInfoDTO.getProvider(), apiProductDTO.getProvider());
         Assert.assertEquals(apiProductInfoDTO.getContext(), apiProductDTO.getContext());
@@ -305,6 +313,7 @@ public class ApiProductTestHelper {
     }
 
     private void verifyApiDtoWithApiProduct(org.wso2.am.integration.clients.store.api.v1.dto.APIDTO apiDTO, APIProductDTO apiProductDTO) {
+
         Assert.assertEquals(apiDTO.getId(), apiProductDTO.getId());
         Assert.assertEquals(apiDTO.getAdditionalProperties(), apiProductDTO.getAdditionalProperties());
         verifyBusinessInformation(apiDTO.getBusinessInformation(), apiProductDTO.getBusinessInformation());
@@ -323,6 +332,7 @@ public class ApiProductTestHelper {
     }
 
     private void verifyApiInfoDtoWithApiProduct(APIInfoDTO apiInfo, APIProductDTO apiProductDTO) {
+
         Assert.assertEquals(apiInfo.getContext(), apiProductDTO.getContext());
         Assert.assertEquals(apiInfo.getDescription(), apiProductDTO.getDescription());
         Assert.assertEquals(apiInfo.getId(), apiProductDTO.getId());
@@ -334,6 +344,7 @@ public class ApiProductTestHelper {
 
     private void verifyBusinessInformation(APIBusinessInformationDTO portalBusinessInfo,
                                            APIProductBusinessInformationDTO publisherBusinessInfo) {
+
         Assert.assertEquals(portalBusinessInfo.getBusinessOwner(), publisherBusinessInfo.getBusinessOwner());
         Assert.assertEquals(portalBusinessInfo.getBusinessOwnerEmail(), publisherBusinessInfo.getBusinessOwnerEmail());
         Assert.assertEquals(portalBusinessInfo.getTechnicalOwner(), publisherBusinessInfo.getTechnicalOwner());
@@ -342,6 +353,7 @@ public class ApiProductTestHelper {
 
     private void verifyResources(List<org.wso2.am.integration.clients.store.api.v1.dto.APIOperationsDTO> storeAPIOperations,
                                  List<ProductAPIDTO> publisherAPIProductOperations) {
+
         storeAPIOperations.sort((o1, o2) -> {
             if (o1.getTarget().equals(o2.getTarget())) {
                 return o1.getVerb().compareTo(o2.getVerb());
@@ -375,6 +387,7 @@ public class ApiProductTestHelper {
     }
 
     private void verifyScopes(List<ScopeInfoDTO> scopeInfoDTOs, List<APIScopeDTO> apiScopeDTOS) {
+
         scopeInfoDTOs.sort(Comparator.comparing(ScopeInfoDTO::getName));
         List<ScopeDTO> scopeDTOs = apiScopeDTOS.stream().map(APIScopeDTO::getScope).collect(Collectors.toList());
         scopeDTOs.sort(Comparator.comparing(ScopeDTO::getName));
@@ -393,6 +406,7 @@ public class ApiProductTestHelper {
     }
 
     private void verifyPolicies(List<APITiersDTO> apiTiersDTOs, List<String> policies) {
+
         Assert.assertEquals(apiTiersDTOs.size(), policies.size());
 
         apiTiersDTOs.sort(Comparator.comparing(APITiersDTO::getTierName));

--- a/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/impl/ApiProductTestHelper.java
+++ b/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/impl/ApiProductTestHelper.java
@@ -206,7 +206,7 @@ public class ApiProductTestHelper {
     }
 
     public org.wso2.am.integration.clients.store.api.v1.dto.APIDTO verifyApiProductInPortal(APIProductDTO apiProductDTO)
-            throws org.wso2.am.integration.clients.store.api.ApiException {
+            throws org.wso2.am.integration.clients.store.api.ApiException, InterruptedException {
         org.wso2.am.integration.clients.store.api.v1.dto.APIDTO responseData = restAPIStore.getAPI(apiProductDTO.getId());
 
         // Validate mandatory fields returned in response data
@@ -218,12 +218,17 @@ public class ApiProductTestHelper {
 
         boolean isAPIProductInListing = false;
         int productCount = 0;
-        for (APIInfoDTO apiInfo : apiInfos) {
-            if (apiInfo.getId().equals(apiProductDTO.getId())) {
-                isAPIProductInListing = true;
-                ++productCount;
-                verifyApiInfoDtoWithApiProduct(apiInfo, apiProductDTO);
+        int retries = 0;
+        while(productCount==0 && retries<5){
+            Thread.sleep(5000);
+            for (APIInfoDTO apiInfo : apiInfos) {
+                if (apiInfo.getId().equals(apiProductDTO.getId())) {
+                    isAPIProductInListing = true;
+                    ++productCount;
+                    verifyApiInfoDtoWithApiProduct(apiInfo, apiProductDTO);
+                }
             }
+            retries++;
         }
 
         Assert.assertTrue(isAPIProductInListing);


### PR DESCRIPTION
**The following tests were failing when executed with MSSQL due to time taken for API Products to appear in devportal.**
APIProductCreationTestCase.testCreateAndInvokeApiProductWithScopes
APIProductCreationTestCase.testCreateAndInvokeApiProductWithVisibilityRestrictedApi
 
Fix:
Adding polling with a wait for API product to appear in devportal.