### PR TITLE
Fix endpoint URLs used within tests 

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/header/CORSHeadersTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/header/CORSHeadersTestCase.java
@@ -280,7 +280,7 @@ public class CORSHeadersTestCase extends APIManagerLifecycleBaseTest {
                 + File.separator + "CORSApi.yaml";
         File definition = new File(swaggerPath);
         JSONObject endpoints = new JSONObject();
-        endpoints.put("url", "test");
+        endpoints.put("url", "https://test.com");
 
         JSONObject endpointConfig = new JSONObject();
         endpointConfig.put("endpoint_type", "http");

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/publisher/APIM18CreateAnAPIThroughThePublisherRestAPITestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/publisher/APIM18CreateAnAPIThroughThePublisherRestAPITestCase.java
@@ -195,7 +195,7 @@ public class APIM18CreateAnAPIThroughThePublisherRestAPITestCase extends APIMInt
                 "swagger-archive.zip";
         File definition = new File(swaggerPath);
         JSONObject endpoints = new JSONObject();
-        endpoints.put("url", "test");
+        endpoints.put("url", "https://test.com");
 
         JSONObject endpointConfig = new JSONObject();
         endpointConfig.put("endpoint_type", "http");
@@ -230,7 +230,7 @@ public class APIM18CreateAnAPIThroughThePublisherRestAPITestCase extends APIMInt
                 "incorrect-swagger-archive.zip";
         File definition = new File(swaggerPath);
         JSONObject endpoints = new JSONObject();
-        endpoints.put("url", "test");
+        endpoints.put("url", "https://test.com");
 
         JSONObject endpointConfig = new JSONObject();
         endpointConfig.put("endpoint_type", "http");


### PR DESCRIPTION
## Purpose
This PR ensures that all endpoint URLs used within tests are valid. This fix is added in order to support the fix introduced by [1].

Related PRs:

- [1] https://github.com/wso2/carbon-apimgt/pull/10773