### PR TITLE
Add parameters for axis2 blocking client in j2 template

### DIFF
--- a/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/axis2_blocking_client.xml.j2
+++ b/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/axis2_blocking_client.xml.j2
@@ -21,6 +21,10 @@
     <!-- ================================================= -->
     <!-- Parameters -->
     <!-- ================================================= -->
+    {% for parameter_key,parameter_value in axis2_blocking_client.parameters.items() %}
+    <parameter name="{{parameter_key}}">{{parameter_value}}</parameter>
+    {% endfor %}
+    
     <parameter name="hotdeployment">true</parameter>
     <parameter name="hotupdate">false</parameter>
     <parameter name="enableMTOM">false</parameter>


### PR DESCRIPTION
fix https://github.com/wso2/product-apim/issues/11332


```
    {% for parameter_key,parameter_value in axis2_blocking_client.parameters.items() %}
    <parameter name="{{parameter_key}}">{{parameter_value}}</parameter>
    {% endfor %}
```