### PR TITLE
[Streaming API] Set OUT_ONLY property as true for WebSocket endpoints

### DIFF
--- a/modules/distribution/resources/api_templates/endpoint_template.xml
+++ b/modules/distribution/resources/api_templates/endpoint_template.xml
@@ -98,6 +98,7 @@
         ##macro for websocket endpoints
         #macro ( websocket_endpoint $name )
 <endpoint xmlns="http://ws.apache.org/ns/synapse" name="${name}_${websocketResourceKey}">
+<property name="OUT_ONLY" value="true"/>
 <http uri-template="$util.escapeXml($endpointUrl)">
 #timeout( $ep.get('config') )
 </http>


### PR DESCRIPTION
## Purpose
$subject. Fixes https://github.com/wso2/product-apim/issues/10822