### PR TITLE
Adding Key Manager related integration tests 

### DIFF
--- a/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/helpers/AdminApiTestHelper.java
+++ b/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/helpers/AdminApiTestHelper.java
@@ -259,9 +259,20 @@ public class AdminApiTestHelper {
         Assert.assertEquals(actualKeyManager.getAvailableGrantTypes(), expectedKeyManager.getAvailableGrantTypes(),
                 "Key Manager available grant types does not match with the expected Key Manager " +
                         "available grant types");
-        Assert.assertEquals(actualKeyManager.getAdditionalProperties(), expectedKeyManager.getAdditionalProperties(),
+    }
+
+    /**
+     * Verify whether the additional properties values of the key manager DTO contains the expected values.
+     *
+     * @param expectedAdditionalProperties Expected key manager which contains the expected field values.
+     * @param actualAdditionalProperties   Key manager object of which the field values should be verified.
+     */
+    public void verifyKeyManagerAdditionalProperties(Object expectedAdditionalProperties,
+                                                     Object actualAdditionalProperties) {
+        Assert.assertEquals(actualAdditionalProperties, expectedAdditionalProperties,
                 "Key Manager additional properties does not match with the expected Key Manager " +
                         "additional properties");
+
     }
 
 }

--- a/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/helpers/AdminApiTestHelper.java
+++ b/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/helpers/AdminApiTestHelper.java
@@ -18,9 +18,15 @@
 package org.wso2.am.integration.test.helpers;
 
 import org.testng.Assert;
-import org.wso2.am.integration.clients.admin.api.dto.*;
-
-import java.util.List;
+import org.wso2.am.integration.clients.admin.api.dto.APICategoryDTO;
+import org.wso2.am.integration.clients.admin.api.dto.AdvancedThrottlePolicyDTO;
+import org.wso2.am.integration.clients.admin.api.dto.ApplicationThrottlePolicyDTO;
+import org.wso2.am.integration.clients.admin.api.dto.CustomRuleDTO;
+import org.wso2.am.integration.clients.admin.api.dto.EnvironmentDTO;
+import org.wso2.am.integration.clients.admin.api.dto.KeyManagerDTO;
+import org.wso2.am.integration.clients.admin.api.dto.LabelDTO;
+import org.wso2.am.integration.clients.admin.api.dto.SubscriptionThrottlePolicyDTO;
+import org.wso2.am.integration.clients.admin.api.dto.VHostDTO;
 
 /**
  * A collection of helper methods to aid Admin REST API related tests

--- a/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/helpers/AdminApiTestHelper.java
+++ b/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/helpers/AdminApiTestHelper.java
@@ -18,14 +18,9 @@
 package org.wso2.am.integration.test.helpers;
 
 import org.testng.Assert;
-import org.wso2.am.integration.clients.admin.api.dto.AdvancedThrottlePolicyDTO;
-import org.wso2.am.integration.clients.admin.api.dto.APICategoryDTO;
-import org.wso2.am.integration.clients.admin.api.dto.ApplicationThrottlePolicyDTO;
-import org.wso2.am.integration.clients.admin.api.dto.CustomRuleDTO;
-import org.wso2.am.integration.clients.admin.api.dto.EnvironmentDTO;
-import org.wso2.am.integration.clients.admin.api.dto.LabelDTO;
-import org.wso2.am.integration.clients.admin.api.dto.SubscriptionThrottlePolicyDTO;
-import org.wso2.am.integration.clients.admin.api.dto.VHostDTO;
+import org.wso2.am.integration.clients.admin.api.dto.*;
+
+import java.util.List;
 
 /**
  * A collection of helper methods to aid Admin REST API related tests
@@ -211,4 +206,56 @@ public class AdminApiTestHelper {
         Assert.assertEquals(actualApiCategory.getDescription(), expectedApiCategory.getDescription(),
                 "Api category description does not match with the expected api category description");
     }
+
+    /**
+     * Verify whether the field values of the key manager DTO contains the expected values.
+     *
+     * @param expectedKeyManager Expected key manager which contains the expected field values.
+     * @param actualKeyManager   Key manager object of which the field values should be verified.
+     */
+    public void verifyKeyManagerDTO(KeyManagerDTO expectedKeyManager, KeyManagerDTO actualKeyManager) {
+
+        Assert.assertEquals(actualKeyManager.getId(), expectedKeyManager.getId(),
+                "Key Manager ID does not match with the expected Key Manager ID");
+        Assert.assertEquals(actualKeyManager.getName(), expectedKeyManager.getName(),
+                "Key Manager name does not match with the expected Key Manager name");
+        Assert.assertEquals(actualKeyManager.getDescription(), expectedKeyManager.getDescription(),
+                "Key Manager description does not match with the expected Key Manager description");
+        Assert.assertEquals(actualKeyManager.getDisplayName(), expectedKeyManager.getDisplayName(),
+                "Key Manager display name does not match with the expected Key Manager display name");
+        Assert.assertEquals(actualKeyManager.getCertificates(), expectedKeyManager.getCertificates(),
+                "Key Manager certificates  does not match with the expected Key Manager certificates");
+        Assert.assertEquals(actualKeyManager.getIntrospectionEndpoint(), expectedKeyManager.getIntrospectionEndpoint(),
+                "Key Manager introspection endpoint does not match with the expected Key Manager " +
+                        "introspection endpoint");
+        Assert.assertEquals(actualKeyManager.getRevokeEndpoint(), expectedKeyManager.getRevokeEndpoint(),
+                "Key Manager revoke endpoint does not match with the expected Key Manager revoke endpoint");
+        Assert.assertEquals(actualKeyManager.getClientRegistrationEndpoint(),
+                expectedKeyManager.getClientRegistrationEndpoint(),
+                "Key Manager client registration endpoint does not match with the expected Key Manager " +
+                        "client registration endpoint");
+        Assert.assertEquals(actualKeyManager.getTokenEndpoint(), expectedKeyManager.getTokenEndpoint(),
+                "Key Manager token endpoint does not match with the expected Key Manager token endpoint");
+        Assert.assertEquals(actualKeyManager.getUserInfoEndpoint(), expectedKeyManager.getUserInfoEndpoint(),
+                "Key Manager user info endpoint  does not match with the expected user info endpoint");
+        Assert.assertEquals(actualKeyManager.getAuthorizeEndpoint(), expectedKeyManager.getAuthorizeEndpoint(),
+                "Key Manager authorize endpoint does not match with the expected Key Manager authorize endpoint");
+        Assert.assertEquals(actualKeyManager.getScopeManagementEndpoint(),
+                expectedKeyManager.getScopeManagementEndpoint(),
+                "Key Manager scope management endpoint does not match with the expected Key Manager " +
+                        "scope management endpoint");
+        Assert.assertEquals(actualKeyManager.getConsumerKeyClaim(), expectedKeyManager.getConsumerKeyClaim(),
+                "Key Manager consumer key claim does not match with the expected Key Manager consumer key claim");
+        Assert.assertEquals(actualKeyManager.getScopesClaim(), expectedKeyManager.getScopesClaim(),
+                "Key Manager scopes claim does not match with the expected Key Manager scopes claim");
+        Assert.assertEquals(actualKeyManager.getIssuer(), expectedKeyManager.getIssuer(),
+                "Key Manager issuer  does not match with the expected Key Manager issuer");
+        Assert.assertEquals(actualKeyManager.getAvailableGrantTypes(), expectedKeyManager.getAvailableGrantTypes(),
+                "Key Manager available grant types does not match with the expected Key Manager " +
+                        "available grant types");
+        Assert.assertEquals(actualKeyManager.getAdditionalProperties(), expectedKeyManager.getAdditionalProperties(),
+                "Key Manager additional properties does not match with the expected Key Manager " +
+                        "additional properties");
+    }
+
 }

--- a/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/impl/DtoFactory.java
+++ b/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/impl/DtoFactory.java
@@ -16,25 +16,8 @@
 
 package org.wso2.am.integration.test.impl;
 
-import org.wso2.am.integration.clients.admin.api.dto.APICategoryDTO;
-import org.wso2.am.integration.clients.admin.api.dto.AdvancedThrottlePolicyDTO;
-import org.wso2.am.integration.clients.admin.api.dto.ApplicationThrottlePolicyDTO;
-import org.wso2.am.integration.clients.admin.api.dto.BandwidthLimitDTO;
-import org.wso2.am.integration.clients.admin.api.dto.ConditionalGroupDTO;
-import org.wso2.am.integration.clients.admin.api.dto.CustomAttributeDTO;
-import org.wso2.am.integration.clients.admin.api.dto.CustomRuleDTO;
-import org.wso2.am.integration.clients.admin.api.dto.EnvironmentDTO;
-import org.wso2.am.integration.clients.admin.api.dto.EventCountLimitDTO;
-import org.wso2.am.integration.clients.admin.api.dto.HeaderConditionDTO;
-import org.wso2.am.integration.clients.admin.api.dto.IPConditionDTO;
-import org.wso2.am.integration.clients.admin.api.dto.JWTClaimsConditionDTO;
-import org.wso2.am.integration.clients.admin.api.dto.LabelDTO;
-import org.wso2.am.integration.clients.admin.api.dto.QueryParameterConditionDTO;
-import org.wso2.am.integration.clients.admin.api.dto.RequestCountLimitDTO;
-import org.wso2.am.integration.clients.admin.api.dto.SubscriptionThrottlePolicyDTO;
-import org.wso2.am.integration.clients.admin.api.dto.ThrottleConditionDTO;
-import org.wso2.am.integration.clients.admin.api.dto.ThrottleLimitDTO;
-import org.wso2.am.integration.clients.admin.api.dto.VHostDTO;
+import com.google.gson.JsonObject;
+import org.wso2.am.integration.clients.admin.api.dto.*;
 import org.wso2.am.integration.clients.publisher.api.v1.dto.APIProductDTO;
 import org.wso2.am.integration.clients.publisher.api.v1.dto.ProductAPIDTO;
 import org.wso2.am.integration.test.Constants;
@@ -417,5 +400,77 @@ public class DtoFactory {
         return new APICategoryDTO().
                 name(name).
                 description(description);
+    }
+
+    /**
+     * Creates an key manager DTO using the given parameters.
+     *
+     * @param name                       Name of key manager.
+     * @param displayName                Display name of the key manager.
+     * @param description                Description of the key manager.
+     * @param type                       Type of the key manager.
+     * @param issuer                     Issuer of the key manager.
+     * @param clientRegistrationEndpoint Client registration endpoint of the key manager.
+     * @param introspectionEndpoint      Introspection endpoint of the key manager.
+     * @param tokenEndpoint              Token endpoint of the key manager.
+     * @param revokeEndpoint             Revoke endpoint of the key manager.
+     * @param userInfoEndpoint           User info endpoint of the key manager.
+     * @param authorizeEndpoint          Authorize endpoint of the key manager.
+     * @param scopeManagementEndpoint    Scope management endpoint of the key manager.
+     * @param consumerKeyClaim           Consumer key claim URI of the key manager.
+     * @param scopesClaim                Scopes claim URI of the key manager.
+     * @param availableGrantTypes        Available grant types of the key manager.
+     * @param additionalProperties       Additional properties of the key manager.
+     * @param certificates               Certificates of the key manager.
+     * @return Created key manager DTO.
+     */
+    public static KeyManagerDTO createKeyManagerDTO(String name, String description, String type, String displayName,
+                                                    String introspectionEndpoint, String issuer,
+                                                    String clientRegistrationEndpoint, String tokenEndpoint,
+                                                    String revokeEndpoint, String userInfoEndpoint,
+                                                    String authorizeEndpoint, String scopeManagementEndpoint,
+                                                    String consumerKeyClaim, String scopesClaim,
+                                                    List<String> availableGrantTypes, Object additionalProperties,
+                                                    KeyManagerCertificatesDTO certificates) {
+
+        KeyManagerDTO keyManagerDTO = new KeyManagerDTO();
+        keyManagerDTO.setType(type);
+        keyManagerDTO.setName(name);
+        keyManagerDTO.setDescription(description);
+        keyManagerDTO.setDisplayName(displayName);
+        keyManagerDTO.setEnabled(true);
+        keyManagerDTO.setIntrospectionEndpoint(introspectionEndpoint);
+        keyManagerDTO.setRevokeEndpoint(revokeEndpoint);
+        keyManagerDTO.setClientRegistrationEndpoint(clientRegistrationEndpoint);
+        keyManagerDTO.setTokenEndpoint(tokenEndpoint);
+        keyManagerDTO.setUserInfoEndpoint(userInfoEndpoint);
+        keyManagerDTO.setAuthorizeEndpoint(authorizeEndpoint);
+        keyManagerDTO.setScopeManagementEndpoint(scopeManagementEndpoint);
+        keyManagerDTO.setConsumerKeyClaim(consumerKeyClaim);
+        keyManagerDTO.setScopesClaim(scopesClaim);
+        keyManagerDTO.setIssuer(issuer);
+        keyManagerDTO.setCertificates(certificates);
+        keyManagerDTO.setEnableMapOAuthConsumerApps(true);
+        keyManagerDTO.setEnableTokenGeneration(true);
+        keyManagerDTO.setEnableOAuthAppCreation(true);
+        keyManagerDTO.setAvailableGrantTypes(availableGrantTypes);
+        keyManagerDTO.setAdditionalProperties(additionalProperties);
+        return keyManagerDTO;
+    }
+
+    /**
+     * Creates an key manager certificate DTO using the given parameters.
+     *
+     * @param type        Type of the key manager certificate.
+     * @param value       Value of the key manager certificate.
+     * @return Created key manager certificate DTO.
+     */
+    public static KeyManagerCertificatesDTO createKeyManagerCertificatesDTO(KeyManagerCertificatesDTO.TypeEnum type,
+                                                                            String value) {
+
+        KeyManagerCertificatesDTO keyManagerCertificatesDTO =  new KeyManagerCertificatesDTO();
+        keyManagerCertificatesDTO.setType(type);
+        keyManagerCertificatesDTO.setValue(value);
+        return keyManagerCertificatesDTO;
     }
 }

--- a/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/impl/DtoFactory.java
+++ b/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/impl/DtoFactory.java
@@ -16,13 +16,30 @@
 
 package org.wso2.am.integration.test.impl;
 
-import com.google.gson.JsonObject;
-import org.wso2.am.integration.clients.admin.api.dto.*;
+import org.wso2.am.integration.clients.admin.api.dto.APICategoryDTO;
+import org.wso2.am.integration.clients.admin.api.dto.AdvancedThrottlePolicyDTO;
+import org.wso2.am.integration.clients.admin.api.dto.ApplicationThrottlePolicyDTO;
+import org.wso2.am.integration.clients.admin.api.dto.BandwidthLimitDTO;
+import org.wso2.am.integration.clients.admin.api.dto.ConditionalGroupDTO;
+import org.wso2.am.integration.clients.admin.api.dto.CustomAttributeDTO;
+import org.wso2.am.integration.clients.admin.api.dto.CustomRuleDTO;
+import org.wso2.am.integration.clients.admin.api.dto.EnvironmentDTO;
+import org.wso2.am.integration.clients.admin.api.dto.EventCountLimitDTO;
+import org.wso2.am.integration.clients.admin.api.dto.HeaderConditionDTO;
+import org.wso2.am.integration.clients.admin.api.dto.IPConditionDTO;
+import org.wso2.am.integration.clients.admin.api.dto.JWTClaimsConditionDTO;
+import org.wso2.am.integration.clients.admin.api.dto.KeyManagerCertificatesDTO;
+import org.wso2.am.integration.clients.admin.api.dto.KeyManagerDTO;
+import org.wso2.am.integration.clients.admin.api.dto.LabelDTO;
+import org.wso2.am.integration.clients.admin.api.dto.QueryParameterConditionDTO;
+import org.wso2.am.integration.clients.admin.api.dto.RequestCountLimitDTO;
+import org.wso2.am.integration.clients.admin.api.dto.SubscriptionThrottlePolicyDTO;
+import org.wso2.am.integration.clients.admin.api.dto.ThrottleConditionDTO;
+import org.wso2.am.integration.clients.admin.api.dto.ThrottleLimitDTO;
+import org.wso2.am.integration.clients.admin.api.dto.VHostDTO;
 import org.wso2.am.integration.clients.publisher.api.v1.dto.APIProductDTO;
 import org.wso2.am.integration.clients.publisher.api.v1.dto.ProductAPIDTO;
-import org.wso2.am.integration.test.Constants;
 
-import java.util.Arrays;
 import java.util.List;
 
 public class DtoFactory {

--- a/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/impl/RestAPIAdminImpl.java
+++ b/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/impl/RestAPIAdminImpl.java
@@ -235,19 +235,19 @@ public class RestAPIAdminImpl {
         return keyManagerCollectionApi.keyManagersGet();
     }
 
-    public KeyManagerDTO getKeyManager(String uuid) throws ApiException {
+    public ApiResponse<KeyManagerDTO> getKeyManager(String uuid) throws ApiException {
 
-        return keyManagerIndividualApi.keyManagersKeyManagerIdGet(uuid);
+        return keyManagerIndividualApi.keyManagersKeyManagerIdGetWithHttpInfo(uuid);
     }
 
-    public KeyManagerDTO updateKeyManager(String uuid, KeyManagerDTO keyManagerDTO) throws ApiException {
+    public ApiResponse<KeyManagerDTO> updateKeyManager(String uuid, KeyManagerDTO keyManagerDTO) throws ApiException {
 
-        return keyManagerIndividualApi.keyManagersKeyManagerIdPut(uuid, keyManagerDTO);
+        return keyManagerIndividualApi.keyManagersKeyManagerIdPutWithHttpInfo(uuid, keyManagerDTO);
     }
 
-    public void deleteKeyManager(String uuid) throws ApiException {
+    public ApiResponse<Void> deleteKeyManager(String uuid) throws ApiException {
 
-        keyManagerIndividualApi.keyManagersKeyManagerIdDelete(uuid);
+        return keyManagerIndividualApi.keyManagersKeyManagerIdDeleteWithHttpInfo(uuid);
     }
 
     public SettingsDTO getSettings() throws ApiException {

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/restapi/admin/KeyManagersTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/restapi/admin/KeyManagersTestCase.java
@@ -750,7 +750,7 @@ public class KeyManagersTestCase extends APIMIntegrationBaseTest {
 
     @Test(groups = {"wso2.am"}, description = "Test get and update key manager",
             dependsOnMethods = "testAddKeyManagerWithForgeRockWithOptionalParams")
-    public void testGetAndUpdateKeyManager() throws Exception {
+    public void testUpdateKeyManager() throws Exception {
         //Get the added Key manager
         String keyManagerId = keyManagerDTO.getId();
         ApiResponse<KeyManagerDTO> retrievedKeyManager = restAPIAdmin.getKeyManager(keyManagerId);
@@ -768,7 +768,7 @@ public class KeyManagersTestCase extends APIMIntegrationBaseTest {
     }
 
     @Test(groups = {"wso2.am"}, description = "Test add key manager with existing key manager name",
-            dependsOnMethods = "testGetAndUpdateKeyManager")
+            dependsOnMethods = "testUpdateKeyManager")
     public void testAddKeyManagerWithExistingKeyManagerName() throws ApiException {
 
         //Exception occurs when adding a key manager with an existing key manager name. The status code

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/restapi/admin/KeyManagersTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/restapi/admin/KeyManagersTestCase.java
@@ -1,0 +1,732 @@
+package org.wso2.am.integration.tests.restapi.admin;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import org.apache.http.HttpStatus;
+import org.testng.Assert;
+import org.testng.annotations.*;
+import org.wso2.am.integration.clients.admin.ApiException;
+import org.wso2.am.integration.clients.admin.ApiResponse;
+import org.wso2.am.integration.clients.admin.api.dto.KeyManagerCertificatesDTO;
+import org.wso2.am.integration.clients.admin.api.dto.KeyManagerDTO;
+import org.wso2.am.integration.test.helpers.AdminApiTestHelper;
+import org.wso2.am.integration.test.impl.DtoFactory;
+import org.wso2.am.integration.test.utils.base.APIMIntegrationBaseTest;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class KeyManagersTestCase extends APIMIntegrationBaseTest {
+    private AdminApiTestHelper adminApiTestHelper;
+    private KeyManagerDTO keyManagerDTO;
+
+    @Factory(dataProvider = "userModeDataProvider")
+    public KeyManagersTestCase(TestUserMode userMode) {
+        this.userMode = userMode;
+    }
+
+    @DataProvider
+    public static Object[][] userModeDataProvider() {
+        return new Object[][]{new Object[]{TestUserMode.SUPER_TENANT_ADMIN},
+                new Object[]{TestUserMode.TENANT_ADMIN}};
+    }
+
+    @BeforeClass(alwaysRun = true)
+    public void setEnvironment() throws Exception {
+        super.init(userMode);
+        adminApiTestHelper = new AdminApiTestHelper();
+    }
+
+    //Auth0 Key Manager
+    @Test(groups = {"wso2.am"}, description = "Test add key manager with Auth0 type with only mandatory parameters")
+    public void testAddKeyManagerWithAuth0() throws Exception {
+        //Create the key manager DTO with Auth0 key manager type with only Mandatory parameters
+        String name = "Auth0KeyManagerOne";
+        String type = "Auth0";
+        String displayName = "Test Key Manager Auth0";
+        String introspectionEndpoint = "none";
+        String revokeEndpoint = "https://dev-ted144kt.us.auth0.com/oauth/revoke";
+        String clientRegistrationEndpoint = "https://dev-ted144kt.us.auth0.com/oidc/register";
+        String tokenEndpoint = "https://dev-ted144kt.us.auth0.com/oauth/token";
+        String authorizeEndpoint = "https://dev-ted144kt.us.auth0.com/authorize";
+        String consumerKeyClaim = "azp";
+        String scopesClaim = "scope";
+        List<String> availableGrantTypes = Collections.emptyList();
+        JsonObject jsonObject = new JsonObject();
+        jsonObject.addProperty("client_id", "clientIdValue");
+        jsonObject.addProperty("client_secret", "clientSecretValue");
+        jsonObject.addProperty("audience", "audienceValue");
+        jsonObject.addProperty("self_validate_jwt", true);
+        Object additionalProperties = new Gson().fromJson(jsonObject, Map.class);
+        keyManagerDTO = DtoFactory.createKeyManagerDTO(name, null, type, displayName, introspectionEndpoint,
+                null, clientRegistrationEndpoint, tokenEndpoint, revokeEndpoint, null, authorizeEndpoint,
+                null, consumerKeyClaim, scopesClaim, availableGrantTypes, additionalProperties,
+                null);
+
+        //Add the Auth0 key manager
+        ApiResponse<KeyManagerDTO> addedKeyManagers = restAPIAdmin.addKeyManager(keyManagerDTO);
+        Assert.assertEquals(addedKeyManagers.getStatusCode(), HttpStatus.SC_CREATED);
+        KeyManagerDTO addedKeyManagerDTO = addedKeyManagers.getData();
+        String keyManagerId = addedKeyManagerDTO.getId();
+
+        //Assert the status code and key manager ID
+        Assert.assertNotNull(keyManagerId, "The Key Manager ID cannot be null or empty");
+        keyManagerDTO.setId(keyManagerId);
+        //Verify the created key manager DTO
+        adminApiTestHelper.verifyKeyManagerDTO(keyManagerDTO, addedKeyManagerDTO);
+    }
+
+    @Test(groups = {"wso2.am"}, description = "Test add key manager with Auth0 type without a mandatory parameter")
+    public void testAddKeyManagerWithAuth0WithoutMandatoryParam() throws Exception {
+        //Create the key manager DTO with Auth0 key manager type without Connector Configurations (Mandatory parameter)
+        String name = "Auth0KeyManagerTwo";
+        String type = "Auth0";
+        String displayName = "Test Key Manager Auth0";
+        String introspectionEndpoint = "none";
+        String revokeEndpoint = "https://dev-ted144kt.us.auth0.com/oauth/revoke";
+        String clientRegistrationEndpoint = "https://dev-ted144kt.us.auth0.com/oidc/register";
+        String tokenEndpoint = "https://dev-ted144kt.us.auth0.com/oauth/token";
+        String authorizeEndpoint = "https://dev-ted144kt.us.auth0.com/authorize";
+        String consumerKeyClaim = "azp";
+        String scopesClaim = "scope";
+        List<String> availableGrantTypes = Collections.emptyList();
+        //Connector Configurations - client Id, client secret and audience are not provided
+        JsonObject jsonObject = new JsonObject();
+        Object additionalProperties = new Gson().fromJson(jsonObject, Map.class);
+        String certificateValue = "";
+        KeyManagerCertificatesDTO keyManagerCertificates =
+                DtoFactory.createKeyManagerCertificatesDTO(KeyManagerCertificatesDTO.TypeEnum.PEM, certificateValue);
+        keyManagerDTO = DtoFactory.createKeyManagerDTO(name, null, type, displayName, introspectionEndpoint,
+                null, clientRegistrationEndpoint, tokenEndpoint, revokeEndpoint, null, authorizeEndpoint,
+                null, consumerKeyClaim, scopesClaim, availableGrantTypes, additionalProperties,
+                keyManagerCertificates);
+
+        //Add the Auth0 key manager - This should fail
+        try {
+            restAPIAdmin.addKeyManager(keyManagerDTO);
+        } catch (ApiException e) {
+            Assert.assertEquals(e.getCode(), HttpStatus.SC_BAD_REQUEST);
+        }
+    }
+
+    @Test(groups = {"wso2.am"}, description = "Test add key manager with Auth0 type with mandatory " +
+            "and some optional parameters")
+    public void testAddKeyManagerWithAuth0WithOptionalParams() throws Exception {
+        //Create the key manager DTO with Auth0 key manager type with mandatory and some optional parameters
+        String name = "Auth0KeyManagerThree";
+        String type = "Auth0";
+        String displayName = "Test Key Manager Auth0";
+        String introspectionEndpoint = "none";
+        String revokeEndpoint = "https://dev-ted144kt.us.auth0.com/oauth/revoke";
+        String clientRegistrationEndpoint = "https://dev-ted144kt.us.auth0.com/oidc/register";
+        String tokenEndpoint = "https://dev-ted144kt.us.auth0.com/oauth/token";
+        String authorizeEndpoint = "https://dev-ted144kt.us.auth0.com/authorize";
+        String consumerKeyClaim = "azp";
+        String scopesClaim = "scope";
+        JsonObject jsonObject = new JsonObject();
+        jsonObject.addProperty("client_id", "clientIdValue");
+        jsonObject.addProperty("client_secret", "clientSecretValue");
+        jsonObject.addProperty("audience", "audienceValue");
+        jsonObject.addProperty("self_validate_jwt", true);
+        Object additionalProperties = new Gson().fromJson(jsonObject, Map.class);
+        //Optional parameters
+        String description = "This is a test key manager";
+        String issuer = "https://dev-ted144kt.us.auth0.com/";
+        List<String> availableGrantTypes =
+                Arrays.asList("client_credentials", "password", "implicit", "refresh_token");
+        String certificateValue = "https://dev-ted144kt.us.auth0.com/.well-known/jwks.json";
+        KeyManagerCertificatesDTO keyManagerCertificates =
+                DtoFactory.createKeyManagerCertificatesDTO(KeyManagerCertificatesDTO.TypeEnum.JWKS, certificateValue);
+
+        keyManagerDTO = DtoFactory.createKeyManagerDTO(name, description, type, displayName, introspectionEndpoint,
+                issuer, clientRegistrationEndpoint, tokenEndpoint, revokeEndpoint, null, authorizeEndpoint,
+                null, consumerKeyClaim, scopesClaim, availableGrantTypes, additionalProperties,
+                keyManagerCertificates);
+
+        //Add the Auth0 key manager
+        ApiResponse<KeyManagerDTO> addedKeyManagers = restAPIAdmin.addKeyManager(keyManagerDTO);
+        Assert.assertEquals(addedKeyManagers.getStatusCode(), HttpStatus.SC_CREATED);
+        KeyManagerDTO addedKeyManagerDTO = addedKeyManagers.getData();
+        String keyManagerId = addedKeyManagerDTO.getId();
+
+        //Assert the status code and key manager ID
+        Assert.assertNotNull(keyManagerId, "The Key Manager ID cannot be null or empty");
+        keyManagerDTO.setId(keyManagerId);
+        //Verify the created key manager DTO
+        adminApiTestHelper.verifyKeyManagerDTO(keyManagerDTO, addedKeyManagerDTO);
+    }
+
+    //WSO2 IS Key Manager
+    @Test(groups = {"wso2.am"}, description = "Test add key manager with WSO2IS type with only mandatory parameters")
+    public void testAddKeyManagerWithWso2IS() throws Exception {
+        //Create the key manager DTO with WSO2 IS key manager type with only Mandatory parameters
+        String name = "Wso2ISKeyManagerOne";
+        String type = "WSO2-IS";
+        String displayName = "Test Key Manager WSO2IS";
+        String introspectionEndpoint = "https://localhost:9444/oauth2/introspect";
+        String clientRegistrationEndpoint = "https://localhost:9444/keymanager-operations/dcr/register";
+        String scopeManagementEndpoint = "https://wso2is.com:9444/api/identity/oauth2/v1.0/scopes";
+        String consumerKeyClaim = "azp";
+        String scopesClaim = "scope";
+        List<String> availableGrantTypes = Collections.emptyList();
+        JsonObject jsonObject = new JsonObject();
+        jsonObject.addProperty("Username", "admin");
+        jsonObject.addProperty("Password", "admin");
+        jsonObject.addProperty("self_validate_jwt", true);
+        Object additionalProperties = new Gson().fromJson(jsonObject, Map.class);
+        keyManagerDTO = DtoFactory.createKeyManagerDTO(name, null, type, displayName, introspectionEndpoint,
+                null, clientRegistrationEndpoint, null, null, null, null,
+                scopeManagementEndpoint, consumerKeyClaim, scopesClaim, availableGrantTypes, additionalProperties,
+                null);
+
+        //Add the WSO2 IS key manager
+        ApiResponse<KeyManagerDTO> addedKeyManagers = restAPIAdmin.addKeyManager(keyManagerDTO);
+        Assert.assertEquals(addedKeyManagers.getStatusCode(), HttpStatus.SC_CREATED);
+        KeyManagerDTO addedKeyManagerDTO = addedKeyManagers.getData();
+        String keyManagerId = addedKeyManagerDTO.getId();
+
+        //Assert the status code and key manager ID
+        Assert.assertNotNull(keyManagerId, "The Key Manager ID cannot be null or empty");
+        keyManagerDTO.setId(keyManagerId);
+        //Verify the created key manager DTO
+        adminApiTestHelper.verifyKeyManagerDTO(keyManagerDTO, addedKeyManagerDTO);
+    }
+
+    @Test(groups = {"wso2.am"}, description = "Test add key manager with WSO2IS type without a mandatory parameter")
+    public void testAddKeyManagerWithWso2ISWithoutMandatoryParam() throws Exception {
+        //Create the key manager DTO with WSO2 IS key manager type without Connector Configurations (Mandatory parameter)
+        String name = "Wso2ISKeyManagerTwo";
+        String type = "WSO2-IS";
+        String displayName = "Test Key Manager WSO2IS";
+        String introspectionEndpoint = "https://localhost:9444/oauth2/introspect";
+        String clientRegistrationEndpoint = "https://localhost:9444/keymanager-operations/dcr/register";
+        String scopeManagementEndpoint = "https://wso2is.com:9444/api/identity/oauth2/v1.0/scopes";
+        String consumerKeyClaim = "azp";
+        String scopesClaim = "scope";
+        List<String> availableGrantTypes = Collections.emptyList();
+        //Connector Configurations - username and password are not provided
+        JsonObject jsonObject = new JsonObject();
+        Object additionalProperties = new Gson().fromJson(jsonObject, Map.class);
+        keyManagerDTO = DtoFactory.createKeyManagerDTO(name, null, type, displayName, introspectionEndpoint,
+                null, clientRegistrationEndpoint, null, null, null, null,
+                scopeManagementEndpoint, consumerKeyClaim, scopesClaim, availableGrantTypes, additionalProperties,
+                null);
+
+        //Add the WSO2 IS key manager - This should fail
+        try {
+            restAPIAdmin.addKeyManager(keyManagerDTO);
+        } catch (ApiException e) {
+            Assert.assertEquals(e.getCode(), HttpStatus.SC_BAD_REQUEST);
+        }
+    }
+
+    @Test(groups = {"wso2.am"}, description = "Test add key manager with WSO2IS type with mandatory " +
+            "and some optional parameters")
+    public void testAddKeyManagerWithWso2ISWithOptionalParams() throws Exception {
+        //Create the key manager DTO with WSO2 IS key manager type with mandatory and some optional parameters
+        String name = "Wso2ISKeyManagerThree";
+        String type = "WSO2-IS";
+        String displayName = "Test Key Manager WSO2IS";
+        String introspectionEndpoint = "https://localhost:9444/oauth2/introspect";
+        String clientRegistrationEndpoint = "https://localhost:9444/keymanager-operations/dcr/register";
+        String scopeManagementEndpoint = "https://wso2is.com:9444/api/identity/oauth2/v1.0/scopes";
+        String consumerKeyClaim = "azp";
+        String scopesClaim = "scope";
+        JsonObject jsonObject = new JsonObject();
+        jsonObject.addProperty("Username", "admin");
+        jsonObject.addProperty("Password", "admin");
+        jsonObject.addProperty("self_validate_jwt", true);
+        Object additionalProperties = new Gson().fromJson(jsonObject, Map.class);
+        //Optional parameters
+        String description = "This is a test key manager";
+        String issuer = "https://localhost:9444/services";
+        List<String> availableGrantTypes =
+                Arrays.asList("client_credentials", "password", "implicit", "refresh_token");
+        String certificateValue = "https://localhost:9443/oauth2/jwks";
+        KeyManagerCertificatesDTO keyManagerCertificates =
+                DtoFactory.createKeyManagerCertificatesDTO(KeyManagerCertificatesDTO.TypeEnum.JWKS, certificateValue);
+
+        keyManagerDTO = DtoFactory.createKeyManagerDTO(name, description, type, displayName, introspectionEndpoint,
+                issuer, clientRegistrationEndpoint, null, null, null, null,
+                scopeManagementEndpoint, consumerKeyClaim, scopesClaim, availableGrantTypes, additionalProperties,
+                keyManagerCertificates);
+
+        //Add the WSO2 IS key manager
+        ApiResponse<KeyManagerDTO> addedKeyManagers = restAPIAdmin.addKeyManager(keyManagerDTO);
+        Assert.assertEquals(addedKeyManagers.getStatusCode(), HttpStatus.SC_CREATED);
+        KeyManagerDTO addedKeyManagerDTO = addedKeyManagers.getData();
+        String keyManagerId = addedKeyManagerDTO.getId();
+
+        //Assert the status code and key manager ID
+        Assert.assertNotNull(keyManagerId, "The Key Manager ID cannot be null or empty");
+        keyManagerDTO.setId(keyManagerId);
+        //Verify the created key manager DTO
+        adminApiTestHelper.verifyKeyManagerDTO(keyManagerDTO, addedKeyManagerDTO);
+    }
+
+    //Keycloak Key Manager
+    @Test(groups = {"wso2.am"}, description = "Test add key manager with Keycloak type with only mandatory parameters")
+    public void testAddKeyManagerWithKeycloak() throws Exception {
+        //Create the key manager DTO with Keycloak key manager type with only Mandatory parameters
+        String name = "KeycloakKeyManagerOne";
+        String type = "KeyCloak";
+        String displayName = "Test Key Manager Keycloak";
+        String issuer = "https://localhost:8443/auth/realms/master";
+        String introspectionEndpoint = "https://localhost:8443/auth/realms/master/protocol/openid-connect/token/introspect";
+        String clientRegistrationEndpoint = "https://localhost:8443/auth/realms/master/clients-registrations/openid-connect";
+        String tokenEndpoint = "https://localhost:8443/auth/realms/master/protocol/openid-connect/token";
+        String consumerKeyClaim = "azp";
+        String scopesClaim = "scope";
+        List<String> availableGrantTypes = Collections.emptyList();
+        JsonObject jsonObject = new JsonObject();
+        jsonObject.addProperty("client_id", "clientIdValue");
+        jsonObject.addProperty("client_secret", "clientSecretValue");
+        jsonObject.addProperty("self_validate_jwt", true);
+        Object additionalProperties = new Gson().fromJson(jsonObject, Map.class);
+        keyManagerDTO = DtoFactory.createKeyManagerDTO(name, null, type, displayName, introspectionEndpoint,
+                issuer, clientRegistrationEndpoint, tokenEndpoint, null, null, null,
+                null, consumerKeyClaim, scopesClaim, availableGrantTypes, additionalProperties,
+                null);
+
+        //Add the Keycloak key manager
+        ApiResponse<KeyManagerDTO> addedKeyManagers = restAPIAdmin.addKeyManager(keyManagerDTO);
+        Assert.assertEquals(addedKeyManagers.getStatusCode(), HttpStatus.SC_CREATED);
+        KeyManagerDTO addedKeyManagerDTO = addedKeyManagers.getData();
+        String keyManagerId = addedKeyManagerDTO.getId();
+
+        //Assert the status code and key manager ID
+        Assert.assertNotNull(keyManagerId, "The Key Manager ID cannot be null or empty");
+        keyManagerDTO.setId(keyManagerId);
+        //Verify the created key manager DTO
+        adminApiTestHelper.verifyKeyManagerDTO(keyManagerDTO, addedKeyManagerDTO);
+    }
+
+    @Test(groups = {"wso2.am"}, description = "Test add key manager with Keycloak type without a mandatory parameter")
+    public void testAddKeyManagerWithKeycloakWithoutMandatoryParam() throws Exception {
+        //Create the key manager DTO with Keycloak key manager type without Connector Configurations (Mandatory parameter)
+        String name = "KeycloakKeyManagerTwo";
+        String type = "KeyCloak";
+        String displayName = "Test Key Manager Keycloak";
+        String issuer = "https://localhost:8443/auth/realms/master";
+        String introspectionEndpoint = "https://localhost:8443/auth/realms/master/protocol/openid-connect/token/introspect";
+        String clientRegistrationEndpoint = "https://localhost:8443/auth/realms/master/clients-registrations/openid-connect";
+        String tokenEndpoint = "https://localhost:8443/auth/realms/master/protocol/openid-connect/token";
+        String consumerKeyClaim = "azp";
+        String scopesClaim = "scope";
+        List<String> availableGrantTypes = Collections.emptyList();
+        //Connector Configurations - client Id and client secret are not provided
+        JsonObject jsonObject = new JsonObject();
+        Object additionalProperties = new Gson().fromJson(jsonObject, Map.class);
+        keyManagerDTO = DtoFactory.createKeyManagerDTO(name, null, type, displayName, introspectionEndpoint,
+                issuer, clientRegistrationEndpoint, tokenEndpoint, null, null, null,
+                null, consumerKeyClaim, scopesClaim, availableGrantTypes, additionalProperties,
+                null);
+        //Add the Keycloak key manager - This should fail
+        try {
+            restAPIAdmin.addKeyManager(keyManagerDTO);
+        } catch (ApiException e) {
+            Assert.assertEquals(e.getCode(), HttpStatus.SC_BAD_REQUEST);
+        }
+    }
+
+    @Test(groups = {"wso2.am"}, description = "Test add key manager with Keycloak type with mandatory " +
+            "and some optional parameters")
+    public void testAddKeyManagerWithKeycloakWithOptionalParams() throws Exception {
+        //Create the key manager DTO with Keycloak key manager type with mandatory and some optional parameters
+        String name = "KeycloakKeyManagerThree";
+        String type = "KeyCloak";
+        String displayName = "Test Key Manager Keycloak";
+        String issuer = "https://localhost:8443/auth/realms/master";
+        String introspectionEndpoint = "https://localhost:8443/auth/realms/master/protocol/openid-connect/token/introspect";
+        String clientRegistrationEndpoint = "https://localhost:8443/auth/realms/master/clients-registrations/openid-connect";
+        String tokenEndpoint = "https://localhost:8443/auth/realms/master/protocol/openid-connect/token";
+        String consumerKeyClaim = "azp";
+        String scopesClaim = "scope";
+        JsonObject jsonObject = new JsonObject();
+        jsonObject.addProperty("client_id", "clientIdValue");
+        jsonObject.addProperty("client_secret", "clientSecretValue");
+        jsonObject.addProperty("self_validate_jwt", true);
+        Object additionalProperties = new Gson().fromJson(jsonObject, Map.class);
+        //Optional Parameters
+        String description = "This is a test key manager";
+        String revokeEndpoint = "https://localhost:8443/auth/realms/master/protocol/openid-connect/revoke";
+        String userInfoEndpoint = "https://localhost:8443/auth/realms/master/protocol/openid-connect/userinfo";
+        String authorizeEndpoint = "https://localhost:8443/auth/realms/master/protocol/openid-connect/auth";
+        String scopeManagementEndpoint = "https://localhost:8443/auth/realms/master/protocol/openid-connect/scopes";
+        List<String> availableGrantTypes =
+                Arrays.asList("client_credentials", "password", "implicit", "refresh_token");
+        keyManagerDTO = DtoFactory.createKeyManagerDTO(name, description, type, displayName, introspectionEndpoint,
+                issuer, clientRegistrationEndpoint, tokenEndpoint, revokeEndpoint, userInfoEndpoint, authorizeEndpoint,
+                scopeManagementEndpoint, consumerKeyClaim, scopesClaim, availableGrantTypes, additionalProperties,
+                null);
+        //Add the Keycloak key manager
+        ApiResponse<KeyManagerDTO> addedKeyManagers = restAPIAdmin.addKeyManager(keyManagerDTO);
+        Assert.assertEquals(addedKeyManagers.getStatusCode(), HttpStatus.SC_CREATED);
+        KeyManagerDTO addedKeyManagerDTO = addedKeyManagers.getData();
+        String keyManagerId = addedKeyManagerDTO.getId();
+
+        //Assert the status code and key manager ID
+        Assert.assertNotNull(keyManagerId, "The Key Manager ID cannot be null or empty");
+        keyManagerDTO.setId(keyManagerId);
+        //Verify the created key manager DTO
+        adminApiTestHelper.verifyKeyManagerDTO(keyManagerDTO, addedKeyManagerDTO);
+    }
+
+    //Okta Key Manager
+    @Test(groups = {"wso2.am"}, description = "Test add key manager with Okta type with only mandatory parameters")
+    public void testAddKeyManagerWithOkta() throws Exception {
+        //Create the key manager DTO with Okta key manager type with only Mandatory parameters
+        String name = "OktaKeyManagerOne";
+        String type = "Okta";
+        String displayName = "Test Key Manager Okta";
+        String introspectionEndpoint = "https://dev-599740.okta.com/oauth2/default/v1/introspect";
+        String clientRegistrationEndpoint = "https://dev-599740.okta.com/oauth2/v1/clients";
+        String tokenEndpoint = "https://dev-599740.okta.com/oauth2/default/v1/token";
+        String revokeEndpoint = "https://dev-599740.okta.com/oauth2/default/v1/revoke";
+        String consumerKeyClaim = "cid";
+        String scopesClaim = "scp";
+        List<String> availableGrantTypes = Collections.emptyList();
+        JsonObject jsonObject = new JsonObject();
+        jsonObject.addProperty("apiKey", "apiKeyValue");
+        jsonObject.addProperty("client_id", "clientIdValue");
+        jsonObject.addProperty("client_secret", "clientSecretValue");
+        jsonObject.addProperty("self_validate_jwt", true);
+        Object additionalProperties = new Gson().fromJson(jsonObject, Map.class);
+        keyManagerDTO = DtoFactory.createKeyManagerDTO(name, null, type, displayName, introspectionEndpoint,
+                null, clientRegistrationEndpoint, tokenEndpoint, revokeEndpoint, null, null,
+                null, consumerKeyClaim, scopesClaim, availableGrantTypes, additionalProperties,
+                null);
+
+        //Add the Okta key manager
+        ApiResponse<KeyManagerDTO> addedKeyManagers = restAPIAdmin.addKeyManager(keyManagerDTO);
+        Assert.assertEquals(addedKeyManagers.getStatusCode(), HttpStatus.SC_CREATED);
+        KeyManagerDTO addedKeyManagerDTO = addedKeyManagers.getData();
+        String keyManagerId = addedKeyManagerDTO.getId();
+
+        //Assert the status code and key manager ID
+        Assert.assertNotNull(keyManagerId, "The Key Manager ID cannot be null or empty");
+        keyManagerDTO.setId(keyManagerId);
+        //Verify the created key manager DTO
+        adminApiTestHelper.verifyKeyManagerDTO(keyManagerDTO, addedKeyManagerDTO);
+    }
+
+    @Test(groups = {"wso2.am"}, description = "Test add key manager with Okta type without a mandatory parameter")
+    public void testAddKeyManagerWithOktaWithoutMandatoryParam() throws Exception {
+        //Create the key manager DTO with Okta key manager type without Connector Configurations (Mandatory parameter)
+        String name = "OktaKeyManagerTwo";
+        String type = "Okta";
+        String displayName = "Test Key Manager Okta";
+        String introspectionEndpoint = "https://dev-599740.okta.com/oauth2/default/v1/introspect";
+        String clientRegistrationEndpoint = "https://dev-599740.okta.com/oauth2/v1/clients";
+        String tokenEndpoint = "https://dev-599740.okta.com/oauth2/default/v1/token";
+        String revokeEndpoint = "https://dev-599740.okta.com/oauth2/default/v1/revoke";
+        String consumerKeyClaim = "cid";
+        String scopesClaim = "scp";
+        List<String> availableGrantTypes = Collections.emptyList();
+        //Connector Configurations - client Id, client secret and API key are not provided
+        JsonObject jsonObject = new JsonObject();
+        Object additionalProperties = new Gson().fromJson(jsonObject, Map.class);
+        keyManagerDTO = DtoFactory.createKeyManagerDTO(name, null, type, displayName, introspectionEndpoint,
+                null, clientRegistrationEndpoint, tokenEndpoint, revokeEndpoint, null, null,
+                null, consumerKeyClaim, scopesClaim, availableGrantTypes, additionalProperties,
+                null);
+        //Add the Okta key manager - This should fail
+        try {
+            restAPIAdmin.addKeyManager(keyManagerDTO);
+        } catch (ApiException e) {
+            Assert.assertEquals(e.getCode(), HttpStatus.SC_BAD_REQUEST);
+        }
+    }
+
+    @Test(groups = {"wso2.am"}, description = "Test add key manager with Okta type with mandatory " +
+            "and some optional parameters")
+    public void testAddKeyManagerWithOktaWithOptionalParams() throws Exception {
+        //Create the key manager DTO with Okta key manager type with mandatory and some optional parameters
+        String name = "OktaKeyManagerThree";
+        String type = "Okta";
+        String displayName = "Test Key Manager Okta";
+        String introspectionEndpoint = "https://dev-599740.okta.com/oauth2/default/v1/introspect";
+        String clientRegistrationEndpoint = "https://dev-599740.okta.com/oauth2/v1/clients";
+        String tokenEndpoint = "https://dev-599740.okta.com/oauth2/default/v1/token";
+        String revokeEndpoint = "https://dev-599740.okta.com/oauth2/default/v1/revoke";
+        String consumerKeyClaim = "cid";
+        String scopesClaim = "scp";
+        JsonObject jsonObject = new JsonObject();
+        jsonObject.addProperty("apiKey", "apiKeyValue");
+        jsonObject.addProperty("client_id", "clientIdValue");
+        jsonObject.addProperty("client_secret", "clientSecretValue");
+        jsonObject.addProperty("self_validate_jwt", true);
+        Object additionalProperties = new Gson().fromJson(jsonObject, Map.class);
+        //Optional parameters
+        String description = "This is a test key manager";
+        String issuer = "https://dev-599740.okta.com/oauth2/default";
+        String userInfoEndpoint = "https://dev-599740.okta.com/oauth2/default/v1/userinfo";
+        String authorizeEndpoint = "https://dev-599740.okta.com/oauth2/default/v1/authorize";
+        String scopeManagementEndpoint = "https://dev-599740.okta.com/oauth2/default/v1/scopes";
+        List<String> availableGrantTypes =
+                Arrays.asList("client_credentials", "password", "implicit", "refresh_token", "authorization_code");
+        String certificateValue = "https://dev-599740.okta.com/oauth2/default/v1/keys";
+        KeyManagerCertificatesDTO keyManagerCertificates =
+                DtoFactory.createKeyManagerCertificatesDTO(KeyManagerCertificatesDTO.TypeEnum.JWKS, certificateValue);
+
+        keyManagerDTO = DtoFactory.createKeyManagerDTO(name, description, type, displayName, introspectionEndpoint,
+                issuer, clientRegistrationEndpoint, tokenEndpoint, revokeEndpoint, userInfoEndpoint, authorizeEndpoint,
+                scopeManagementEndpoint, consumerKeyClaim, scopesClaim, availableGrantTypes, additionalProperties,
+                keyManagerCertificates);
+        //Add the Okta key manager
+        ApiResponse<KeyManagerDTO> addedKeyManagers = restAPIAdmin.addKeyManager(keyManagerDTO);
+        Assert.assertEquals(addedKeyManagers.getStatusCode(), HttpStatus.SC_CREATED);
+        KeyManagerDTO addedKeyManagerDTO = addedKeyManagers.getData();
+        String keyManagerId = addedKeyManagerDTO.getId();
+
+        //Assert the status code and key manager ID
+        Assert.assertNotNull(keyManagerId, "The Key Manager ID cannot be null or empty");
+        keyManagerDTO.setId(keyManagerId);
+        //Verify the created key manager DTO
+        adminApiTestHelper.verifyKeyManagerDTO(keyManagerDTO, addedKeyManagerDTO);
+    }
+
+    //PingFederate Key Manager
+    @Test(groups = {"wso2.am"}, description = "Test add key manager with PingFederate type with only mandatory parameters")
+    public void testAddKeyManagerWithPingFederate() throws Exception {
+        //Create the key manager DTO with PingFederate key manager type with only Mandatory parameters
+        String name = "PingFederateKeyManagerOne";
+        String type = "PingFederate";
+        String displayName = "Test Key Manager PingFederate";
+        String issuer = "https://localhost:9031";
+        String introspectionEndpoint = "https://localhost:9031/as/introspect.oauth2";
+        String clientRegistrationEndpoint = "https://localhost:9031/pf-ws/rest/oauth/clients";
+        String tokenEndpoint = "https://localhost:9031/as/token.oauth2";
+        String consumerKeyClaim = "client_id_name";
+        String scopesClaim = "scope";
+        List<String> availableGrantTypes = Collections.emptyList();
+        JsonObject jsonObject = new JsonObject();
+        jsonObject.addProperty("username", "admin");
+        jsonObject.addProperty("password", "admin");
+        jsonObject.addProperty("client_id", "clientIdValue");
+        jsonObject.addProperty("client_secret", "clientSecretValue");
+        jsonObject.addProperty("self_validate_jwt", true);
+        Object additionalProperties = new Gson().fromJson(jsonObject, Map.class);
+        keyManagerDTO = DtoFactory.createKeyManagerDTO(name, null, type, displayName, introspectionEndpoint,
+                issuer, clientRegistrationEndpoint, tokenEndpoint, null, null,
+                null, null, consumerKeyClaim, scopesClaim, availableGrantTypes,
+                additionalProperties, null);
+
+        //Add the PingFederate key manager
+        ApiResponse<KeyManagerDTO> addedKeyManagers = restAPIAdmin.addKeyManager(keyManagerDTO);
+        Assert.assertEquals(addedKeyManagers.getStatusCode(), HttpStatus.SC_CREATED);
+        KeyManagerDTO addedKeyManagerDTO = addedKeyManagers.getData();
+        String keyManagerId = addedKeyManagerDTO.getId();
+
+        //Assert the status code and key manager ID
+        Assert.assertNotNull(keyManagerId, "The Key Manager ID cannot be null or empty");
+        keyManagerDTO.setId(keyManagerId);
+        //Verify the created key manager DTO
+        adminApiTestHelper.verifyKeyManagerDTO(keyManagerDTO, addedKeyManagerDTO);
+    }
+
+    @Test(groups = {"wso2.am"}, description = "Test add key manager with PingFederate type without a mandatory parameter")
+    public void testAddKeyManagerWithPingFederateWithoutMandatoryParam() throws Exception {
+        //Create the key manager DTO with PingFederate key manager type without Connector Configurations (Mandatory parameter)
+        String name = "PingFederateKeyManagerTwo";
+        String type = "PingFederate";
+        String displayName = "Test Key Manager PingFederate";
+        String issuer = "https://localhost:9031";
+        String introspectionEndpoint = "https://localhost:9031/as/introspect.oauth2";
+        String clientRegistrationEndpoint = "https://localhost:9031/pf-ws/rest/oauth/clients";
+        String tokenEndpoint = "https://localhost:9031/as/token.oauth2";
+        String consumerKeyClaim = "client_id_name";
+        String scopesClaim = "scope";
+        List<String> availableGrantTypes = Collections.emptyList();
+        //Connector Configurations - client Id, client secret, username and password are not provided
+        JsonObject jsonObject = new JsonObject();
+        Object additionalProperties = new Gson().fromJson(jsonObject, Map.class);
+        keyManagerDTO = DtoFactory.createKeyManagerDTO(name, null, type, displayName, introspectionEndpoint,
+                issuer, clientRegistrationEndpoint, tokenEndpoint, null, null,
+                null, null, consumerKeyClaim, scopesClaim, availableGrantTypes,
+                additionalProperties, null);
+        //Add the PingFederate key manager - This should fail
+        try {
+            restAPIAdmin.addKeyManager(keyManagerDTO);
+        } catch (ApiException e) {
+            Assert.assertEquals(e.getCode(), HttpStatus.SC_BAD_REQUEST);
+        }
+    }
+
+    @Test(groups = {"wso2.am"}, description = "Test add key manager with PingFederate type with mandatory " +
+            "and some optional parameters")
+    public void testAddKeyManagerWithPingFederateWithOptionalParams() throws Exception {
+        //Create the key manager DTO with PingFederate key manager type with mandatory and some optional parameters
+        String name = "PingFederateKeyManagerThree";
+        String type = "PingFederate";
+        String displayName = "Test Key Manager PingFederate";
+        String issuer = "https://localhost:9031";
+        String introspectionEndpoint = "https://localhost:9031/as/introspect.oauth2";
+        String clientRegistrationEndpoint = "https://localhost:9031/pf-ws/rest/oauth/clients";
+        String tokenEndpoint = "https://localhost:9031/as/token.oauth2";
+        String consumerKeyClaim = "client_id_name";
+        String scopesClaim = "scope";
+        JsonObject jsonObject = new JsonObject();
+        jsonObject.addProperty("username", "admin");
+        jsonObject.addProperty("password", "admin");
+        jsonObject.addProperty("client_id", "clientIdValue");
+        jsonObject.addProperty("client_secret", "clientSecretValue");
+        jsonObject.addProperty("self_validate_jwt", true);
+        Object additionalProperties = new Gson().fromJson(jsonObject, Map.class);
+        //Optional parameters
+        String description = "This is a test key manager";
+        String userInfoEndpoint = "https://localhost:9031/as/userinfo.oauth2";
+        String authorizeEndpoint = "https://localhost:9031/as/authorization.oauth2";
+        String scopeManagementEndpoint = "https://localhost:9031/as/scope.oauth2";
+        String revokeEndpoint = "https://localhost:9031/as/revoke_token.oauth2";
+        List<String> availableGrantTypes =
+                Arrays.asList("client_credentials", "password", "implicit", "refresh_token", "authorization_code");
+        String certificateValue = "https://localhost:9031/pf/JWKS";
+        KeyManagerCertificatesDTO keyManagerCertificates =
+                DtoFactory.createKeyManagerCertificatesDTO(KeyManagerCertificatesDTO.TypeEnum.JWKS, certificateValue);
+
+        keyManagerDTO = DtoFactory.createKeyManagerDTO(name, description, type, displayName, introspectionEndpoint,
+                issuer, clientRegistrationEndpoint, tokenEndpoint, revokeEndpoint, userInfoEndpoint, authorizeEndpoint,
+                scopeManagementEndpoint, consumerKeyClaim, scopesClaim, availableGrantTypes, additionalProperties,
+                keyManagerCertificates);
+        //Add the PingFederate key manager
+        ApiResponse<KeyManagerDTO> addedKeyManagers = restAPIAdmin.addKeyManager(keyManagerDTO);
+        Assert.assertEquals(addedKeyManagers.getStatusCode(), HttpStatus.SC_CREATED);
+        KeyManagerDTO addedKeyManagerDTO = addedKeyManagers.getData();
+        String keyManagerId = addedKeyManagerDTO.getId();
+
+        //Assert the status code and key manager ID
+        Assert.assertNotNull(keyManagerId, "The Key Manager ID cannot be null or empty");
+        keyManagerDTO.setId(keyManagerId);
+        //Verify the created key manager DTO
+        adminApiTestHelper.verifyKeyManagerDTO(keyManagerDTO, addedKeyManagerDTO);
+    }
+
+    //ForgeRock Key Manager
+    @Test(groups = {"wso2.am"}, description = "Test add key manager with ForgeRock type with only mandatory parameters")
+    public void testAddKeyManagerWithForgeRock() throws Exception {
+        //Create the key manager DTO with ForgeRock key manager type with only Mandatory parameters
+        String name = "ForgeRockKeyManagerOne";
+        String type = "Forgerock";
+        String displayName = "Test Key Manager ForgeRock";
+        String issuer = "http://localhost:8080/openam/oauth2";
+        String introspectionEndpoint = "http://localhost:8080/openam/oauth2/introspect";
+        String clientRegistrationEndpoint = "http://localhost:8080/openam/oauth2/register";
+        String tokenEndpoint = "http://localhost:8080/openam/oauth2/access_token";
+        String consumerKeyClaim = "aud";
+        String scopesClaim = "scp";
+        List<String> availableGrantTypes = Collections.emptyList();
+        JsonObject jsonObject = new JsonObject();
+        jsonObject.addProperty("client_id", "clientIdValue");
+        jsonObject.addProperty("client_secret", "clientSecretValue");
+        jsonObject.addProperty("self_validate_jwt", true);
+        Object additionalProperties = new Gson().fromJson(jsonObject, Map.class);
+        keyManagerDTO = DtoFactory.createKeyManagerDTO(name, null, type, displayName, introspectionEndpoint,
+                issuer, clientRegistrationEndpoint, tokenEndpoint, null, null,
+                null, null, consumerKeyClaim, scopesClaim, availableGrantTypes,
+                additionalProperties, null);
+
+        //Add the ForgeRock key manager
+        ApiResponse<KeyManagerDTO> addedKeyManagers = restAPIAdmin.addKeyManager(keyManagerDTO);
+        Assert.assertEquals(addedKeyManagers.getStatusCode(), HttpStatus.SC_CREATED);
+        KeyManagerDTO addedKeyManagerDTO = addedKeyManagers.getData();
+        String keyManagerId = addedKeyManagerDTO.getId();
+
+        //Assert the status code and key manager ID
+        Assert.assertNotNull(keyManagerId, "The Key Manager ID cannot be null or empty");
+        keyManagerDTO.setId(keyManagerId);
+        //Verify the created key manager DTO
+        adminApiTestHelper.verifyKeyManagerDTO(keyManagerDTO, addedKeyManagerDTO);
+    }
+
+    @Test(groups = {"wso2.am"}, description = "Test add key manager with ForgeRock type without a mandatory parameter")
+    public void testAddKeyManagerWithForgeRockWithoutMandatoryParam() throws Exception {
+        //Create the key manager DTO with ForgeRock key manager type without Connector Configurations (Mandatory parameter)
+        String name = "ForgeRockKeyManagerTwo";
+        String type = "Forgerock";
+        String displayName = "Test Key Manager ForgeRock";
+        String issuer = "http://localhost:8080/openam/oauth2";
+        String introspectionEndpoint = "http://localhost:8080/openam/oauth2/introspect";
+        String clientRegistrationEndpoint = "http://localhost:8080/openam/oauth2/register";
+        String tokenEndpoint = "http://localhost:8080/openam/oauth2/access_token";
+        String consumerKeyClaim = "aud";
+        String scopesClaim = "scp";
+        List<String> availableGrantTypes = Collections.emptyList();
+        //Connector Configurations - client Id and client secret are not provided
+        JsonObject jsonObject = new JsonObject();
+        Object additionalProperties = new Gson().fromJson(jsonObject, Map.class);
+        keyManagerDTO = DtoFactory.createKeyManagerDTO(name, null, type, displayName, introspectionEndpoint,
+                issuer, clientRegistrationEndpoint, tokenEndpoint, null, null,
+                null, null, consumerKeyClaim, scopesClaim, availableGrantTypes,
+                additionalProperties, null);
+        //Add the ForgeRock key manager - This should fail
+        try {
+            restAPIAdmin.addKeyManager(keyManagerDTO);
+        } catch (ApiException e) {
+            Assert.assertEquals(e.getCode(), HttpStatus.SC_BAD_REQUEST);
+        }
+    }
+
+    @Test(groups = {"wso2.am"}, description = "Test add key manager with ForgeRock type with mandatory " +
+            "and some optional parameters")
+    public void testAddKeyManagerWithForgeRockWithOptionalParams() throws Exception {
+        //Create the key manager DTO with ForgeRock key manager type with mandatory and some optional parameters
+        String name = "ForgeRockKeyManagerThree";
+        String type = "Forgerock";
+        String displayName = "Test Key Manager ForgeRock";
+        String issuer = "http://localhost:8080/openam/oauth2";
+        String introspectionEndpoint = "http://localhost:8080/openam/oauth2/introspect";
+        String clientRegistrationEndpoint = "http://localhost:8080/openam/oauth2/register";
+        String tokenEndpoint = "http://localhost:8080/openam/oauth2/access_token";
+        String consumerKeyClaim = "aud";
+        String scopesClaim = "scp";
+        JsonObject jsonObject = new JsonObject();
+        jsonObject.addProperty("client_id", "clientIdValue");
+        jsonObject.addProperty("client_secret", "clientSecretValue");
+        jsonObject.addProperty("self_validate_jwt", true);
+        Object additionalProperties = new Gson().fromJson(jsonObject, Map.class);
+        //Optional parameters
+        String description = "This is a test key manager";
+        String userInfoEndpoint = "http://localhost:8080/openam/oauth2/userinfo";
+        String authorizeEndpoint = "http://localhost:8080/openam/oauth2/authorize";
+        String scopeManagementEndpoint = "http://localhost:8080/openam/oauth2/scopes";
+        String revokeEndpoint = "http://localhost:8080/openam/oauth2/revoke";
+        List<String> availableGrantTypes =
+                Arrays.asList("client_credentials", "password", "implicit", "refresh_token", "authorization_code");
+        String certificateValue = "http://localhost:8080/openam/oauth2/connect/jwk_url";
+        KeyManagerCertificatesDTO keyManagerCertificates =
+                DtoFactory.createKeyManagerCertificatesDTO(KeyManagerCertificatesDTO.TypeEnum.JWKS, certificateValue);
+
+        keyManagerDTO = DtoFactory.createKeyManagerDTO(name, description, type, displayName, introspectionEndpoint,
+                issuer, clientRegistrationEndpoint, tokenEndpoint, revokeEndpoint, userInfoEndpoint,
+                authorizeEndpoint, scopeManagementEndpoint, consumerKeyClaim, scopesClaim, availableGrantTypes,
+                additionalProperties, keyManagerCertificates);
+
+        //Add the ForgeRock key manager
+        ApiResponse<KeyManagerDTO> addedKeyManagers = restAPIAdmin.addKeyManager(keyManagerDTO);
+        Assert.assertEquals(addedKeyManagers.getStatusCode(), HttpStatus.SC_CREATED);
+        KeyManagerDTO addedKeyManagerDTO = addedKeyManagers.getData();
+        String keyManagerId = addedKeyManagerDTO.getId();
+
+        //Assert the status code and key manager ID
+        Assert.assertNotNull(keyManagerId, "The Key Manager ID cannot be null or empty");
+        keyManagerDTO.setId(keyManagerId);
+        //Verify the created key manager DTO
+        adminApiTestHelper.verifyKeyManagerDTO(keyManagerDTO, addedKeyManagerDTO);
+    }
+
+    /*TODO:
+       Testcase for adding a key manager with existing name
+       Testcase for adding a key manager with a name with space (Eg: Auth0 Keymanager)
+       Update Key manager
+       Delete Key manager
+     */
+
+    @AfterClass(alwaysRun = true)
+    public void destroy() throws Exception {
+        super.cleanUp();
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/restapi/admin/KeyManagersTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/restapi/admin/KeyManagersTestCase.java
@@ -1,10 +1,30 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.wso2.am.integration.tests.restapi.admin;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import org.apache.http.HttpStatus;
 import org.testng.Assert;
-import org.testng.annotations.*;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
 import org.wso2.am.integration.clients.admin.ApiException;
 import org.wso2.am.integration.clients.admin.ApiResponse;
 import org.wso2.am.integration.clients.admin.api.dto.KeyManagerCertificatesDTO;

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/restapi/admin/KeyManagersTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/restapi/admin/KeyManagersTestCase.java
@@ -19,6 +19,7 @@ package org.wso2.am.integration.tests.restapi.admin;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import org.apache.http.HttpStatus;
+import org.checkerframework.checker.units.qual.K;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -27,6 +28,7 @@ import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
 import org.wso2.am.integration.clients.admin.ApiException;
 import org.wso2.am.integration.clients.admin.ApiResponse;
+import org.wso2.am.integration.clients.admin.api.dto.AdvancedThrottlePolicyDTO;
 import org.wso2.am.integration.clients.admin.api.dto.KeyManagerCertificatesDTO;
 import org.wso2.am.integration.clients.admin.api.dto.KeyManagerDTO;
 import org.wso2.am.integration.test.helpers.AdminApiTestHelper;
@@ -34,10 +36,7 @@ import org.wso2.am.integration.test.impl.DtoFactory;
 import org.wso2.am.integration.test.utils.base.APIMIntegrationBaseTest;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class KeyManagersTestCase extends APIMIntegrationBaseTest {
     private AdminApiTestHelper adminApiTestHelper;
@@ -99,7 +98,8 @@ public class KeyManagersTestCase extends APIMIntegrationBaseTest {
         adminApiTestHelper.verifyKeyManagerDTO(keyManagerDTO, addedKeyManagerDTO);
     }
 
-    @Test(groups = {"wso2.am"}, description = "Test add key manager with Auth0 type without a mandatory parameter")
+    @Test(groups = {"wso2.am"}, description = "Test add key manager with Auth0 type without a mandatory parameter",
+            dependsOnMethods = "testAddKeyManagerWithAuth0")
     public void testAddKeyManagerWithAuth0WithoutMandatoryParam() throws Exception {
         //Create the key manager DTO with Auth0 key manager type without Connector Configurations (Mandatory parameter)
         String name = "Auth0KeyManagerTwo";
@@ -133,7 +133,7 @@ public class KeyManagersTestCase extends APIMIntegrationBaseTest {
     }
 
     @Test(groups = {"wso2.am"}, description = "Test add key manager with Auth0 type with mandatory " +
-            "and some optional parameters")
+            "and some optional parameters", dependsOnMethods = "testAddKeyManagerWithAuth0WithoutMandatoryParam")
     public void testAddKeyManagerWithAuth0WithOptionalParams() throws Exception {
         //Create the key manager DTO with Auth0 key manager type with mandatory and some optional parameters
         String name = "Auth0KeyManagerThree";
@@ -180,7 +180,8 @@ public class KeyManagersTestCase extends APIMIntegrationBaseTest {
     }
 
     //WSO2 IS Key Manager
-    @Test(groups = {"wso2.am"}, description = "Test add key manager with WSO2IS type with only mandatory parameters")
+    @Test(groups = {"wso2.am"}, description = "Test add key manager with WSO2IS type with only mandatory parameters",
+            dependsOnMethods = "testAddKeyManagerWithAuth0WithOptionalParams")
     public void testAddKeyManagerWithWso2IS() throws Exception {
         //Create the key manager DTO with WSO2 IS key manager type with only Mandatory parameters
         String name = "Wso2ISKeyManagerOne";
@@ -215,7 +216,8 @@ public class KeyManagersTestCase extends APIMIntegrationBaseTest {
         adminApiTestHelper.verifyKeyManagerDTO(keyManagerDTO, addedKeyManagerDTO);
     }
 
-    @Test(groups = {"wso2.am"}, description = "Test add key manager with WSO2IS type without a mandatory parameter")
+    @Test(groups = {"wso2.am"}, description = "Test add key manager with WSO2IS type without a mandatory parameter",
+            dependsOnMethods = "testAddKeyManagerWithWso2IS")
     public void testAddKeyManagerWithWso2ISWithoutMandatoryParam() throws Exception {
         //Create the key manager DTO with WSO2 IS key manager type without Connector Configurations (Mandatory parameter)
         String name = "Wso2ISKeyManagerTwo";
@@ -244,7 +246,7 @@ public class KeyManagersTestCase extends APIMIntegrationBaseTest {
     }
 
     @Test(groups = {"wso2.am"}, description = "Test add key manager with WSO2IS type with mandatory " +
-            "and some optional parameters")
+            "and some optional parameters", dependsOnMethods = "testAddKeyManagerWithWso2ISWithoutMandatoryParam")
     public void testAddKeyManagerWithWso2ISWithOptionalParams() throws Exception {
         //Create the key manager DTO with WSO2 IS key manager type with mandatory and some optional parameters
         String name = "Wso2ISKeyManagerThree";
@@ -288,7 +290,8 @@ public class KeyManagersTestCase extends APIMIntegrationBaseTest {
     }
 
     //Keycloak Key Manager
-    @Test(groups = {"wso2.am"}, description = "Test add key manager with Keycloak type with only mandatory parameters")
+    @Test(groups = {"wso2.am"}, description = "Test add key manager with Keycloak type with only mandatory parameters",
+            dependsOnMethods = "testAddKeyManagerWithWso2ISWithOptionalParams")
     public void testAddKeyManagerWithKeycloak() throws Exception {
         //Create the key manager DTO with Keycloak key manager type with only Mandatory parameters
         String name = "KeycloakKeyManagerOne";
@@ -324,7 +327,8 @@ public class KeyManagersTestCase extends APIMIntegrationBaseTest {
         adminApiTestHelper.verifyKeyManagerDTO(keyManagerDTO, addedKeyManagerDTO);
     }
 
-    @Test(groups = {"wso2.am"}, description = "Test add key manager with Keycloak type without a mandatory parameter")
+    @Test(groups = {"wso2.am"}, description = "Test add key manager with Keycloak type without a mandatory parameter",
+            dependsOnMethods = "testAddKeyManagerWithKeycloak")
     public void testAddKeyManagerWithKeycloakWithoutMandatoryParam() throws Exception {
         //Create the key manager DTO with Keycloak key manager type without Connector Configurations (Mandatory parameter)
         String name = "KeycloakKeyManagerTwo";
@@ -353,7 +357,7 @@ public class KeyManagersTestCase extends APIMIntegrationBaseTest {
     }
 
     @Test(groups = {"wso2.am"}, description = "Test add key manager with Keycloak type with mandatory " +
-            "and some optional parameters")
+            "and some optional parameters", dependsOnMethods = "testAddKeyManagerWithKeycloakWithoutMandatoryParam")
     public void testAddKeyManagerWithKeycloakWithOptionalParams() throws Exception {
         //Create the key manager DTO with Keycloak key manager type with mandatory and some optional parameters
         String name = "KeycloakKeyManagerThree";
@@ -396,7 +400,8 @@ public class KeyManagersTestCase extends APIMIntegrationBaseTest {
     }
 
     //Okta Key Manager
-    @Test(groups = {"wso2.am"}, description = "Test add key manager with Okta type with only mandatory parameters")
+    @Test(groups = {"wso2.am"}, description = "Test add key manager with Okta type with only mandatory parameters",
+            dependsOnMethods = "testAddKeyManagerWithKeycloakWithOptionalParams")
     public void testAddKeyManagerWithOkta() throws Exception {
         //Create the key manager DTO with Okta key manager type with only Mandatory parameters
         String name = "OktaKeyManagerOne";
@@ -433,7 +438,8 @@ public class KeyManagersTestCase extends APIMIntegrationBaseTest {
         adminApiTestHelper.verifyKeyManagerDTO(keyManagerDTO, addedKeyManagerDTO);
     }
 
-    @Test(groups = {"wso2.am"}, description = "Test add key manager with Okta type without a mandatory parameter")
+    @Test(groups = {"wso2.am"}, description = "Test add key manager with Okta type without a mandatory parameter",
+            dependsOnMethods = "testAddKeyManagerWithOkta")
     public void testAddKeyManagerWithOktaWithoutMandatoryParam() throws Exception {
         //Create the key manager DTO with Okta key manager type without Connector Configurations (Mandatory parameter)
         String name = "OktaKeyManagerTwo";
@@ -462,7 +468,7 @@ public class KeyManagersTestCase extends APIMIntegrationBaseTest {
     }
 
     @Test(groups = {"wso2.am"}, description = "Test add key manager with Okta type with mandatory " +
-            "and some optional parameters")
+            "and some optional parameters", dependsOnMethods = "testAddKeyManagerWithOktaWithoutMandatoryParam")
     public void testAddKeyManagerWithOktaWithOptionalParams() throws Exception {
         //Create the key manager DTO with Okta key manager type with mandatory and some optional parameters
         String name = "OktaKeyManagerThree";
@@ -510,7 +516,8 @@ public class KeyManagersTestCase extends APIMIntegrationBaseTest {
     }
 
     //PingFederate Key Manager
-    @Test(groups = {"wso2.am"}, description = "Test add key manager with PingFederate type with only mandatory parameters")
+    @Test(groups = {"wso2.am"}, description = "Test add key manager with PingFederate type with only mandatory parameters",
+            dependsOnMethods = "testAddKeyManagerWithOktaWithOptionalParams")
     public void testAddKeyManagerWithPingFederate() throws Exception {
         //Create the key manager DTO with PingFederate key manager type with only Mandatory parameters
         String name = "PingFederateKeyManagerOne";
@@ -548,7 +555,8 @@ public class KeyManagersTestCase extends APIMIntegrationBaseTest {
         adminApiTestHelper.verifyKeyManagerDTO(keyManagerDTO, addedKeyManagerDTO);
     }
 
-    @Test(groups = {"wso2.am"}, description = "Test add key manager with PingFederate type without a mandatory parameter")
+    @Test(groups = {"wso2.am"}, description = "Test add key manager with PingFederate type without a mandatory parameter",
+            dependsOnMethods = "testAddKeyManagerWithPingFederate")
     public void testAddKeyManagerWithPingFederateWithoutMandatoryParam() throws Exception {
         //Create the key manager DTO with PingFederate key manager type without Connector Configurations (Mandatory parameter)
         String name = "PingFederateKeyManagerTwo";
@@ -577,7 +585,7 @@ public class KeyManagersTestCase extends APIMIntegrationBaseTest {
     }
 
     @Test(groups = {"wso2.am"}, description = "Test add key manager with PingFederate type with mandatory " +
-            "and some optional parameters")
+            "and some optional parameters", dependsOnMethods = "testAddKeyManagerWithPingFederateWithoutMandatoryParam")
     public void testAddKeyManagerWithPingFederateWithOptionalParams() throws Exception {
         //Create the key manager DTO with PingFederate key manager type with mandatory and some optional parameters
         String name = "PingFederateKeyManagerThree";
@@ -626,7 +634,8 @@ public class KeyManagersTestCase extends APIMIntegrationBaseTest {
     }
 
     //ForgeRock Key Manager
-    @Test(groups = {"wso2.am"}, description = "Test add key manager with ForgeRock type with only mandatory parameters")
+    @Test(groups = {"wso2.am"}, description = "Test add key manager with ForgeRock type with only mandatory parameters",
+            dependsOnMethods = "testAddKeyManagerWithPingFederateWithOptionalParams")
     public void testAddKeyManagerWithForgeRock() throws Exception {
         //Create the key manager DTO with ForgeRock key manager type with only Mandatory parameters
         String name = "ForgeRockKeyManagerOne";
@@ -662,7 +671,8 @@ public class KeyManagersTestCase extends APIMIntegrationBaseTest {
         adminApiTestHelper.verifyKeyManagerDTO(keyManagerDTO, addedKeyManagerDTO);
     }
 
-    @Test(groups = {"wso2.am"}, description = "Test add key manager with ForgeRock type without a mandatory parameter")
+    @Test(groups = {"wso2.am"}, description = "Test add key manager with ForgeRock type without a mandatory parameter",
+            dependsOnMethods = "testAddKeyManagerWithForgeRock")
     public void testAddKeyManagerWithForgeRockWithoutMandatoryParam() throws Exception {
         //Create the key manager DTO with ForgeRock key manager type without Connector Configurations (Mandatory parameter)
         String name = "ForgeRockKeyManagerTwo";
@@ -691,7 +701,7 @@ public class KeyManagersTestCase extends APIMIntegrationBaseTest {
     }
 
     @Test(groups = {"wso2.am"}, description = "Test add key manager with ForgeRock type with mandatory " +
-            "and some optional parameters")
+            "and some optional parameters", dependsOnMethods = "testAddKeyManagerWithForgeRockWithoutMandatoryParam")
     public void testAddKeyManagerWithForgeRockWithOptionalParams() throws Exception {
         //Create the key manager DTO with ForgeRock key manager type with mandatory and some optional parameters
         String name = "ForgeRockKeyManagerThree";
@@ -738,12 +748,24 @@ public class KeyManagersTestCase extends APIMIntegrationBaseTest {
         adminApiTestHelper.verifyKeyManagerDTO(keyManagerDTO, addedKeyManagerDTO);
     }
 
-    /*TODO:
-       Testcase for adding a key manager with existing name
-       Testcase for adding a key manager with a name with space (Eg: Auth0 Keymanager)
-       Update Key manager
-       Delete Key manager
-     */
+    @Test(groups = {"wso2.am"}, description = "Test get and update key manager",
+            dependsOnMethods = "testAddKeyManagerWithForgeRockWithOptionalParams")
+    public void testGetAndUpdateKeyManager() throws Exception {
+        //Get the added Key manager
+        String keyManagerId = keyManagerDTO.getId();
+        ApiResponse<KeyManagerDTO> retrievedKeyManager = restAPIAdmin.getKeyManager(keyManagerId);
+        Assert.assertEquals(retrievedKeyManager.getStatusCode(), HttpStatus.SC_OK);
+        //Update the key manager
+        String updatedDescription = "This is a updated test key manager";
+        keyManagerDTO.setDescription(updatedDescription);
+        ApiResponse<KeyManagerDTO> updatedKeyManager =
+                restAPIAdmin.updateKeyManager(keyManagerId, keyManagerDTO);
+        KeyManagerDTO updatedKeyManagerDTO = updatedKeyManager.getData();
+        Assert.assertEquals(updatedKeyManager.getStatusCode(), HttpStatus.SC_OK);
+
+        //Verify the updated key manager DTO
+        adminApiTestHelper.verifyKeyManagerDTO(keyManagerDTO, updatedKeyManagerDTO);
+    }
 
     @AfterClass(alwaysRun = true)
     public void destroy() throws Exception {

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/restapi/admin/KeyManagersTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/restapi/admin/KeyManagersTestCase.java
@@ -767,6 +767,34 @@ public class KeyManagersTestCase extends APIMIntegrationBaseTest {
         adminApiTestHelper.verifyKeyManagerDTO(keyManagerDTO, updatedKeyManagerDTO);
     }
 
+    @Test(groups = {"wso2.am"}, description = "Test add key manager with existing key manager name",
+            dependsOnMethods = "testGetAndUpdateKeyManager")
+    public void testAddKeyManagerWithExistingKeyManagerName() throws ApiException {
+
+        //Exception occurs when adding a key manager with an existing key manager name. The status code
+        //in the Exception object is used to assert this scenario
+        try {
+            restAPIAdmin.addKeyManager(keyManagerDTO);
+        } catch (ApiException e) {
+            Assert.assertEquals(e.getCode(), HttpStatus.SC_CONFLICT);
+        }
+    }
+
+    @Test(groups = {"wso2.am"}, description = "Test delete key manager",
+            dependsOnMethods = "testAddKeyManagerWithExistingKeyManagerName")
+    public void testDeleteKeyManager() throws Exception {
+        ApiResponse<Void> apiResponse =
+                restAPIAdmin.deleteKeyManager(keyManagerDTO.getId());
+        Assert.assertEquals(apiResponse.getStatusCode(), HttpStatus.SC_OK);
+
+        //Delete non existing key manager - not found
+        try {
+            apiResponse = restAPIAdmin.deleteKeyManager(UUID.randomUUID().toString());
+        } catch (ApiException e) {
+            Assert.assertEquals(e.getCode(), HttpStatus.SC_NOT_FOUND);
+        }
+    }
+
     @AfterClass(alwaysRun = true)
     public void destroy() throws Exception {
         super.cleanUp();

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -242,6 +242,7 @@
             <class name="org.wso2.am.integration.tests.restapi.admin.throttlingpolicy.CustomThrottlingPolicyTestCase"/>
             <class name="org.wso2.am.integration.tests.restapi.admin.throttlingpolicy.AdvancedThrottlingPolicyTestCase"/>
             <class name="org.wso2.am.integration.tests.restapi.admin.EnvironmentTestCase"/>
+            <class name="org.wso2.am.integration.tests.restapi.admin.KeyManagersTestCase"/>
         </classes>
     </test>
 


### PR DESCRIPTION
## Purpose

This PR adds the integration test cases related to Key manager in the Admin portal.

## Implemented Testcases 

**1. Auth0 as Key manager**

- _testAddKeyManagerWithAuth0_ - Test case for adding Auth0 as key manager with only mandatory parameters.
- _testAddKeyManagerWithAuth0WithoutMandatoryParam_ - Test case for adding Auth0 as key manager without Connector Configurations.
-  _testAddKeyManagerWithAuth0WithOptionalParams_ - Test case for adding Auth0 as key manager with some optional parameters.
- _testGetKeyManagerWithAuth0_ - Test case for getting key manager with Auth0 type.
- _testUpdateKeyManagerWithAuth0_ - Test case for updating key manager with Auth0 type.
- _testDeleteKeyManagerWithAuth0_ - Test case for deleting key manager with Auth0 type.

**2. WSO2 IS as Key manager**

- _testAddKeyManagerWithWso2IS_ - Test case for adding Wso2IS as key manager with only mandatory parameters.
- _testAddKeyManagerWithWso2ISWithoutMandatoryParam_ - Test case for adding Wso2IS as key manager without Connector Configurations.
-  _testAddKeyManagerWithWso2ISWithOptionalParams_ - Test case for adding Wso2IS as key manager with some optional parameters.
- _testGetKeyManagerWithWso2IS_ - Test case for getting key manager with Wso2IS type.
- _testUpdateKeyManagerWithWso2IS_ - Test case for updating key manager with Wso2IS type.
- _testDeleteKeyManagerWithWso2IS_ - Test case for deleting key manager with Wso2IS type.

**3. Keycloak as Key manager**

- _testAddKeyManagerWithKeycloak_ - Test case for adding Keycloak as key manager with only mandatory parameters.
- _testAddKeyManagerWithKeycloakWithoutMandatoryParam_ - Test case for adding Keycloak as key manager without Connector Configurations.
-  _testAddKeyManagerWithKeycloakWithOptionalParams_ - Test case for adding Keycloak as key manager with some optional parameters.
- _testGetKeyManagerWithKeycloak_ - Test case for getting key manager with Keycloak type.
- _testUpdateKeyManagerWithKeycloak_ - Test case for updating key manager with Keycloak type.
- _testDeleteKeyManagerWithKeycloak_ - Test case for deleting key manager with Keycloak type.

**4. Okta as Key manager**

- _testAddKeyManagerWithOkta_ - Test case for adding Okta as key manager with only mandatory parameters.
- _testAddKeyManagerWithOktaWithoutMandatoryParam_ - Test case for adding Okta as key manager without Connector Configurations.
-  _testAddKeyManagerWithOktaWithOptionalParams_ - Test case for adding Okta as key manager with some optional parameters.
- _testGetKeyManagerWithOkta_ - Test case for getting key manager with Okta type.
- _testUpdateKeyManagerWithOkta_ - Test case for updating key manager with Okta type.
- _testDeleteKeyManagerWithOkta_ - Test case for deleting key manager with Okta type.

**5. PingFederate as Key manager**

- _testAddKeyManagerWithPingFederate_ - Test case for adding PingFederate as key manager with only mandatory parameters.
- _testAddKeyManagerWithPingFederateWithoutMandatoryParam_ - Test case for adding PingFederate as key manager without Connector Configurations.
-  _testAddKeyManagerWithPingFederateWithOptionalParams_ - Test case for adding PingFederate as key manager with some optional parameters.
- _testGetKeyManagerWithPingFederate_ - Test case for getting key manager with PingFederate type.
- _testUpdateKeyManagerWithPingFederate_ - Test case for updating key manager with PingFederate type.
- _testDeleteKeyManagerWithPingFederate_ - Test case for deleting key manager with PingFederate type.

**6. ForgeRock as Key manager**

- _testAddKeyManagerWithForgeRock_ - Test case for adding ForgeRock as key manager with only mandatory parameters.
- _testAddKeyManagerWithForgeRockWithoutMandatoryParam_ - Test case for adding ForgeRock as key manager without Connector Configurations.
-  _testAddKeyManagerWithForgeRockWithOptionalParams_ - Test case for adding ForgeRock as key manager with some optional parameters.
- _testGetKeyManagerWithForgeRock_ - Test case for getting key manager with ForgeRock type.
- _testUpdateKeyManagerWithForgeRock_ - Test case for updating key manager with ForgeRock type.
- _testDeleteKeyManagerWithForgeRock_ - Test case for deleting key manager with ForgeRock type.

_testAddKeyManagerWithExistingKeyManagerName_ - Test case for adding a key manager with an existing name.