### PR TITLE
Adding integration tests for the error messages from the backend when deleting an Advanced Throttling Policy that is already assigned to an API

### DIFF
--- a/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/impl/RestAPIPublisherImpl.java
+++ b/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/impl/RestAPIPublisherImpl.java
@@ -290,6 +290,9 @@ public class RestAPIPublisherImpl {
         body.setEndpointConfig(apiRequest.getEndpointConfig());
         body.setSecurityScheme(apiRequest.getSecurityScheme());
         body.setType(APIDTO.TypeEnum.fromValue(apiRequest.getType()));
+        if (StringUtils.isNotBlank(apiRequest.getApiTier())) {
+            body.setApiThrottlingPolicy(apiRequest.getApiTier());
+        }
         List<String> tierList = new ArrayList<>();
         tierList.add(Constants.TIERS_UNLIMITED);
         body.setPolicies(Arrays.asList(apiRequest.getTiersCollection().split(",")));
@@ -543,6 +546,9 @@ public class RestAPIPublisherImpl {
         body.setCorsConfiguration(new APICorsConfigurationDTO());
         body.setTags(Arrays.asList(apiRequest.getTags().split(",")));
         body.setEndpointConfig(apiRequest.getEndpointConfig());
+        if (StringUtils.isNotBlank(apiRequest.getApiTier())) {
+            body.setApiThrottlingPolicy(apiRequest.getApiTier());
+        }
         List<String> tierList = new ArrayList<>();
         tierList.add(Constants.TIERS_UNLIMITED);
         body.setPolicies(Arrays.asList(apiRequest.getTiersCollection().split(",")));

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/restapi/admin/throttlingpolicy/AdvancedThrottlingPolicyTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/restapi/admin/throttlingpolicy/AdvancedThrottlingPolicyTestCase.java
@@ -218,8 +218,8 @@ public class AdvancedThrottlingPolicyTestCase extends APIMIntegrationBaseTest {
                     "Advanced throttling policy " + requestCountPolicyDTO.getPolicyName() + ": " + requestCountPolicyDTO
                             .getPolicyId() + " deleted even it is already assigned to an API.");
             Assert.assertTrue(e.getResponseBody().contains(
-                    "Policy " + requestCountPolicyDTO.getPolicyName() + ": " + requestCountPolicyDTO.getPolicyId()
-                            + " already attached to API/Resource"));
+                    "Cannot delete the advanced policy with the name " + requestCountPolicyDTO.getPolicyName()
+                            + " because it is already assigned to an API/Resource"));
         } finally {
             if (apiID != null) {
                 restAPIPublisher.deleteAPI(apiID);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/restapi/admin/throttlingpolicy/AdvancedThrottlingPolicyTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/restapi/admin/throttlingpolicy/AdvancedThrottlingPolicyTestCase.java
@@ -39,8 +39,11 @@ import org.wso2.am.integration.clients.admin.api.dto.ThrottleLimitDTO;
 import org.wso2.am.integration.test.helpers.AdminApiTestHelper;
 import org.wso2.am.integration.test.impl.DtoFactory;
 import org.wso2.am.integration.test.utils.base.APIMIntegrationBaseTest;
+import org.wso2.am.integration.test.utils.bean.APIRequest;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.carbon.automation.test.utils.http.client.HttpResponse;
 
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -196,8 +199,36 @@ public class AdvancedThrottlingPolicyTestCase extends APIMIntegrationBaseTest {
         adminApiTestHelper.verifyAdvancedThrottlePolicyDTO(requestCountPolicyDTO, updatedPolicyDTO);
     }
 
-    @Test(groups = {"wso2.am"}, description = "Test delete advanced throttling policy",
+    @Test(groups = {"wso2.am"}, description = "Test delete already assigned advanced throttling policy",
             dependsOnMethods = "testGetAndUpdatePolicy")
+    public void testDeletePolicyAlreadyExisting() throws Exception {
+        APIRequest apiRequest = new APIRequest("AdvancedThrottlingPolicyTest", "AdvancedThrottlingPolicy",
+                new URL(backEndServerUrl.getWebAppURLHttp() + "jaxrs_basic/services/customers/customerservice/"));
+        apiRequest.setProvider(user.getUserName());
+        apiRequest.setVersion("1.0.0");
+        HttpResponse addResponse = restAPIPublisher.addAPI(apiRequest);
+        String apiID = addResponse.getData();
+
+        apiRequest.setApiTier(requestCountPolicyDTO.getPolicyName());
+        restAPIPublisher.updateAPI(apiRequest, apiID);
+        try {
+            restAPIAdmin.deleteAdvancedThrottlingPolicy(requestCountPolicyDTO.getPolicyId());
+        } catch (ApiException e) {
+            Assert.assertEquals(e.getCode(), HttpStatus.SC_FORBIDDEN,
+                    "Advanced throttling policy " + requestCountPolicyDTO.getPolicyName() + ": " + requestCountPolicyDTO
+                            .getPolicyId() + " deleted even it is already assigned to an API.");
+            Assert.assertTrue(e.getResponseBody().contains(
+                    "Policy " + requestCountPolicyDTO.getPolicyName() + ": " + requestCountPolicyDTO.getPolicyId()
+                            + " already attached to API/Resource"));
+        } finally {
+            if (apiID != null) {
+                restAPIPublisher.deleteAPI(apiID);
+            }
+        }
+    }
+
+    @Test(groups = {"wso2.am"}, description = "Test delete advanced throttling policy",
+            dependsOnMethods = "testDeletePolicyAlreadyExisting")
     public void testDeletePolicy() throws Exception {
 
         ApiResponse<Void> apiResponse =


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim/issues/11401
Adding integration tests to [1].

## Goals
Adding integration tests to the fix done to improve the error messages from the backend when deleting an Advanced Throttling Policy that is already assigned to an API.

## Approach
- Added a new integration test under the AdvancedThrottlingPolicyTestCase named **testDeletePolicyAlreadyExisting**.

## Related PRs
[1] https://github.com/wso2/carbon-apimgt/pull/10659

## Test environment
- JDK 1.8.0_251
- OS: Ubuntu 20.04.2 LTS