### PR TITLE
Fix malformed endpoint url used in NewVersionUpdateTestCase

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/NewVersionUpdateTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/NewVersionUpdateTestCase.java
@@ -63,8 +63,7 @@ public class NewVersionUpdateTestCase extends APIMIntegrationBaseTest {
     public void setEnvironment() throws Exception {
         super.init(userMode);
         endpointUrl = backEndServerUrl.getWebAppURLHttp() + "am/sample/calculator/v1/api/add";
-        endpointUrlNew =
-                backEndServerUrl.getWebAppURLHttp() + "https://localhost:9443/am/sample/calculator/v1/api/multiply";
+        endpointUrlNew = backEndServerUrl.getWebAppURLHttp() + "am/sample/calculator/v1/api/multiply";
 
     }
 


### PR DESCRIPTION
With the related PR linked below which adds endpoint url validation to carbon-apimgt, this invalid url was identified. This PR fixes the invalid endpoint url used within the NewVersionUpdateTestCase.

Related PR:
[#carbon-apimgt/pull/10715](https://github.com/wso2/carbon-apimgt/pull/10715)