### PR TITLE
Fix compilation failure

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/CrossTenantSubscriptionTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/CrossTenantSubscriptionTestCase.java
@@ -99,7 +99,7 @@ public class CrossTenantSubscriptionTestCase extends APIManagerLifecycleBaseTest
                 new RestAPIStoreImpl(
                         USER_MITCHEL,
                         "mitch123",
-                        "tenantb.com", storeURLHttps);
+                        "tenantb.com", storeURLHttps, restAPIGateway);
 
         // Adding API
         String apiContext = "crossSubAPI";


### PR DESCRIPTION
Fix compilation failure in CrossTenantSubscriptionTestCase due to 
```
Error:  /home/runner/work/carbon-apimgt/carbon-apimgt/product-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/CrossTenantSubscriptionTestCase.java:[99,17] no suitable constructor found for RestAPIStoreImpl(java.lang.String,java.lang.String,java.lang.String,java.lang.String)
    constructor org.wso2.am.integration.test.impl.RestAPIStoreImpl.RestAPIStoreImpl(java.lang.String,java.lang.String,java.lang.String,java.lang.String,org.wso2.am.integration.test.impl.RestAPIGatewayImpl) is not applicable
      (actual and formal argument lists differ in length)
    constructor org.wso2.am.integration.test.impl.RestAPIStoreImpl.RestAPIStoreImpl(java.lang.String,java.lang.String) is not applicable
      (actual and formal argument lists differ in length)
```