### PR TITLE
Adding a test for multiple versioned APIs retrieval from Devportal

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/NewVersionUpdateTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/NewVersionUpdateTestCase.java
@@ -25,7 +25,9 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
 import org.wso2.am.integration.clients.publisher.api.v1.dto.APIDTO;
+import org.wso2.am.integration.clients.store.api.v1.dto.APIListDTO;
 import org.wso2.am.integration.test.utils.base.APIMIntegrationBaseTest;
+import org.wso2.am.integration.test.utils.base.APIMIntegrationConstants;
 import org.wso2.am.integration.test.utils.bean.APILifeCycleAction;
 import org.wso2.am.integration.test.utils.bean.APIRequest;
 import org.wso2.carbon.automation.engine.annotations.ExecutionEnvironment;
@@ -116,6 +118,21 @@ public class NewVersionUpdateTestCase extends APIMIntegrationBaseTest {
         APIDTO apidto = g.fromJson(apiResponse.getData(), APIDTO.class);
         String endPointConfig = apidto.getEndpointConfig().toString();
         assertTrue(endPointConfig.contains(endpointUrlNew));
+    }
+
+    @Test(groups = { "wso2.am" },
+            description = "Check the count of the APIs when display multiple versioned APIs option is disabled in "
+                    + "devportal", dependsOnMethods = "testNewVersionAPIUpdate")
+    public void testCheckMultipleVersionedAPIsCount()
+            throws Exception {
+        // Publish the versioned API
+        restAPIPublisher.changeAPILifeCycleStatus(apiId2, APILifeCycleAction.PUBLISH.getAction());
+
+        waitForAPIDeployment();
+
+        APIListDTO restAPIStoreAllAPIs = restAPIStore.getAllAPIs(user.getUserDomain());
+        assertEquals(restAPIStoreAllAPIs.getCount().toString(), String.valueOf(1), "Wrong API count returned");
+        assertEquals(restAPIStoreAllAPIs.getList().get(0).getVersion(), APIVersionNew, "Wrong API list returned");
     }
 
     @AfterClass(alwaysRun = true)

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/NewVersionUpdateTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/NewVersionUpdateTestCase.java
@@ -27,7 +27,6 @@ import org.testng.annotations.Test;
 import org.wso2.am.integration.clients.publisher.api.v1.dto.APIDTO;
 import org.wso2.am.integration.clients.store.api.v1.dto.APIListDTO;
 import org.wso2.am.integration.test.utils.base.APIMIntegrationBaseTest;
-import org.wso2.am.integration.test.utils.base.APIMIntegrationConstants;
 import org.wso2.am.integration.test.utils.bean.APILifeCycleAction;
 import org.wso2.am.integration.test.utils.bean.APIRequest;
 import org.wso2.carbon.automation.engine.annotations.ExecutionEnvironment;


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim/issues/11627

## Goals
When displaying the multiple version of APIs feature in the dev portal is disabled, we need to display the search count based on the default version of the API. A test was added for this scenario.

## Related PRs
- https://github.com/wso2/carbon-apimgt/pull/10786

## Test environment
- JDK 1.8.0_251
- Ubuntu 20.04.2 LTS
