### PR TITLE
Updating wso2-is-km version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1474,7 +1474,7 @@
 
         <!-- WSDL4J dependencies -->
         <wsdl4j.version>1.6.3.wso2v3</wsdl4j.version>
-        <wso2is.km.version>1.2.20</wso2is.km.version>
+        <wso2is.km.version>1.2.21</wso2is.km.version>
         <okta.keymanager.feature.version>3.0.6</okta.keymanager.feature.version>
         <keycloak.keymanager.feature.version>2.0.6</keycloak.keymanager.feature.version>
         <auth0.keymanager.feature.version>1.0.1</auth0.keymanager.feature.version>


### PR DESCRIPTION
### Purpose
This PR bumps the wso2is.km.version from `1.2.20` to `1.2.21`.
