### PR TITLE
Map APIM proxy configs to Choreo API proxy configs

### DIFF
--- a/modules/distribution/product/src/main/resources/conf/default.json
+++ b/modules/distribution/product/src/main/resources/conf/default.json
@@ -415,5 +415,19 @@
       "value": false
     }
   ],
-  "throttle_properties.'throttling.distributed.counter.type'": "hazelcast"
+  "throttle_properties.'throttling.distributed.counter.type'": "hazelcast",
+  "apim.proxy_config.enable": false,
+  "apim.proxy_config.host" : "",
+  "apim.proxy_config.port": "",
+  "apim.proxy_config.username": "",
+  "apim.proxy_config.password": "",
+  "apim.analytics.properties.proxy_config_enable": "$ref{apim.proxy_config.enable}",
+  "apim.analytics.properties.proxy_config_host": "$ref{apim.proxy_config.host}",
+  "apim.analytics.properties.proxy_config_port": "$ref{apim.proxy_config.port}",
+  "apim.analytics.properties.proxy_config_username": "$ref{apim.proxy_config.username}",
+  "apim.analytics.properties.proxy_config_password": "$ref{apim.proxy_config.password}",
+  "apim.analytics.properties.keystore_location": "${carbon.home}/repository/resources/security/$ref{keystore.primary.file_name}",
+  "apim.analytics.properties.keystore_password": "$ref{keystore.primary.password}",
+  "apim.analytics.properties.truststore_location": "${carbon.home}/repository/resources/security/$ref{truststore.file_name}",
+  "apim.analytics.properties.truststore_password": "$ref{truststore.password}"
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1481,7 +1481,7 @@
         <auth0.keymanager.feature.version>1.0.1</auth0.keymanager.feature.version>
         <pingfederate.keymanager.feature.version>1.0.3</pingfederate.keymanager.feature.version>
         <forgerock.keymanager.feature.version>1.0.2</forgerock.keymanager.feature.version>
-        <apim.analytics.publisher.version>1.0.5</apim.analytics.publisher.version>
+        <apim.analytics.publisher.version>1.0.6</apim.analytics.publisher.version>
         <disruptor.orbit.version>3.4.2.wso2v1</disruptor.orbit.version>
     </properties>
 


### PR DESCRIPTION
With this change, the APIM proxy configs will be applied for Analytics Choreo API as well.

Related PRs 
https://github.com/wso2/carbon-apimgt/pull/11077
https://github.com/wso2/apim-analytics-publisher/pull/72