### PR TITLE
Add integration developer role to tenant.confs

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/common/tenant-conf.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/common/tenant-conf.json
@@ -354,6 +354,10 @@
     "DevOpsRole" : {
       "CreateOnTenantLoad" : true,
       "RoleName" : "Internal/devops"
+    },
+    "IntegrationDeveloperRole" : {
+      "CreateOnTenantLoad" : true,
+      "RoleName" : "Internal/integration_dev"
     }
   }
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/monetization/tenant-conf.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/monetization/tenant-conf.json
@@ -354,6 +354,10 @@
     "DevOpsRole" : {
       "CreateOnTenantLoad" : true,
       "RoleName" : "Internal/devops"
+    },
+    "IntegrationDeveloperRole" : {
+      "CreateOnTenantLoad" : true,
+      "RoleName" : "Internal/integration_dev"
     }
   }
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/notification/tenant-conf.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/notification/tenant-conf.json
@@ -354,6 +354,10 @@
     "DevOpsRole" : {
       "CreateOnTenantLoad" : true,
       "RoleName" : "Internal/devops"
+    },
+    "IntegrationDeveloperRole" : {
+      "CreateOnTenantLoad" : true,
+      "RoleName" : "Internal/integration_dev"
     }
   }
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/tenantConf/tenant-conf.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/tenantConf/tenant-conf.json
@@ -354,6 +354,10 @@
     "DevOpsRole" : {
       "CreateOnTenantLoad" : true,
       "RoleName" : "Internal/devops"
+    },
+    "IntegrationDeveloperRole" : {
+      "CreateOnTenantLoad" : true,
+      "RoleName" : "Internal/integration_dev"
     }
   }
 }


### PR DESCRIPTION
## Purpose
As $subject, this will add the IntegrationDeveloperRole to the tenant.confs


### Related PRs
- https://github.com/wso2/carbon-apimgt/pull/11010