### PR TITLE
[Streaming API] Add WebSub HTTP and HTTPS event receiver endpoint configs

### DIFF
--- a/modules/distribution/product/src/main/conf/deployment.toml
+++ b/modules/distribution/product/src/main/conf/deployment.toml
@@ -61,6 +61,8 @@ ws_endpoint = "ws://localhost:9099"
 wss_endpoint = "wss://localhost:8099"
 http_endpoint = "http://localhost:${http.nio.port}"
 https_endpoint = "https://localhost:${https.nio.port}"
+websub_event_receiver_http_endpoint = "http://localhost:9021"
+websub_event_receiver_https_endpoint = "https://localhost:8021"
 
 #[apim.cache.gateway_token]
 #enable = true


### PR DESCRIPTION
## Purpose
$subject, to `deployment.toml`.
```toml
[[apim.gateway.environment]]
######## other properties ########
websub_event_receiver_http_endpoint = "http://localhost:7788"
websub_event_receiver_https_endpoint = "https://localhost:7789"
```

## Related PRs
https://github.com/wso2/carbon-apimgt/pull/10349