### PR TITLE
Add gateway label to default deployment.toml for sync runtime artifacts

### DIFF
--- a/modules/distribution/product/src/main/conf/deployment.toml
+++ b/modules/distribution/product/src/main/conf/deployment.toml
@@ -62,6 +62,9 @@ wss_endpoint = "wss://localhost:8099"
 http_endpoint = "http://localhost:${http.nio.port}"
 https_endpoint = "https://localhost:${https.nio.port}"
 
+[apim.sync_runtime_artifacts.gateway]
+gateway_labels =["Default"]
+
 #[apim.cache.gateway_token]
 #enable = true
 #expiry_time = "900s"

--- a/modules/distribution/product/src/main/resources/conf/deployment-templates/gateway-worker.toml
+++ b/modules/distribution/product/src/main/resources/conf/deployment-templates/gateway-worker.toml
@@ -48,6 +48,9 @@ signing_algorithm = "SHA256withRSA"
 #enable_user_claims = true
 #claims_extractor_impl = "org.wso2.carbon.apimgt.impl.token.DefaultClaimsRetriever"
 
+[apim.sync_runtime_artifacts.gateway]
+gateway_labels =["Default"]
+
 # Traffic Manager configurations
 [apim.throttling]
 username= "$ref{super_admin.username}"


### PR DESCRIPTION
### Purpose
As $subject, this will add a Default gateway label to the deployment.toml since the user can have a misunderstanding about the gateway label.

### Issues
Fixes https://github.com/wso2/product-apim/issues/10170