### PR TITLE
Remove Flash language support

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/header/CORSAccessControlAllowCredentialsHeaderTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/header/CORSAccessControlAllowCredentialsHeaderTestCase.java
@@ -183,7 +183,7 @@ public class CORSAccessControlAllowCredentialsHeaderTestCase extends APIManagerL
             ApiResponse<byte[]> sdkGenerationResponse = restAPIStore.generateSDKUpdated(apiId, language,
                     user.getUserDomain());
             assertEquals(sdkGenerationResponse.getStatusCode(), Response.Status.OK.getStatusCode(),
-                    "Error when generating SDK for " + language + " language");
+                    "Error when generating SDK for the " + language + " language");
         }
     }
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/header/CORSAccessControlAllowCredentialsHeaderTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/header/CORSAccessControlAllowCredentialsHeaderTestCase.java
@@ -61,7 +61,7 @@ import static org.testng.Assert.assertTrue;
 /**
  * Test CORS Access-Control-Allow-Credentials functionality
  */
-@SetEnvironment(executionEnvironments = {ExecutionEnvironment.STANDALONE })
+@SetEnvironment(executionEnvironments = {ExecutionEnvironment.STANDALONE})
 public class CORSAccessControlAllowCredentialsHeaderTestCase extends APIManagerLifecycleBaseTest {
 
     private static final String API_NAME_2 = "CorsACACHeadersTestAPI_2";
@@ -116,7 +116,7 @@ public class CORSAccessControlAllowCredentialsHeaderTestCase extends APIManagerL
         assertNotNull(header, ACCESS_CONTROL_ALLOW_ORIGIN_HEADER + " header is not available in the response.");
 
         assertNotNull(pickHeader(responseHeaders, ACCESS_CONTROL_ALLOW_CREDENTIALS_HEADER),
-                   ACCESS_CONTROL_ALLOW_CREDENTIALS_HEADER + " header is not available in the response.");
+                ACCESS_CONTROL_ALLOW_CREDENTIALS_HEADER + " header is not available in the response.");
     }
 
     private String createPublishAndSubscribeToApi(User user, String apiName, String apiContext, String apiVersion,
@@ -197,8 +197,8 @@ public class CORSAccessControlAllowCredentialsHeaderTestCase extends APIManagerL
 
     @DataProvider
     public static Object[][] userModeDataProvider() {
-        return new Object[][] { new Object[] { TestUserMode.SUPER_TENANT_ADMIN },
-                new Object[] { TestUserMode.TENANT_ADMIN },
+        return new Object[][]{new Object[]{TestUserMode.SUPER_TENANT_ADMIN},
+                new Object[]{TestUserMode.TENANT_ADMIN},
         };
     }
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/header/CORSAccessControlAllowCredentialsHeaderTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/header/CORSAccessControlAllowCredentialsHeaderTestCase.java
@@ -177,9 +177,8 @@ public class CORSAccessControlAllowCredentialsHeaderTestCase extends APIManagerL
             "CheckAccessControlAllowCredentialsHeadersWithSpecificOrigin"})
     public void testAllSupportedSDKGeneration() throws Exception {
 
-        String languages[] = new String[]{
-                "android", "java", "csharp", "dart", "flash", "groovy", "javascript", "jmeter", "perl", "php", "python",
-                "ruby", "swift5", "clojure"};
+        String languages[] = new String[]{"android", "java", "csharp", "dart", "groovy", "javascript", "jmeter", "perl",
+                "php", "python", "ruby", "swift5", "clojure"};
         for (String language : languages) {
             ApiResponse<byte[]> sdkGenerationResponse = restAPIStore.generateSDKUpdated(apiId, language,
                     user.getUserDomain());


### PR DESCRIPTION
- Related to https://github.com/wso2/orbit/pull/532
- Flash language support for SDK generation is deprecated in the open API generator v5.3.0