### PR TITLE
Add the j2 mapping to enable the specified Cipher Suites for the websocket apis

### DIFF
--- a/modules/distribution/product/src/main/resources/conf/templates/repository/deployment/server/synapse-configs/default/inbound-endpoints/SecureWebSocketInboundEndpoint.xml.j2
+++ b/modules/distribution/product/src/main/resources/conf/templates/repository/deployment/server/synapse-configs/default/inbound-endpoints/SecureWebSocketInboundEndpoint.xml.j2
@@ -18,5 +18,8 @@
         <parameter name="wss.ssl.key.store.pass">{{apim.wss.keystore.password}}</parameter>
         <parameter name="wss.ssl.cert.pass">{{apim.wss.keystore.key_password}}</parameter>
         <parameter name="wss.ssl.protocols">{{apim.wss.ssl_enabled_protocols}}</parameter>
+        {% if apim.wss.ciphers is defined %}
+        <parameter name="wss.ssl.cipher.suites">{{apim.wss.ciphers}}</parameter>
+        {% endif %}
     </parameters>
 </inboundEndpoint>

--- a/modules/distribution/product/src/main/resources/conf/templates/repository/resources/apim-synapse-config/SecureWebSocketInboundEndpoint.xml.j2
+++ b/modules/distribution/product/src/main/resources/conf/templates/repository/resources/apim-synapse-config/SecureWebSocketInboundEndpoint.xml.j2
@@ -18,5 +18,8 @@
         <parameter name="wss.ssl.key.store.pass">{{apim.wss.keystore.password}}</parameter>
         <parameter name="wss.ssl.cert.pass">{{apim.wss.keystore.key_password}}</parameter>
         <parameter name="wss.ssl.protocols">{{apim.wss.ssl_enabled_protocols}}</parameter>
+        {% if apim.wss.ciphers is defined %}
+        <parameter name="wss.ssl.cipher.suites">{{apim.wss.ciphers}}</parameter>
+        {% endif %}
     </parameters>
 </inboundEndpoint>


### PR DESCRIPTION
Fixes wso2/product-apim#10799 by adding the j2 mapping to enable the specified Cipher Suites for the Web socket inbound endpoint.