### PR TITLE
Add integration test for app display name in auth code grant consent page

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         include:
           - id: 1
-            segment: apim-integration-tests-api-common, apim-integration-tests-api-change-endpoint, apim-integration-tests-api-product, apim-integration-tests-api-lifecycle, apim-integration-tests-api-lifecycle-2, apim-email-secondary-userstore-tests, apim-CORS-tests, apim-integration-tests-samples, apim-publisher-tests, apim-store-tests, apim-integration-tests-graphql, admin-rest-api-tests, rest-api-tests, apim-mediation-tests, apim-websocket-tests
+            segment: apim-integration-tests-api-common, apim-integration-tests-api-change-endpoint, apim-integration-tests-api-product, apim-integration-tests-api-lifecycle, apim-integration-tests-api-lifecycle-2, apim-email-secondary-userstore-tests, apim-CORS-tests, apim-integration-tests-samples, apim-publisher-tests, apim-store-tests, apim-grant-type-token-tests, apim-integration-tests-graphql, admin-rest-api-tests, rest-api-tests, apim-mediation-tests, apim-websocket-tests
           - id: 2
             segment: apim-integration-tests-without-restarts, apim-integration-tests-without-advance-throttling, apim-integration-tests-application-sharing, apim-JWT-integration-tests, apim-urlsafe-JWT-integration-tests, apim-integration-tests-endpoint-security, apim-integration-tests-external-idp, apim-integration-emailusername-login, apim-integration-tests-workflow, apim-streaming-api-tests
       fail-fast: false

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/application/GrantTypeTokenGenerateTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/application/GrantTypeTokenGenerateTestCase.java
@@ -107,13 +107,12 @@ public class GrantTypeTokenGenerateTestCase extends APIManagerLifecycleBaseTest 
 
         //Apply application consent page related config
         superTenantKeyManagerContext = new AutomationContext(APIMIntegrationConstants.AM_PRODUCT_GROUP_NAME,
-                APIMIntegrationConstants.AM_KEY_MANAGER_INSTANCE,
-                TestUserMode.SUPER_TENANT_ADMIN);
+                APIMIntegrationConstants.AM_KEY_MANAGER_INSTANCE, TestUserMode.SUPER_TENANT_ADMIN);
         serverConfigurationManager = new ServerConfigurationManager(superTenantKeyManagerContext);
 
-        serverConfigurationManager.applyConfiguration(new File(getAMResourceLocation()
-                + File.separator + "configFiles" + File.separator + "applicationConsentPage" +
-                File.separator + "deployment.toml"));
+        serverConfigurationManager.applyConfiguration(new File(
+                getAMResourceLocation() + File.separator + "configFiles" + File.separator + "applicationConsentPage"
+                        + File.separator + "deployment.toml"));
 
         //create Application
         HttpResponse applicationResponse = restAPIStore.createApplication(APP_NAME,
@@ -360,9 +359,8 @@ public class GrantTypeTokenGenerateTestCase extends APIManagerLifecycleBaseTest 
         //Sending first request to approve grant authorization to app
         headers.clear();
         headers.put("Content-Type", APPLICATION_CONTENT_TYPE);
-        String url =
-                identityLoginURL + "?response_type=code&" + "client_id=" + consumerKey + "&scope=PRODUCTION&redirect_uri="
-                        + CALLBACK_URL;
+        String url = identityLoginURL + "?response_type=code&" + "client_id=" + consumerKey
+                + "&scope=PRODUCTION&redirect_uri=" + CALLBACK_URL;
         HttpResponse res = HTTPSClientUtils.doGet(url, headers);
         String sessionNonceCookie = res.getHeaders().get(SET_COOKIE_HEADER);
         String sessionDataKey = getURLParameter(res.getHeaders().get(LOCATION_HEADER), "sessionDataKey");

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/applicationConsentPage/deployment.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/applicationConsentPage/deployment.toml
@@ -1,0 +1,79 @@
+[server]
+#hostname = "localhost"
+#offset=0
+base_path = "${carbon.protocol}://${carbon.host}:${carbon.management.port}"
+server_role = "default"
+
+[super_admin]
+username = "admin"
+password = "admin"
+create_admin_account = true
+
+[user_store]
+type = "database_unique_id"
+
+[database.apim_db]
+driver = "$env{API_MANAGER_DATABASE_DRIVER}"
+url = "$env{API_MANAGER_DATABASE_URL}"
+username = "$env{API_MANAGER_DATABASE_USERNAME}"
+password = "$env{API_MANAGER_DATABASE_PASSWORD}"
+validationQuery = "$env{API_MANAGER_DATABASE_VALIDATION_QUERY}"
+
+[database.shared_db]
+driver = "$env{SHARED_DATABASE_DRIVER}"
+url = "$env{SHARED_DATABASE_URL}"
+username = "$env{SHARED_DATABASE_USERNAME}"
+password = "$env{SHARED_DATABASE_PASSWORD}"
+validationQuery = "$env{SHARED_DATABASE_VALIDATION_QUERY}"
+
+[keystore.tls]
+file_name =  "wso2carbon.jks"
+type =  "JKS"
+password =  "wso2carbon"
+alias =  "wso2carbon"
+key_password =  "wso2carbon"
+
+[[apim.gateway.environment]]
+name = "Default"
+type = "hybrid"
+display_in_api_console = true
+description = "This is a hybrid gateway that handles both production and sandbox token traffic."
+show_as_token_endpoint_url = true
+service_url = "https://localhost:${mgt.transport.https.port}/services/"
+username = "admin"
+password = "admin"
+http_endpoint = "ws://wsserverhost:9797"
+https_endpoint = "https://serverhost:9898"
+
+[apim.cors]
+allow_origins = "*"
+allow_methods = ["GET","PUT","POST","DELETE","PATCH","OPTIONS"]
+allow_headers = ["authorization","Access-Control-Allow-Origin","Content-Type","SOAPAction"]
+allow_credentials = false
+
+[transport]
+passthru_https.listener.ssl_profile_interval = 6000
+
+[apim.certificate_reloader]
+period = "1m"
+
+[database.local]
+url = "jdbc:h2:./repository/database/WSO2CARBON_DB;DB_CLOSE_ON_EXIT=FALSE"
+
+[[event_listener]]
+id = "token_revocation"
+type = "org.wso2.carbon.identity.core.handler.AbstractIdentityHandler"
+name = "org.wso2.is.notification.ApimOauthEventInterceptor"
+order = 1
+[event_listener.properties]
+notification_endpoint = "https://localhost:${mgt.transport.https.port}/internal/data/v1/notify"
+username = "${admin.username}"
+password = "${admin.password}"
+'header.X-WSO2-KEY-MANAGER' = "default"
+
+[apim.sync_runtime_artifacts.gateway.skip_list]
+apis = ["admin--git2231head_v1.0.0.xml","admin--PizzaShackAPI_v1.0.0.xml","admin--ScriptMediatorAPI_v1.0.xml",
+"APIThrottleBackendAPI.xml","BackEndSecurity.xml","DigestAuth_API.xml","git2231.xml","HttpPATCHSupport_API.xml","JWKS-Backend.xml","JWTBackendAPI.xml","multiVSR_v1.0.0.xml","Response_API_1.xml","Response_API_2.xml","Response_Custom_API.xml","Response_Error_API.xml","Response_Loc_API.xml","SpecialCRN_v1.0.0.xml","status_code_204_API.xml","stockquote.xml","XML_API.xml","Version1.xml","Version2.xml"]
+
+[oauth]
+show_display_name_in_consent_page = true

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -224,7 +224,6 @@
             <class name="org.wso2.am.integration.tests.other.APIMANAGER5326CustomStatusMsgTestCase"/>
             <!--<class name="org.wso2.am.integration.tests.application.ApplicationCallbackURLTestCase"/-->
             <class name="org.wso2.am.integration.tests.admin.OAuthApplicationOwnerUpdateTestCase"/>
-            <class name="org.wso2.am.integration.tests.application.GrantTypeTokenGenerateTestCase"/>
             <class name="org.wso2.am.integration.tests.jwt.JWTGrantTestCase"/>
             <class name="org.wso2.am.integration.tests.api.sdk.SDKGenerationTestCase"/>
             <class name="org.wso2.am.integration.tests.application.CAPIMGT12CallBackURLOverwriteTestCase"/>
@@ -234,6 +233,12 @@
             <!--disable test case since it need to configure DAS -->
             <!--<class name="org.wso2.am.integration.tests.stats.APIMANAGER4731StoreStatisticsWhenTokenEncryptedTestCase"/>-->
             <!--<class name="org.wso2.am.integration.tests.other.APIMANAGER5327KeyGenerationWithPGSQLTestCase"/>-->
+        </classes>
+    </test>
+
+    <test name="apim-grant-type-token-tests" preserve-order="true" parallel="false" group-by-instances="true">
+        <classes>
+            <class name="org.wso2.am.integration.tests.application.GrantTypeTokenGenerateTestCase"/>
         </classes>
     </test>
 


### PR DESCRIPTION
## Purpose

- Resolves https://github.com/wso2/product-apim/issues/11620

This PR updates the `identity.xml.j2` template file with the support to show the application display name in consent page by adding in the following config.

`<ShowDisplayNameInConsentPage>{{oauth.show_display_name_in_consent_page}}</ShowDisplayNameInConsentPage>`

 Also, it adds an integration test to verify the fix. This integration test inspects the html content of the rendered consent page UI in order to verify that the consent page does display the application name when the below mentioned config is set to true from `deployment.toml`.

```
[oauth]
show_display_name_in_consent_page = true
```

In order to achieve this, a new test was added to `GrantTypeTokenGenerateTestCase`.

<img width="597" alt="Screenshot 2021-09-18 at 13 36 06" src="https://user-images.githubusercontent.com/30475839/134019628-fa5dfbc6-025a-4191-b32b-f1a0fae8e238.png">

## Related PRs

- https://github.com/wso2/carbon-apimgt/pull/10800
- https://github.com/wso2-extensions/apim-km-wso2is/pull/57
- https://github.com/wso2/carbon-identity-framework/pull/3740