### PR TITLE
Exclude duplicate json-smart jar

### DIFF
--- a/modules/distribution/product/src/main/assembly/bin.xml
+++ b/modules/distribution/product/src/main/assembly/bin.xml
@@ -97,6 +97,7 @@
                 <!--<exclude>**/repository/components/plugins/waffle_1.4.0.wso2v1.jar</exclude>-->
                 <!--<exclude>**/repository/components/plugins/compass_2.0.1.wso2v2.jar</exclude>-->
                 <!--<exclude>**/repository/components/plugins/poi_3.9.0.wso2v1.jar</exclude>-->
+                <exclude>**/repository/components/plugins/net.minidev.json-smart_2.3.0.jar</exclude>
 
                 <!-- Remove jars which are not needed-->
                 <exclude>**/repository/components/plugins/org.wso2.carbon.feature.mgt.stub_${carbon.kernel.version}.jar</exclude>


### PR DESCRIPTION
$subject.

Two json-smart jars are getting packed in APIM. (One from synapse and one from Identity components.). This will exclude one temporarily until Identity components are updated.