### PR TITLE
Add Test Case to Verify Generation of all Supported SDKs

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -544,7 +544,7 @@ java-property-utils_1.9.0.wso2v1.jar                                            
 org.wso2.carbon.user.core_4.6.2.jar                                                                 bundle         apache2
 org.wso2.carbon.apimgt.keymgt.stub_9.0.178.jar                                                      bundle         apache2
 io.netty.transport_4.1.63.Final.jar                                                                 bundle         apache2
-openapi-generator_4.3.1.wso2v2.jar                                                                  bundle         apache2
+openapi-generator_4.3.1.wso2v3.jar                                                                  bundle         apache2
 commons-io-2.4.jar                                                                                  jarinbundle    apache2
 slf4j-ext-1.7.12.jar                                                                                jarinbundle    mit
 org.wso2.carbon.event.output.adapter.cassandra_5.2.34.jar                                           bundle         apache2

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/header/CORSAccessControlAllowCredentialsHeaderTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/header/CORSAccessControlAllowCredentialsHeaderTestCase.java
@@ -31,6 +31,7 @@ import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
 import org.wso2.am.integration.clients.publisher.api.ApiException;
 import org.wso2.am.integration.clients.publisher.api.v1.dto.APIOperationsDTO;
+import org.wso2.am.integration.clients.store.api.ApiResponse;
 import org.wso2.am.integration.clients.store.api.v1.dto.ApplicationDTO;
 import org.wso2.am.integration.clients.store.api.v1.dto.ApplicationKeyDTO;
 import org.wso2.am.integration.clients.store.api.v1.dto.ApplicationKeyGenerateRequestDTO;
@@ -50,8 +51,10 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.ws.rs.core.Response;
 import javax.xml.xpath.XPathExpressionException;
 
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
@@ -170,6 +173,20 @@ public class CORSAccessControlAllowCredentialsHeaderTestCase extends APIManagerL
         return accessToken;
     }
 
+    @Test(groups = {"wso2.am"}, description = "Test generation of all supported SDKs", dependsOnMethods = {
+            "CheckAccessControlAllowCredentialsHeadersWithSpecificOrigin"})
+    public void testAllSupportedSDKGeneration() throws Exception {
+
+        String languages[] = new String[]{
+                "android", "java", "csharp", "dart", "flash", "groovy", "javascript", "jmeter", "perl", "php", "python",
+                "ruby", "swift5", "clojure"};
+        for (String language : languages) {
+            ApiResponse<byte[]> sdkGenerationResponse = restAPIStore.generateSDKUpdated(apiId, language,
+                    user.getUserDomain());
+            assertEquals(sdkGenerationResponse.getStatusCode(), Response.Status.OK.getStatusCode(),
+                    "Error when generating SDK for " + language + " language");
+        }
+    }
 
     @AfterClass(alwaysRun = true)
     public void destroy() throws Exception {

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/corsACACTest/deployment.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/corsACACTest/deployment.toml
@@ -52,6 +52,9 @@ allow_methods = ["GET", "PUT", "POST", "DELETE", "PATCH", "OPTIONS"]
 allow_headers = ["authorization","Access-Control-Allow-Origin","Content-Type","SOAPAction","Authorization"]
 allow_credentials = true
 
+[apim.sdk]
+supported_languages = ["android", "java", "csharp", "dart", "flash", "groovy", "javascript", "jmeter", "perl", "php", "python", "ruby", "swift5", "clojure"]
+
 [transport]
 passthru_https.listener.ssl_profile_interval = 6000
 passthru_https.sender.ssl_profile.interval = 6000


### PR DESCRIPTION
## Purpose
Add Test Case to Verify Generation of all Supported SDKs

## Approach
- In order to verify the generation of all supported SDKs, the supported SDKs had to be added to the deployment.toml. So, this test case had to be added within a test case which was already having a deployment.toml change. Hence, this test case was added to CORSAccessControlAllowCredentialsHeaderTestCase.java which included a deployment.toml change.

- Verified the generation of all the supported SDKs by calling the relevant DevPortal REST API and checking whether the status code is '200 OK'.