### PR TITLE
Add integration tests for resource level security granularity for API key

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/APISecurityTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/APISecurityTestCase.java
@@ -374,6 +374,11 @@ public class APISecurityTestCase extends APIManagerLifecycleBaseTest {
 
         HttpResponse response8 = restAPIPublisher.addAPI(apiRequest8);
         apiId8 = response8.getData();
+
+        createAPIRevisionAndDeployUsingRest(apiId8, restAPIPublisher);
+        restAPIPublisher.changeAPILifeCycleStatusToPublish(apiId8, false);
+        waitForAPIDeploymentSync(apiRequest8.getProvider(), apiRequest8.getName(), apiRequest8.getVersion(),
+                APIMIntegrationConstants.IS_API_EXISTS);
     }
 
     @Test(description = "This test case tests the behaviour of internal Key token on Created API with authentication " +

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/APISecurityTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/APISecurityTestCase.java
@@ -469,7 +469,7 @@ public class APISecurityTestCase extends APIManagerLifecycleBaseTest {
     public void testInvocationWithoutResourceSecurity() throws Exception {
 
         // Validate for security disabled API
-        HttpResponse response = restAPIPublisher.getAPI(apiId7);
+        HttpResponse response = restAPIPublisher.getAPI(apiId8);
         String retrievedSwagger;
 
         APIDTO apidto = new Gson().fromJson(response.getData(), APIDTO.class);
@@ -480,7 +480,7 @@ public class APISecurityTestCase extends APIManagerLifecycleBaseTest {
         }
 
         // Verify the security of API in Swagger
-        retrievedSwagger = restAPIPublisher.getSwaggerByID(apiId7);
+        retrievedSwagger = restAPIPublisher.getSwaggerByID(apiId8);
         List<Object> authTypes = validateResourceSecurity(retrievedSwagger);
         for (Object authType : authTypes) {
             Assert.assertEquals(authType, "None", "Incorrect auth type");


### PR DESCRIPTION
## Purpose

-  Fixes : https://github.com/wso2/product-apim/issues/11612

## Goals

- Adding an integration test  for invoking resources with disabled security in API key enabled APIs

## Related PRs

- https://github.com/wso2/carbon-apimgt/pull/10850

## Test environment

- JDK 1.8.0_251
