### PR TITLE
Adding extensions cache registry handler

### DIFF
--- a/modules/distribution/product/src/main/resources/conf/templates/repository/conf/registry.xml.j2
+++ b/modules/distribution/product/src/main/resources/conf/templates/repository/conf/registry.xml.j2
@@ -152,6 +152,13 @@
     </filter>
    </handler>
 
+   <!--This handler clears the extensions caches when tenant-config is updated.-->
+   <handler class="org.wso2.is.key.manager.core.handlers.TenantConfigMediaTypeHandler" methods="PUT,DELETE">
+      <filter class="org.wso2.carbon.registry.core.jdbc.handlers.filters.MediaTypeMatcher">
+        <property name="mediaType">tenant-config</property>
+     </filter>
+   </handler>
+
    <!--This handler updates ga-config local entry when ga-config in the registry is updated.-->
    <handler class="org.wso2.carbon.apimgt.impl.handlers.GAConfigMediaTypeHandler" methods="PUT">
       <filter class="org.wso2.carbon.registry.core.jdbc.handlers.filters.MediaTypeMatcher">

--- a/modules/distribution/product/src/main/resources/conf/templates/repository/conf/registry.xml.j2
+++ b/modules/distribution/product/src/main/resources/conf/templates/repository/conf/registry.xml.j2
@@ -345,7 +345,6 @@
         </exclusions>
     </indexingConfiguration>
 
-    
     <versionResourcesOnChange>false</versionResourcesOnChange>
 
     <!-- NOTE: You can edit the options under "StaticConfiguration" only before the

--- a/pom.xml
+++ b/pom.xml
@@ -1462,7 +1462,7 @@
 
         <!-- WSDL4J dependencies -->
         <wsdl4j.version>1.6.3.wso2v3</wsdl4j.version>
-        <wso2is.km.version>1.2.7</wso2is.km.version>
+        <wso2is.km.version>1.2.8</wso2is.km.version>
         <okta.keymanager.feature.version>3.0.6</okta.keymanager.feature.version>
         <keycloak.keymanager.feature.version>2.0.5</keycloak.keymanager.feature.version>
         <auth0.keymanager.feature.version>1.0.1</auth0.keymanager.feature.version>


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim/issues/10549
Fixes: https://github.com/wso2/product-apim/issues/10640

## Goals
Adding extensions cache registry handler which will clear the extensions cache when there is a change in the tenant-conf.json on the registry.

## Related PRs
https://github.com/wso2-extensions/apim-km-wso2is/pull/44

## Test environment
- JDK 1.8.0_251
- Ubuntu 20.04 LTS
