### PR TITLE
Add synapse property inbound.port.offset.enable to default.json file

### DIFF
--- a/modules/distribution/product/src/main/resources/conf/default.json
+++ b/modules/distribution/product/src/main/resources/conf/default.json
@@ -120,6 +120,7 @@
   "synapse_properties.'synapse.xpath.func.extensions'": "org.wso2.carbon.mediation.security.vault.xpath.SecureVaultLookupXPathFunctionProvider",
   "synapse_properties.'synapse.carbon.ext.tenant.info'": "org.wso2.carbon.mediation.initializer.handler.CarbonTenantInfoConfigurator",
   "synapse_properties.'synapse.carbon.ext.tenant.info.initiator'": "org.wso2.carbon.mediation.initializer.handler.CarbonTenantInfoInitiator",
+  "synapse_properties.'inbound.port.offset.enable'": true,
   "passthru_http.'http.socket.timeout'": "180000",
   "passthru_http.'worker_pool_size_core'": "400",
   "passthru_http.'worker_pool_size_max'": "500",


### PR DESCRIPTION
This PR adds **inbound.port.offset.enable** synapse property to default.json file.

Related PR: https://github.com/wso2/carbon-mediation/pull/1542
Related Issue: https://github.com/wso2/micro-integrator/issues/2223 