### PR TITLE
Add missing config to solve reCPATCH issues

### DIFF
--- a/modules/distribution/product/src/main/resources/conf/templates/repository/conf/tomcat/carbon/WEB-INF/web.xml.j2
+++ b/modules/distribution/product/src/main/resources/conf/templates/repository/conf/tomcat/carbon/WEB-INF/web.xml.j2
@@ -109,7 +109,20 @@
 </init-param>
 </filter>
 
-    <filter-mapping>
+<filter>
+    <filter-name>CaptchaFilter</filter-name>
+    <filter-class>org.wso2.carbon.identity.captcha.filter.CaptchaFilter</filter-class>
+</filter>
+<filter-mapping>
+    <filter-name>CaptchaFilter</filter-name>
+    <url-pattern>/samlsso</url-pattern>
+    <url-pattern>/oauth2</url-pattern>
+    <url-pattern>/commonauth</url-pattern>
+    <dispatcher>FORWARD</dispatcher>
+    <dispatcher>REQUEST</dispatcher>
+</filter-mapping>
+
+<filter-mapping>
  <filter-name>HttpHeaderSecurityFilter</filter-name>
  <url-pattern>*</url-pattern>
  </filter-mapping>


### PR DESCRIPTION
### Purpose
After enabling the reCAPTCHA, when we tried to log in to the publisher portal, it throws us a “Please select reCAPTCHA” error message on the Publisher login portal, but still, we can log in to the portal without the reCAPTCHA verification. This is happening due to some missing configs **/repository/conf/tomcat/carbon/WEB-INF/web.xml.** file. This PR will solve that issue.

https://drive.google.com/file/d/1aCx7HmV7wJ4ts3umXxIV3ens-_iH8Pxa/view?usp=sharing 

### Goal 

Adding the following missing config in **/repository/resources/conf/templates/repository/conf/tomcat/carbon/WEB-INF/web.xml.j2.** 
```
<filter>
        <filter-name>CaptchaFilter</filter-name>
        <filter-class>org.wso2.carbon.identity.captcha.filter.CaptchaFilter</filter-class>
 </filter>
    <filter-mapping>
        <filter-name>CaptchaFilter</filter-name>
        <url-pattern>/samlsso</url-pattern>
        <url-pattern>/oauth2</url-pattern>
        <url-pattern>/commonauth</url-pattern>
        <dispatcher>FORWARD</dispatcher>
        <dispatcher>REQUEST</dispatcher>
    </filter-mapping>
```
### Docs Impact
Docs need to be updated with something related to this[1]
[1]. https://github.com/wso2/docs-apim/pull/5075

