### PR TITLE
Add Prototype endpoint test cases

### DIFF
--- a/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/impl/RestAPIPublisherImpl.java
+++ b/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/impl/RestAPIPublisherImpl.java
@@ -71,6 +71,7 @@ import org.wso2.am.integration.clients.publisher.api.v1.dto.GraphQLValidationRes
 import org.wso2.am.integration.clients.publisher.api.v1.dto.LifecycleHistoryDTO;
 import org.wso2.am.integration.clients.publisher.api.v1.dto.LifecycleStateDTO;
 import org.wso2.am.integration.clients.publisher.api.v1.dto.MediationListDTO;
+import org.wso2.am.integration.clients.publisher.api.v1.dto.MockResponsePayloadListDTO;
 import org.wso2.am.integration.clients.publisher.api.v1.dto.OpenAPIDefinitionValidationResponseDTO;
 import org.wso2.am.integration.clients.publisher.api.v1.dto.PatchRequestBodyDTO;
 import org.wso2.am.integration.clients.publisher.api.v1.dto.PostRequestBodyDTO;
@@ -583,6 +584,24 @@ public class RestAPIPublisherImpl {
         HttpResponse response = null;
         if (deleteResponse.getStatusCode() == 200) {
             response = new HttpResponse("Successfully deleted the API", 200);
+        }
+        return response;
+    }
+
+    public HttpResponse generateMockScript(String apiId) throws ApiException {
+        ApiResponse<String> mockResponse = apIsApi.generateMockScriptsWithHttpInfo(apiId, null);
+        HttpResponse response = null;
+        if (mockResponse.getStatusCode() == 200) {
+            response = new HttpResponse("Successfully generated MockScript", 200);
+        }
+        return response;
+    }
+
+    public HttpResponse getGenerateMockScript(String apiId) throws ApiException {
+        ApiResponse<MockResponsePayloadListDTO> mockResponse = apIsApi.getGeneratedMockScriptsOfAPIWithHttpInfo(apiId, null);
+        HttpResponse response = null;
+        if (mockResponse.getStatusCode() == 200) {
+            response = new HttpResponse(mockResponse.getData().toString(), 200);
         }
         return response;
     }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/prototype/PrototypedAPITestcase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/prototype/PrototypedAPITestcase.java
@@ -242,19 +242,18 @@ public class PrototypedAPITestcase extends APIMIntegrationBaseTest {
         restAPIPublisher.deleteAPI(apiID);
     }
 
-
-    @Test(groups = { "wso2.am" }, description = "Create an inline protoype API with OAS3 and Generate mock")
+    @Test(groups = {"wso2.am"}, description = "Create an inline protoype API with OAS3 and Generate mock")
     public void testInlinePrototypeWithMock() throws Exception {
 
         resourcePath = "oas" + File.separator + "v3" + File.separator;
         String originalDefinition = IOUtils.toString(
-                getClass().getClassLoader().getResourceAsStream(resourcePath +"prototype" + File.separator + "oas_import.json"),
+                getClass().getClassLoader().getResourceAsStream(resourcePath + "prototype" + File.separator + "oas_import.json"),
                 "UTF-8");
         String additionalProperties = IOUtils.toString(
-                getClass().getClassLoader().getResourceAsStream(resourcePath +"prototype" + File.separator + "additionalProperties.json"),
+                getClass().getClassLoader().getResourceAsStream(resourcePath + "prototype" + File.separator + "additionalProperties.json"),
                 "UTF-8");
         String updatedMock = IOUtils.toString(
-                getClass().getClassLoader().getResourceAsStream(resourcePath +"prototype" + File.separator + "updatedMockOas.json"),
+                getClass().getClassLoader().getResourceAsStream(resourcePath + "prototype" + File.separator + "updatedMockOas.json"),
                 "UTF-8");
         org.json.JSONObject additionalPropertiesObj = new org.json.JSONObject(additionalProperties);
         additionalPropertiesObj.put("provider", user.getUserName());
@@ -270,7 +269,7 @@ public class PrototypedAPITestcase extends APIMIntegrationBaseTest {
 
         // Generate mock Script for Prototype Implementation
         HttpResponse mockgenResponse = restAPIPublisher.generateMockScript(apiImportId);
-        Assert.assertEquals( mockgenResponse.getResponseCode(), 200);
+        Assert.assertEquals(mockgenResponse.getResponseCode(), 200);
 
         // Retrieve and validate the generated mock script
         HttpResponse mockedGetResponse = restAPIPublisher.getGenerateMockScript(apiImportId);
@@ -295,6 +294,7 @@ public class PrototypedAPITestcase extends APIMIntegrationBaseTest {
     }
 
     private File geTempFileWithContent(String swagger) throws Exception {
+
         File temp = File.createTempFile("swagger", ".json");
         temp.deleteOnExit();
         BufferedWriter out = new BufferedWriter(new FileWriter(temp));

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/prototype/PrototypedAPITestcase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/prototype/PrototypedAPITestcase.java
@@ -1,0 +1,228 @@
+/*
+ *
+ *   Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *   WSO2 Inc. licenses this file to you under the Apache License,
+ *   Version 2.0 (the "License"); you may not use this file except
+ *   in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing,
+ *   software distributed under the License is distributed on an
+ *   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *   KIND, either express or implied.  See the License for the
+ *   specific language governing permissions and limitations
+ *   under the License.
+ *
+ */
+
+package org.wso2.am.integration.tests.prototype;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+import javax.ws.rs.core.Response;
+import javax.xml.xpath.XPathExpressionException;
+
+import com.google.gson.Gson;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.am.integration.clients.publisher.api.v1.dto.APIDTO;
+import org.wso2.am.integration.clients.publisher.api.v1.dto.APIListDTO;
+import org.wso2.am.integration.clients.publisher.api.v1.dto.WorkflowResponseDTO;
+import org.wso2.am.integration.test.impl.RestAPIPublisherImpl;
+import org.wso2.am.integration.test.impl.RestAPIStoreImpl;
+import org.wso2.am.integration.test.utils.APIManagerIntegrationTestException;
+import org.wso2.am.integration.test.utils.base.APIMIntegrationBaseTest;
+import org.wso2.am.integration.test.utils.bean.APILifeCycleAction;
+import org.wso2.am.integration.test.utils.bean.APILifeCycleState;
+import org.wso2.am.integration.test.utils.bean.APIRequest;
+import org.wso2.am.integration.test.utils.generic.APIMTestCaseUtils;
+import org.wso2.am.integration.test.utils.http.HTTPSClientUtils;
+import org.wso2.carbon.apimgt.api.model.APIIdentifier;
+import org.wso2.carbon.automation.test.utils.http.client.HttpResponse;
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
+
+public class PrototypedAPITestcase extends APIMIntegrationBaseTest {
+
+    private final String apiVersion = "1.0.0";
+    private String apiProvider;
+    private String apiName;
+    private String apiEndPointUrl;
+    private String apiID;
+    private APIIdentifier apiIdentifier;
+
+    @BeforeClass(alwaysRun = true)
+    public void setEnvironment() throws APIManagerIntegrationTestException, XPathExpressionException {
+
+        super.init();
+
+        String apiPrototypeEndpointPostfixUrl = "am/sample/pizzashack/v1/api/menu";
+        apiEndPointUrl = gatewayUrlsWrk.getWebAppURLHttp() + apiPrototypeEndpointPostfixUrl;
+
+        restAPIPublisher = new RestAPIPublisherImpl(publisherContext.getContextTenant().getContextUser().getUserName(),
+                publisherContext.getContextTenant().getContextUser().getPassword(),
+                publisherContext.getContextTenant().getDomain(), publisherURLHttps);
+
+        restAPIStore = new RestAPIStoreImpl(storeContext.getContextTenant().getContextUser().getUserName(),
+                storeContext.getContextTenant().getContextUser().getPassword(),
+                storeContext.getContextTenant().getDomain(), storeURLHttps);
+
+        apiProvider = publisherContext.getContextTenant().getContextUser().getUserName();
+    }
+
+    @Test(groups = {"wso2.am"}, description = "Create an API with a prototype endpoint and invoke")
+    public void testPrototypedAPIEndpoint() throws Exception {
+
+        apiName = "APIMPrototypedEndpointAPI1";
+        String apiContext = "pizzashack-prototype";
+        String apiTags = "pizza, order, pizza-menu";
+        String apiDescription = "Pizza API:Allows to manage pizza orders " +
+                "(create, update, retrieve orders)";
+
+        apiIdentifier = new APIIdentifier(apiProvider, apiName, apiVersion);
+        APIRequest apiRequest = new APIRequest(apiName, apiContext, new URL(apiEndPointUrl));
+        apiRequest.setVersion(apiVersion);
+        apiRequest.setDescription(apiDescription);
+        apiRequest.setTags(apiTags);
+        apiRequest.setVisibility(APIDTO.VisibilityEnum.PUBLIC.getValue());
+
+        HttpResponse addAPIResponse = restAPIPublisher.addAPI(apiRequest);
+        assertEquals(addAPIResponse.getResponseCode(), Response.Status.CREATED.getStatusCode(),
+                "Invalid Response Code");
+        apiID = addAPIResponse.getData();
+
+        //Deployed API as a Prototyped API & check the status
+        WorkflowResponseDTO lcChangeResponse = restAPIPublisher.changeAPILifeCycleStatus(apiID,
+                APILifeCycleAction.DEPLOY_AS_PROTOTYPE.getAction());
+
+        HttpResponse response = restAPIPublisher.getAPI(apiID);
+        Gson g = new Gson();
+        APIDTO apidto = g.fromJson(response.getData(), APIDTO.class);
+        String endPointString = "{\"implementation_status\":\"prototyped\",\"endpoint_type\":\"http\"," +
+                "\"production_endpoints\":{\"config\":null," +
+                "\"url\":\"" + apiEndPointUrl + "\"}," +
+                "\"sandbox_endpoints\":{\"config\":null,\"url\":\"" + apiEndPointUrl + "\"}}";
+
+        JSONParser parser = new JSONParser();
+        JSONObject endpoint = (JSONObject) parser.parse(endPointString);
+        apidto.setEndpointConfig(endpoint);
+
+        restAPIPublisher.updateAPI(apidto);
+
+        assertTrue(lcChangeResponse.getLifecycleState().getState().equals("Prototyped"),
+                apiName + "  status not updated as Prototyped");
+        Thread.sleep(15000);
+
+        // Create a revision and Deploy the API
+        createAPIRevisionAndDeployUsingRest(apiID, restAPIPublisher);
+
+        //Check whether Prototype API is available in publisher
+        APIListDTO getAllAPIsResponse = restAPIPublisher.getAllAPIs();
+        assertTrue(APIMTestCaseUtils.isAPIAvailable(apiIdentifier, getAllAPIsResponse),
+                "Implemented" + apiName + " Api is not visible in API Publisher.");
+        Thread.sleep(15000);
+
+        //Check whether Prototype API is available under the Prototyped API
+        org.wso2.am.integration.clients.store.api.v1.dto.APIListDTO prototypedAPIs = restAPIStore
+                .getPrototypedAPIs(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+        assertTrue(APIMTestCaseUtils.isAPIAvailableInStore(apiIdentifier, prototypedAPIs),
+                apiName + " is not visible as Prototyped API");
+
+        Map<String, String> requestHeaders = new HashMap<>();
+        requestHeaders.put("accept", "application/json");
+
+        //Invoke the Prototype endpoint and validate
+        HttpResponse response1 = HTTPSClientUtils
+                .doGet(getAPIInvocationURLHttps(apiContext, apiVersion) +
+                        "", requestHeaders);
+        Assert.assertEquals(response1.getResponseCode(), 200);
+        Assert.assertTrue(response1.getData().contains("BBQ Chicken Bacon"));
+    }
+
+    @Test(groups = {"wso2.am"}, description = "Create an API with a prototype endpoint, demote to created and invoke")
+    public void testDemotedPrototypedEndpointAPItoCreated() throws Exception {
+
+        apiName = "APIMPrototypedEndpointAPI2";
+        String apiContext = "pizzashack-prototype2";
+        String apiTags = "pizza, order, pizza-menu";
+        String apiDescription = "Pizza API:Allows to manage pizza orders " +
+                "(create, update, retrieve orders)";
+
+        apiIdentifier = new APIIdentifier(apiProvider, apiName, apiVersion);
+        APIRequest apiRequest = new APIRequest(apiName, apiContext, new URL(apiEndPointUrl));
+        apiRequest.setVersion(apiVersion);
+        apiRequest.setDescription(apiDescription);
+        apiRequest.setTags(apiTags);
+        apiRequest.setVisibility(APIDTO.VisibilityEnum.PUBLIC.getValue());
+
+        HttpResponse addAPIResponse = restAPIPublisher.addAPI(apiRequest);
+        assertEquals(addAPIResponse.getResponseCode(), Response.Status.CREATED.getStatusCode(),
+                "Invalid Response Code");
+        apiID = addAPIResponse.getData();
+
+        //Deployed API as a Prototyped API & check the status
+        WorkflowResponseDTO lcChangeResponse = restAPIPublisher.changeAPILifeCycleStatus(apiID,
+                APILifeCycleAction.DEPLOY_AS_PROTOTYPE.getAction());
+
+        HttpResponse response = restAPIPublisher.getAPI(apiID);
+        Gson g = new Gson();
+        APIDTO apidto = g.fromJson(response.getData(), APIDTO.class);
+        String endPointString = "{\"implementation_status\":\"prototyped\",\"endpoint_type\":\"http\"," +
+                "\"production_endpoints\":{\"config\":null," +
+                "\"url\":\"" + apiEndPointUrl + "\"}," +
+                "\"sandbox_endpoints\":{\"config\":null,\"url\":\"" + apiEndPointUrl + "\"}}";
+
+        JSONParser parser = new JSONParser();
+        JSONObject endpoint = (JSONObject) parser.parse(endPointString);
+        apidto.setEndpointConfig(endpoint);
+
+        //Update the API with Prototype endpoint
+        restAPIPublisher.updateAPI(apidto);
+
+        assertTrue(lcChangeResponse.getLifecycleState().getState().equals("Prototyped"),
+                apiName + "  status not updated as Prototyped");
+        Thread.sleep(15000);
+
+        // Create a revision and Deploy the API
+        createAPIRevisionAndDeployUsingRest(apiID, restAPIPublisher);
+
+        //Check whether Prototype API is available in publisher
+        APIListDTO getAllAPIsResponse = restAPIPublisher.getAllAPIs();
+        assertTrue(APIMTestCaseUtils.isAPIAvailable(apiIdentifier, getAllAPIsResponse),
+                "Implemented" + apiName + " Api is not visible in API Publisher.");
+        Thread.sleep(15000);
+
+        //Check whether Prototype API is available under the Prototyped API
+        org.wso2.am.integration.clients.store.api.v1.dto.APIListDTO prototypedAPIs = restAPIStore
+                .getPrototypedAPIs(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+        assertTrue(APIMTestCaseUtils.isAPIAvailableInStore(apiIdentifier, prototypedAPIs),
+                apiName + " is not visible as Prototyped API");
+
+        //Change the status PROTOTYPED to CREATED
+        restAPIPublisher.changeAPILifeCycleStatus(apiID, APILifeCycleAction.DEMOTE_TO_CREATE.getAction());
+        assertTrue(APILifeCycleState.CREATED.getState().equals(restAPIPublisher.getLifecycleStatus(apiID).getData()),
+                apiName + "status not updated as CREATED");
+        //Wait for the changes to be applied after demoting to Created.
+        Thread.sleep(15000);
+
+        Map<String, String> requestHeaders = new HashMap<>();
+        requestHeaders.put("accept", "application/json");
+
+        //Invoke the Prototype endpoint
+        HttpResponse response2 = HTTPSClientUtils
+                .doGet(getAPIInvocationURLHttps(apiContext, apiVersion) +
+                        "", requestHeaders);
+
+        Assert.assertEquals(response2.getResponseCode(), 401, "User was able to invoke the API demoted to CREATED from PROTOTYPE");
+    }
+
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/prototype/PrototypedAPITestcase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/prototype/PrototypedAPITestcase.java
@@ -261,7 +261,7 @@ public class PrototypedAPITestcase extends APIMIntegrationBaseTest {
         additionalPropertiesObj.put("context", context);
         org.json.JSONObject updatedMockObj = new org.json.JSONObject(updatedMock);
         updatedMockObj.put("provider", user.getUserName());
-        File file = geTempFileWithContent(originalDefinition);
+        File file = getTempFileWithContent(originalDefinition);
         // Create an api by importing OAS3 file
         APIDTO apidto = restAPIPublisher.importOASDefinition(file, additionalPropertiesObj.toString());
         String apiImportId = apidto.getId();
@@ -311,7 +311,7 @@ public class PrototypedAPITestcase extends APIMIntegrationBaseTest {
         additionalPropertiesObj.put("provider", user.getUserName());
         additionalPropertiesObj.put("context", context);
 
-        File file = geTempFileWithContent(originalDefinition);
+        File file = getTempFileWithContent(originalDefinition);
         // Create an api by importing OAS2 file
         APIDTO apidto = restAPIPublisher.importOASDefinition(file, additionalPropertiesObj.toString());
         String apiImportId = apidto.getId();
@@ -348,7 +348,7 @@ public class PrototypedAPITestcase extends APIMIntegrationBaseTest {
         super.cleanUp();
     }
 
-    private File geTempFileWithContent(String swagger) throws Exception {
+    private File getTempFileWithContent(String swagger) throws Exception {
 
         File temp = File.createTempFile("swagger", ".json");
         temp.deleteOnExit();

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/oas/v2/prototype/additionalProperties.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/oas/v2/prototype/additionalProperties.json
@@ -1,0 +1,60 @@
+{
+  "id": "71889e16-773e-471b-bc53-251569efff64",
+  "name": "SwaggerPetstore_v2_import",
+  "description": null,
+  "context": "/SwaggerPetstorev2import",
+  "version": "1.0.0",
+  "provider": "admin",
+  "lifeCycleStatus": "PUBLISHED",
+  "wsdlInfo": null,
+  "responseCachingEnabled": false,
+  "cacheTimeout": 300,
+  "hasThumbnail": null,
+  "isDefaultVersion": false,
+  "enableSchemaValidation": false,
+  "type": "HTTP",
+  "transport": ["http", "https"],
+  "tags": [],
+  "policies": ["Unlimited"],
+  "apiThrottlingPolicy": "Unlimited",
+  "authorizationHeader": null,
+  "securityScheme": ["oauth2", "oauth_basic_auth_mandatory"],
+  "maxTps": null,
+  "visibility": "PUBLIC",
+  "visibleRoles": [],
+  "visibleTenants": [],
+  "mediationPolicies": [],
+  "subscriptionAvailability": "ALL_TENANTS",
+  "subscriptionAvailableTenants": [],
+  "additionalProperties": [],
+  "monetization": null,
+  "accessControl": "NONE",
+  "accessControlRoles": [],
+  "businessInformation": {
+    "businessOwner": null,
+    "businessOwnerEmail": null,
+    "technicalOwner": null,
+    "technicalOwnerEmail": null
+  },
+  "corsConfiguration": {
+    "corsConfigurationEnabled": true,
+    "accessControlAllowOrigins": ["*"],
+    "accessControlAllowCredentials": false,
+    "accessControlAllowHeaders": ["authorization", "Access-Control-Allow-Origin", "Content-Type", "SOAPAction"],
+    "accessControlAllowMethods": ["GET", "PUT", "POST", "DELETE", "PATCH", "OPTIONS"]
+  },
+  "workflowStatus": null,
+  "endpointConfig": {
+    "endpoint_type": "http",
+    "sandbox_endpoints": {
+      "url": "https://localhost:9443/publisher-new/apis/create/openapi"
+    },
+    "production_endpoints": {
+      "url": "https://localhost:9443/publisher-new/apis/create/openapi"
+    }
+  },
+  "endpointImplementationType": "INLINE",
+  "scopes": [],
+  "operations": [],
+  "threatProtectionPolicies": null
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/oas/v2/prototype/oas_import.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/oas/v2/prototype/oas_import.json
@@ -1,0 +1,86 @@
+{
+  "swagger" : "2.0",
+  "info" : {
+    "version" : "1.0.0",
+    "title" : "SwaggerPetstore_v2"
+  },
+  "security" : [ {
+    "default" : [ ]
+  } ],
+  "paths" : {
+    "/pets" : {
+      "get" : {
+        "parameters" : [ ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        },
+        "security" : [ {
+          "default" : [ "SwaggerPetstore_imp_v2" ]
+        } ],
+        "x-auth-type" : "Application & Application User",
+        "x-throttling-tier" : null
+      }
+    },
+    "/pets/{petId}" : {
+      "get" : {
+        "parameters" : [ {
+          "name" : "petId",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        },
+        "security" : [ {
+          "default" : [ ]
+        } ],
+        "x-auth-type" : "Application & Application User",
+        "x-throttling-tier" : null
+      }
+    },
+    "/oldpets" : {
+      "delete" : {
+        "parameters" : [ ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        },
+        "security" : [ {
+          "default" : [ "SwaggerPetstore_imp_v2" ]
+        } ],
+        "x-auth-type" : "Application & Application User",
+        "x-throttling-tier" : null
+      }
+    }
+  },
+  "securityDefinitions" : {
+    "default" : {
+      "type" : "oauth2",
+      "authorizationUrl" : "https://test.com",
+      "flow" : "implicit",
+      "scopes" : {
+        "SwaggerPetstore_imp_v2" : "SwaggerPetstore_imp_v2"
+      },
+      "x-scopes-bindings" : {
+        "SwaggerPetstore_imp_v2" : "admin"
+      }
+    }
+  },
+  "x-throttling-tier" : "Unlimited",
+  "x-wso2-cors" : {
+    "corsConfigurationEnabled" : true,
+    "accessControlAllowOrigins" : [ "*" ],
+    "accessControlAllowCredentials" : false,
+    "accessControlAllowHeaders" : [ "authorization", "Access-Control-Allow-Origin", "Content-Type", "SOAPAction" ],
+    "accessControlAllowMethods" : [ "GET", "PUT", "POST", "DELETE", "PATCH", "OPTIONS" ]
+  },
+  "x-wso2-production-endpoints" : "https://localhost:9443/publisher-new/apis/create/openapi",
+  "x-wso2-sandbox-endpoints" : "https://localhost:9443/publisher-new/apis/create/openapi",
+  "x-wso2-basePath" : "/SwaggerPetstorev2/1.0.0"
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/oas/v3/prototype/additionalProperties.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/oas/v3/prototype/additionalProperties.json
@@ -1,0 +1,60 @@
+{
+  "id": "71889e16-773e-471b-bc53-251569efff64",
+  "name": "SwaggerPetstore_v3_import",
+  "description": null,
+  "context": "/SwaggerPetstorev3import",
+  "version": "1.0.0",
+  "provider": "admin",
+  "lifeCycleStatus": "PUBLISHED",
+  "wsdlInfo": null,
+  "responseCachingEnabled": false,
+  "cacheTimeout": 300,
+  "hasThumbnail": null,
+  "isDefaultVersion": false,
+  "enableSchemaValidation": false,
+  "type": "HTTP",
+  "transport": ["http", "https"],
+  "tags": [],
+  "policies": ["Unlimited"],
+  "apiThrottlingPolicy": "Unlimited",
+  "authorizationHeader": null,
+  "securityScheme": ["oauth2", "oauth_basic_auth_mandatory"],
+  "maxTps": null,
+  "visibility": "PUBLIC",
+  "visibleRoles": [],
+  "visibleTenants": [],
+  "mediationPolicies": [],
+  "subscriptionAvailability": "ALL_TENANTS",
+  "subscriptionAvailableTenants": [],
+  "additionalProperties": [],
+  "monetization": null,
+  "accessControl": "NONE",
+  "accessControlRoles": [],
+  "businessInformation": {
+    "businessOwner": null,
+    "businessOwnerEmail": null,
+    "technicalOwner": null,
+    "technicalOwnerEmail": null
+  },
+  "corsConfiguration": {
+    "corsConfigurationEnabled": true,
+    "accessControlAllowOrigins": ["*"],
+    "accessControlAllowCredentials": false,
+    "accessControlAllowHeaders": ["authorization", "Access-Control-Allow-Origin", "Content-Type", "SOAPAction"],
+    "accessControlAllowMethods": ["GET", "PUT", "POST", "DELETE", "PATCH", "OPTIONS"]
+  },
+  "workflowStatus": null,
+  "endpointConfig": {
+    "endpoint_type": "http",
+    "sandbox_endpoints": {
+      "url": "https://localhost:9443/publisher-new/apis/create/openapi"
+    },
+    "production_endpoints": {
+      "url": "https://localhost:9443/publisher-new/apis/create/openapi"
+    }
+  },
+  "endpointImplementationType": "INLINE",
+  "scopes": [],
+  "operations": [],
+  "threatProtectionPolicies": null
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/oas/v3/prototype/oas_import.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/oas/v3/prototype/oas_import.json
@@ -1,0 +1,96 @@
+{
+  "openapi" : "3.0.1",
+  "info" : {
+    "title" : "SwaggerPetstore_v3",
+    "version" : "1.0.0"
+  },
+  "servers" : [ {
+    "url" : "/"
+  } ],
+  "security" : [ {
+    "default" : [ ]
+  } ],
+  "paths" : {
+    "/pets" : {
+      "get" : {
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        },
+        "security" : [ {
+          "default" : [ "SwaggerPetstore_imp_v3" ]
+        } ],
+        "x-auth-type" : "Application & Application User",
+        "x-throttling-tier" : null
+      }
+    },
+    "/pets/{petId}" : {
+      "get" : {
+        "parameters" : [ {
+          "name" : "petId",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        },
+        "security" : [ {
+          "default" : [ ]
+        } ],
+        "x-auth-type" : "Application & Application User",
+        "x-throttling-tier" : null
+      }
+    },
+    "/oldpets" : {
+      "delete" : {
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        },
+        "security" : [ {
+          "default" : [ "SwaggerPetstore_imp_v3" ]
+        } ],
+        "x-auth-type" : "Application & Application User",
+        "x-throttling-tier" : null
+      }
+    }
+  },
+  "components" : {
+    "securitySchemes" : {
+      "default" : {
+        "type" : "oauth2",
+        "flows" : {
+          "implicit" : {
+            "authorizationUrl" : "https://test.com",
+            "scopes" : {
+              "SwaggerPetstore_imp_v3" : "SwaggerPetstore_imp_v3"
+            },
+            "x-scopes-bindings" : {
+              "SwaggerPetstore_imp_v3" : "admin"
+            }
+          }
+        }
+      }
+    }
+  },
+  "x-throttling-tier" : "Unlimited",
+  "x-wso2-cors" : {
+    "corsConfigurationEnabled" : true,
+    "accessControlAllowOrigins" : [ "*" ],
+    "accessControlAllowCredentials" : false,
+    "accessControlAllowHeaders" : [ "authorization", "Access-Control-Allow-Origin", "Content-Type", "SOAPAction" ],
+    "accessControlAllowMethods" : [ "GET", "PUT", "POST", "DELETE", "PATCH", "OPTIONS" ]
+  },
+  "x-wso2-production-endpoints" : "https://localhost:9443/publisher-new/apis/create/openapi",
+  "x-wso2-sandbox-endpoints" : "https://localhost:9443/publisher-new/apis/create/openapi",
+  "x-wso2-basePath" : "/SwaggerPetstorev3/1.0.0"
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/oas/v3/prototype/updatedMockOas.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/oas/v3/prototype/updatedMockOas.json
@@ -1,0 +1,104 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "SwaggerPetstore_v3",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "/"
+    }
+  ],
+  "security": [
+    {
+      "default": []
+    }
+  ],
+  "paths": {
+    "/pets": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "default": [
+              "SwaggerPetstore_imp_v3"
+            ]
+          }
+        ],
+        "x-auth-type": "Application & Application User",
+        "x-throttling-tier": null,
+        "x-mediation-script": "var accept = mc.getProperty('AcceptHeader');\nvar responseCode = mc.getProperty('query.param.responseCode');\nvar responseCodeSC;\nvar responses = [];\nif (!responses[200]) {\n  responses[200] = [];\n}\nresponses[200][\"application/json\"] = \"\";\nresponses[200][\"application/xml\"] = \"\";\n\n\nresponses[501] = [];\nresponses[501][\"application/json\"] = {\n\"code\" : 501,\n\"description\" : \"Not Implemented\"}\nresponses[501][\"application/xml\"] = <response><code>501</code><description>Not Implemented</description></response>;\n\nif (responseCode == null) {\n responseCode = 200;\n}\n\nif (!responses[responseCode]) {\n  if (responses[\"default\"]) {\n    responseCode = \"default\"\n  } else {\n    responseCode = 501;\n  }\n}\nif (responseCode === \"default\") {\n  responseCodeSC = mc.getProperty('query.param.responseCode');\n} else {\n  responseCodeSC = responseCode;\n}\nif (accept == null || !responses[responseCode][accept]) {\n accept = \"application/json\";\n}\n\nif (accept == \"application/json\") {\n mc.setProperty('CONTENT_TYPE', 'application/json');\n mc.setProperty('HTTP_SC', responseCodeSC + \"\");\n mc.setPayloadJSON(responses[responseCode][\"application/json\"]);\n} else if (accept == \"application/xml\") {\n mc.setProperty('CONTENT_TYPE', 'application/xml');\n mc.setProperty('HTTP_SC', responseCodeSC + \"\");\n mc.setPayloadXML(responses[responseCode][\"application/xml\"]);\n}"
+      }
+    },
+    "/pets/{petId}": {
+      "get": {
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "style": "simple",
+            "explode": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "default": []
+          }
+        ],
+        "x-auth-type": "Application & Application User",
+        "x-throttling-tier": null,
+        "x-mediation-script": "var accept = mc.getProperty('AcceptHeader');\nvar responseCode = mc.getProperty('query.param.responseCode');\nvar responseCodeSC;\nvar responses = [];\nif (!responses[200]) {\n  responses[200] = [];\n}\nresponses[200][\"application/json\"] = \"\";\nresponses[200][\"application/xml\"] = \"\";\n\n\nresponses[501] = [];\nresponses[501][\"application/json\"] = {\n\"code\" : 501,\n\"description\" : \"Not Implemented\"}\nresponses[501][\"application/xml\"] = <response><code>501</code><description>Not Implemented</description></response>;\n\nif (responseCode == null) {\n responseCode = 200;\n}\n\nif (!responses[responseCode]) {\n  if (responses[\"default\"]) {\n    responseCode = \"default\"\n  } else {\n    responseCode = 501;\n  }\n}\nif (responseCode === \"default\") {\n  responseCodeSC = mc.getProperty('query.param.responseCode');\n} else {\n  responseCodeSC = responseCode;\n}\nif (accept == null || !responses[responseCode][accept]) {\n accept = \"application/json\";\n}\n\nif (accept == \"application/json\") {\n mc.setProperty('CONTENT_TYPE', 'application/json');\n mc.setProperty('HTTP_SC', responseCodeSC + \" Nirons mock Start \");\n mc.setPayloadJSON(responses[responseCode][\"application/json\"]);\n} else if (accept == \"application/xml\") {\n mc.setProperty('CONTENT_TYPE', 'application/xml');\n mc.setProperty('HTTP_SC', responseCodeSC + \"\");\n mc.setPayloadXML(responses[responseCode][\"application/xml\"]);\n}"
+      }
+    },
+    "/oldpets": {
+      "delete": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "default": [
+              "SwaggerPetstore_imp_v3"
+            ]
+          }
+        ],
+        "x-auth-type": "Application & Application User",
+        "x-throttling-tier": null,
+        "x-mediation-script": "var accept = mc.getProperty('AcceptHeader');\nvar responseCode = mc.getProperty('query.param.responseCode');\nvar responseCodeSC;\nvar responses = [];\nif (!responses[200]) {\n  responses[200] = [];\n}\nresponses[200][\"application/json\"] = \"\";\nresponses[200][\"application/xml\"] = \"\";\n\n\nresponses[501] = [];\nresponses[501][\"application/json\"] = {\n\"code\" : 501,\n\"description\" : \"Not Implemented\"}\nresponses[501][\"application/xml\"] = <response><code>501</code><description>Not Implemented</description></response>;\n\nif (responseCode == null) {\n responseCode = 200;\n}\n\nif (!responses[responseCode]) {\n  if (responses[\"default\"]) {\n    responseCode = \"default\"\n  } else {\n    responseCode = 501;\n  }\n}\nif (responseCode === \"default\") {\n  responseCodeSC = mc.getProperty('query.param.responseCode');\n} else {\n  responseCodeSC = responseCode;\n}\nif (accept == null || !responses[responseCode][accept]) {\n accept = \"application/json\";\n}\n\nif (accept == \"application/json\") {\n mc.setProperty('CONTENT_TYPE', 'application/json');\n mc.setProperty('HTTP_SC', responseCodeSC + \"\");\n mc.setPayloadJSON(responses[responseCode][\"application/json\"]);\n} else if (accept == \"application/xml\") {\n mc.setProperty('CONTENT_TYPE', 'application/xml');\n mc.setProperty('HTTP_SC', responseCodeSC + \"\");\n mc.setPayloadXML(responses[responseCode][\"application/xml\"]);\n}"
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "default": {
+        "type": "oauth2",
+        "flows": {
+          "implicit": {
+            "authorizationUrl": "https://test.com",
+            "scopes": {
+              "SwaggerPetstore_imp_v3": "SwaggerPetstore_imp_v3"
+            },
+            "x-scopes-bindings": {
+              "SwaggerPetstore_imp_v3": "admin"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -175,6 +175,7 @@
     <test name="apim-publisher-tests" preserve-order="true" parallel="false" group-by-instances="true">
 
         <classes>
+            <class name="org.wso2.am.integration.tests.prototype.PrototypedAPITestcase"/>
             <class name="org.wso2.am.integration.tests.prototype.APIM23VisibilityOfPrototypedAPIInStoreTestCase"/>
             <class name="org.wso2.am.integration.tests.prototype.APIM24VisibilityOfPrototypedAPIOfDifferentViewInStoreTestCase"/>
             <class name="org.wso2.am.integration.tests.publisher.APIM18CreateAnAPIThroughThePublisherRestAPITestCase"/>


### PR DESCRIPTION
**Following tests were added as a test coverage improvement related to Prototype endpoint APIs**

- Create an API with a prototype endpoint and invoke
- Create an API with a prototype endpoint, demote to created and invoke