### PR TITLE
Fix integration tests to accommodate API Lifecycle related changes

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/prototype/APIM24VisibilityOfPrototypedAPIOfDifferentViewInStoreTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/prototype/APIM24VisibilityOfPrototypedAPIOfDifferentViewInStoreTestCase.java
@@ -111,7 +111,6 @@ public class APIM24VisibilityOfPrototypedAPIOfDifferentViewInStoreTestCase exten
         apidto.setEndpointConfig(endpoint);
 
         restAPIPublisher.updateAPI(apidto);
-        restAPIPublisher.changeAPILifeCycleStatus(apiId, APILifeCycleAction.DEPLOY_AS_PROTOTYPE.getAction());
 
         HttpResponse response2 = restAPIPublisher.getAPI(apiId);
         Gson g2 = new Gson();

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/publisher/APIM574ChangeTheStatusOfAnAPIToPrototypedThroughThePublisherRestAPITestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/publisher/APIM574ChangeTheStatusOfAnAPIToPrototypedThroughThePublisherRestAPITestCase.java
@@ -129,11 +129,26 @@ public class APIM574ChangeTheStatusOfAnAPIToPrototypedThroughThePublisherRestAPI
                 "publisher");
     }
 
-    @Test(groups = {"wso2.am"}, description = "Change the status of the API to PUBLISHED through" +
+    @Test(groups = {"wso2.am"}, description = "Change the status of the API to CREATED through" +
             " the publisher rest API ", dependsOnMethods = "testChangeTheStatusOfTheAPIToPrototyped")
+    public void testChangeTheStatusOfTheAPIToCreated() throws Exception {
+        //Change the status PROTOTYPED to CREATED
+        restAPIPublisher.changeAPILifeCycleStatus(apiId, APILifeCycleAction.DEMOTE_TO_CREATE.getAction());
+        assertTrue(APILifeCycleState.CREATED.getState().equals(restAPIPublisher.getLifecycleStatus(apiId).getData()),
+                apiNameTest + "status not updated as Published");
+        //Check whether published API is available in publisher
+        HttpResponse publishedApiResponse = restAPIPublisher.getAPI(apiId);
+        assertEquals(publishedApiResponse.getResponseCode(), Response.Status.OK.getStatusCode(), apiNameTest +
+                " is not visible in publisher");
+        assertTrue(publishedApiResponse.getData().contains(apiNameTest), apiNameTest + " is not visible in " +
+                "publisher");
+    }
+
+    @Test(groups = {"wso2.am"}, description = "Change the status of the API to PUBLISHED through" +
+            " the publisher rest API ", dependsOnMethods = "testChangeTheStatusOfTheAPIToCreated")
     public void testChangeTheStatusOfTheAPIToPublished() throws Exception {
 
-        //Change the status PROTOTYPED to PUBLISHED
+        //Change the status CREATED to PUBLISHED
         restAPIPublisher.changeAPILifeCycleStatus(apiId, APILifeCycleAction.PUBLISH.getAction());
         assertTrue(APILifeCycleState.PUBLISHED.getState().equals(restAPIPublisher.getLifecycleStatus(apiId).getData()),
                 apiNameTest + "status not updated as Published");

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/restapi/ContentSearchTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/restapi/ContentSearchTestCase.java
@@ -210,8 +210,6 @@ public class ContentSearchTestCase extends APIManagerLifecycleBaseTest {
         String documentId = documentHttpResponse.getData();
         restAPIPublisher.addContentDocument(apiId, documentId, documentContent);
 
-        restAPIPublisher.changeAPILifeCycleStatus(apiId, APILifeCycleAction.PUBLISH.getAction());
-
         //check in publisher
         for (int i = 0; i <= retries; i++) {
             SearchResultListDTO searchResultListDTO = restAPIPublisher.searchAPIs("github4156");


### PR DESCRIPTION
This PR modifies integration tests to accommodate fixes done in https://github.com/wso2/carbon-apimgt/pull/10238 PR.

### Change Information
`APIM24VisibilityOfPrototypedAPIOfDifferentViewInStoreTestCase.java` file related change was done as the removed line tries to re deploy an API to the Prototype state. With the 10238 PR, now if an API is in Prototype state, it cannot again deploy as a prototype. 

`ContentSearchTestCase.java` file related change was done as the removed line tries to re publish an API to the publish state. With the 10238 PR, now if an API is in Publish state, it cannot again deploy to Publish state. 

In `APIM574ChangeTheStatusOfAnAPIToPrototypedThroughThePublisherRestAPITestCase.java` file, earlier an API which was in prototype state, can be moved to publish state. But now we cannot do that. Instead we only have the option to move an API which is in prototype state to created state(demoted). Hence, with this PR, the API which is already in prototype state is moved to created state and then it is promoted to publish state.
