### PR TITLE
Improve OAuth test to check consecutive requests

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/AddEndPointSecurityPerTypeTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/AddEndPointSecurityPerTypeTestCase.java
@@ -431,6 +431,12 @@ public class AddEndPointSecurityPerTypeTestCase extends APIManagerLifecycleBaseT
         Assert.assertTrue(authorization.contains("Bearer"));
         String backendToken = authorization.replaceFirst("Bearer ", "");
         validateIntrospectionResponse(user, backendToken, applicationKeyBeanProduction.getConsumerKey());
+
+        // checking 2nd request also works
+        HttpResponse productionResponse2 =
+                HTTPSClientUtils.doGet(getAPIInvocationURLHttp(apiContext, API_VERSION_1_0_0), requestHeadersGet);
+        Assert.assertEquals(productionResponse2.getResponseCode(), 200);
+
         String sandAppTokenJti = TokenUtils.getJtiOfJwtToken(sandboxApplication.getToken().getAccessToken());
         requestHeadersGet.put("Authorization", "Bearer " + sandAppTokenJti);
         HttpResponse sandboxResponse =

--- a/pom.xml
+++ b/pom.xml
@@ -1286,7 +1286,7 @@
         <project.scm.id>scm-server</project.scm.id>
         <carbon.analytics.common.version>5.2.37</carbon.analytics.common.version>
         <!-- APIM Portals Component Version -->
-        <carbon.apimgt.ui.version>9.0.246</carbon.apimgt.ui.version>
+        <carbon.apimgt.ui.version>9.0.249</carbon.apimgt.ui.version>
 
         <!-- APIM Component Version -->
         <carbon.apimgt.version>9.18.21</carbon.apimgt.version>


### PR DESCRIPTION
## Related PR

https://github.com/wso2/carbon-apimgt/pull/11072

## Issue
https://github.com/wso2/product-apim/issues/12425

## Issue reproduced
`NFO  [org.wso2.carbon.automation.extensions.servers.utils.ServerLogReader] - [2022-02-25 16:02:43,495]  INFO - DataBridge user admin connected
INFO  [org.wso2.carbon.automation.extensions.servers.utils.ServerLogReader] - [2022-02-25 16:02:43,569]  INFO - LogMediator {api:AddEndPointSecurityPerTypeTestCase4:v1.0.0} STATUS = Executing default 'fault' sequence, ERROR_CODE = 0, ERROR_MESSAGE = Error occured in the mediation of the class mediator
ERROR [org.wso2.carbon.automation.engine.testlisteners.TestManagerListener] - org.testng.Assert.fail(Assert.java:93)
ERROR [org.wso2.carbon.automation.engine.testlisteners.TestManagerListener] - org.testng.Assert.failNotEquals(Assert.java:512)
ERROR [org.wso2.carbon.automation.engine.testlisteners.TestManagerListener] - org.testng.Assert.assertEqualsImpl(Assert.java:134)
ERROR [org.wso2.carbon.automation.engine.testlisteners.TestManagerListener] - org.testng.Assert.assertEquals(Assert.java:115)
ERROR [org.wso2.carbon.automation.engine.testlisteners.TestManagerListener] - org.testng.Assert.assertEquals(Assert.java:388)
ERROR [org.wso2.carbon.automation.engine.testlisteners.TestManagerListener] - org.testng.Assert.assertEquals(Assert.java:398)
ERROR [org.wso2.carbon.automation.engine.testlisteners.TestManagerListener] - org.wso2.am.integration.tests.api.lifecycle.AddEndPointSecurityPerTypeTestCase.testAddEndpointSecurityForOauth(AddEndPointSecurityPerTypeTestCase.java:438)
ERROR [org.wso2.carbon.automation.engine.testlisteners.TestManagerListener] - sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
ERROR [org.wso2.carbon.automation.engine.testlisteners.TestManagerListener] - sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
ERROR [org.wso2.carbon.automation.engine.testlisteners.TestManagerListener] - sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
ERROR [org.wso2.carbon.automation.engine.testlisteners.TestManagerListener] - java.lang.reflect.Method.invoke(Method.java:498)
ERROR [org.wso2.carbon.automation.engine.testlisteners.TestManagerListener] - org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:108)
ERROR [org.wso2.carbon.automation.engine.testlisteners.TestManagerListener] - org.testng.internal.Invoker.invokeMethod(Invoker.java:661)
ERROR [org.wso2.carbon.automation.engine.testlisteners.TestManagerListener] - org.testng.internal.Invoker.invokeTestMethod(Invoker.java:869)
ERROR [org.wso2.carbon.automation.engine.testlisteners.TestManagerListener] - org.testng.internal.Invoker.invokeTestMethods(Invoker.java:1193)
ERROR [org.wso2.carbon.automation.engine.testlisteners.TestManagerListener] - org.testng.internal.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:126)
ERROR [org.wso2.carbon.automation.engine.testlisteners.TestManagerListener] - org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:109)
ERROR [org.wso2.carbon.automation.engine.testlisteners.TestManagerListener] - org.testng.TestRunner.privateRun(TestRunner.java:744)
ERROR [org.wso2.carbon.automation.engine.testlisteners.TestManagerListener] - org.testng.TestRunner.run(TestRunner.java:602)
ERROR [org.wso2.carbon.automation.engine.testlisteners.TestManagerListener] - org.testng.SuiteRunner.runTest(SuiteRunner.java:380)
ERROR [org.wso2.carbon.automation.engine.testlisteners.TestManagerListener] - org.testng.SuiteRunner.runSequentially(SuiteRunner.java:375)
ERROR [org.wso2.carbon.automation.engine.testlisteners.TestManagerListener] - org.testng.SuiteRunner.privateRun(SuiteRunner.java:340)
ERROR [org.wso2.carbon.automation.engine.testlisteners.TestManagerListener] - org.testng.SuiteRunner.run(SuiteRunner.java:289)
ERROR [org.wso2.carbon.automation.engine.testlisteners.TestManagerListener] - org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:52)
ERROR [org.wso2.carbon.automation.engine.testlisteners.TestManagerListener] - org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:86)
ERROR [org.wso2.carbon.automation.engine.testlisteners.TestManagerListener] - org.testng.TestNG.runSuitesSequentially(TestNG.java:1301)
ERROR [org.wso2.carbon.automation.engine.testlisteners.TestManagerListener] - org.testng.TestNG.runSuitesLocally(TestNG.java:1226)
ERROR [org.wso2.carbon.automation.engine.testlisteners.TestManagerListener] - org.testng.TestNG.runSuites(TestNG.java:1144)
ERROR [org.wso2.carbon.automation.engine.testlisteners.TestManagerListener] - org.testng.TestNG.run(TestNG.java:1115)
ERROR [org.wso2.carbon.automation.engine.testlisteners.TestManagerListener] - org.apache.maven.surefire.testng.TestNGExecutor.run(TestNGExecutor.java:284)
ERROR [org.wso2.carbon.automation.engine.testlisteners.TestManagerListener] - org.apache.maven.surefire.testng.TestNGXmlTestSuite.execute(TestNGXmlTestSuite.java:75)
ERROR [org.wso2.carbon.automation.engine.testlisteners.TestManagerListener] - org.apache.maven.surefire.testng.TestNGProvider.invoke(TestNGProvider.java:119)
ERROR [org.wso2.carbon.automation.engine.testlisteners.TestManagerListener] - org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:428)
ERROR [org.wso2.carbon.automation.engine.testlisteners.TestManagerListener] - org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
ERROR [org.wso2.carbon.automation.engine.testlisteners.TestManagerListener] - org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:562)
ERROR [org.wso2.carbon.automation.engine.testlisteners.TestManagerListener] - org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:548)
INFO  [org.wso2.carbon.automation.engine.testlisteners.TestManagerListener] - =================== On test failure org.wso2.am.integration.tests.api.lifecycle.AddEndPointSecurityPerTypeTestCase.testAddEndpointSecurityForOauth ===================`
