### PR TITLE
Improving advanced throttling policy test to have a policy name with an underscore

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/restapi/admin/throttlingpolicy/AdvancedThrottlingPolicyTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/restapi/admin/throttlingpolicy/AdvancedThrottlingPolicyTestCase.java
@@ -109,7 +109,7 @@ public class AdvancedThrottlingPolicyTestCase extends APIMIntegrationBaseTest {
     public void testAddPolicyWithBandwidthLimit() throws Exception {
 
         //Create the advanced throttling policy DTO with bandwidth limit
-        String policyName = "TestPolicyTwo";
+        String policyName = "TestPolicyTwo_WithUnderscore";
         Long dataAmount = 2L;
         String dataUnit = "KB";
         List<ConditionalGroupDTO> conditionalGroups = new ArrayList<>();


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim/issues/11410

## Goals
Add a test to validate whether an advanced throttling policy name can contain an underscore.

## Approach
Edit an existing test to have an advanced throttling policy name with an underscore.

## Related PRs
- https://github.com/wso2/carbon-apimgt/pull/10667