### PR TITLE
Add the OPA policy spec, definitions and policy fault handler

### DIFF
--- a/modules/distribution/product/src/main/conf/synapse-configs/default/sequences/_opa_policy_failure_handler_.xml
+++ b/modules/distribution/product/src/main/conf/synapse-configs/default/sequences/_opa_policy_failure_handler_.xml
@@ -1,0 +1,41 @@
+<sequence name="_opa_policy_failure_handler_" xmlns="http://ws.apache.org/ns/synapse">
+    <filter source="get-property('MESSAGE_FORMAT')" regex="soap1[1-2]">
+        <then>
+            <property name="SOAP_FAULT_CODE" value="Client"/>
+            <makefault version="soap11">
+                <code expression="$ctx:SOAP_FAULT_CODE"/>
+                <reason value="Authentication Failure"/>
+                <detail expression="$ctx:ERROR_MESSAGE"/>
+            </makefault>
+        </then>
+        <else>
+            <payloadFactory media-type="json">
+                <format>{"code":"$1","message":"$2"}</format>
+                <args>
+                    <arg expression="$ctx:ERROR_CODE"/>
+                    <arg expression="$ctx:ERROR_MESSAGE"/>
+                </args>
+            </payloadFactory>
+            <filter source="$axis2:HTTP_METHOD" regex="^(?!.*(POST|PUT|PATCH)).*$">
+                <property name="messageType" value="application/json" scope="axis2"/>
+            </filter>
+        </else>
+    </filter>
+    <filter xpath="$ctx:HTTP_RESPONSE_STATUS_CODE">
+        <then>
+            <property name="HTTP_SC" expression="$ctx:HTTP_RESPONSE_STATUS_CODE" scope="axis2"/>
+        </then>
+        <else>
+            <property name="HTTP_SC" value="401" scope="axis2"/>
+        </else>
+    </filter>
+    <property name="RESPONSE" value="true"/>
+    <header name="To" action="remove"/>
+    <property name="NO_ENTITY_BODY" scope="axis2" action="remove"/>
+    <property name="ContentType" scope="axis2" action="remove"/>
+    <property name="Authorization" scope="transport" action="remove"/>
+    <property name="Host" scope="transport" action="remove"/>
+    <property name="Accept" scope="transport" action="remove"/>
+    <property name="X-JWT-Assertion" scope="transport" action="remove"/>
+    <sequence key="_cors_request_handler_"/>
+</sequence>

--- a/modules/distribution/resources/operation_policies/definitions/opaPolicy.j2
+++ b/modules/distribution/resources/operation_policies/definitions/opaPolicy.j2
@@ -21,8 +21,8 @@
       {% if connectionTimeout %}
       <parameter name="connectionTimeout">{{connectionTimeout}}</parameter>
       {% endif %}
-      {% if additionalMCProperties %}
-      <parameter name="additionalMCProperties">{{additionalMCProperties}}</parameter>
+      {% if additionalProperties %}
+      <parameter name="additionalMCProperties">{{additionalProperties}}</parameter>
       {% endif %}
    </additionalParameters>
 </opa>

--- a/modules/distribution/resources/operation_policies/definitions/opaPolicy.j2
+++ b/modules/distribution/resources/operation_policies/definitions/opaPolicy.j2
@@ -1,0 +1,18 @@
+<opa>
+   <serverUrl>{{serverUrl}}</serverUrl>
+   {% if accessToken %}
+   <accessKey>{{accessKey}}</accessKey>
+   {% endif %}
+   <policy>{{policy}}</policy>
+   <rule>{{rule}}</rule>
+   <requestGenerator>org.wso2.carbon.apimgt.gateway.opa.APIMOPARequestGenerator</requestGenerator>
+   {% if additionalParameters %}
+   <additionalParameters>
+      <parameter name="sendAccessToken">{{sendAccessToken}}</parameter>
+      <parameter name="maxOpenConnections">{{maxOpenConnections}}</parameter>
+      <parameter name="maxPerRoute">{{maxPerRoute}}</parameter>
+      <parameter name="connectionTimeout">{{connectionTimeout}}</parameter>
+      <parameter name="additionalMCProperties">"{{additionalMCProperties}}"</parameter>
+   </additionalParameters>
+   {% endif %}
+</opa>

--- a/modules/distribution/resources/operation_policies/definitions/opaPolicy.j2
+++ b/modules/distribution/resources/operation_policies/definitions/opaPolicy.j2
@@ -4,15 +4,25 @@
    <accessKey>{{accessKey}}</accessKey>
    {% endif %}
    <policy>{{policy}}</policy>
+   {% if rule %}
    <rule>{{rule}}</rule>
-   <requestGenerator>org.wso2.carbon.apimgt.gateway.opa.APIMOPARequestGenerator</requestGenerator>
-   {% if additionalParameters %}
-   <additionalParameters>
-      <parameter name="sendAccessToken">{{sendAccessToken}}</parameter>
-      <parameter name="maxOpenConnections">{{maxOpenConnections}}</parameter>
-      <parameter name="maxPerRoute">{{maxPerRoute}}</parameter>
-      <parameter name="connectionTimeout">{{connectionTimeout}}</parameter>
-      <parameter name="additionalMCProperties">"{{additionalMCProperties}}"</parameter>
-   </additionalParameters>
    {% endif %}
+   <requestGenerator>org.wso2.carbon.apimgt.gateway.opa.APIMOPARequestGenerator</requestGenerator>
+   <additionalParameters>
+      {% if sendAccessToken %}
+      <parameter name="sendAccessToken">{{sendAccessToken}}</parameter>
+      {% endif %}
+      {% if maxOpenConnections %}
+      <parameter name="maxOpenConnections">{{maxOpenConnections}}</parameter>
+      {% endif %}
+      {% if maxPerRoute %}
+      <parameter name="maxPerRoute">{{maxPerRoute}}</parameter>
+      {% endif %}
+      {% if connectionTimeout %}
+      <parameter name="connectionTimeout">{{connectionTimeout}}</parameter>
+      {% endif %}
+      {% if additionalMCProperties %}
+      <parameter name="additionalMCProperties">{{additionalMCProperties}}</parameter>
+      {% endif %}
+   </additionalParameters>
 </opa>

--- a/modules/distribution/resources/operation_policies/specifications/opaPolicy.json
+++ b/modules/distribution/resources/operation_policies/specifications/opaPolicy.json
@@ -24,7 +24,6 @@
       "name": "policy",
       "displayName": "Policy",
       "description": "Policy to be validated",
-      "validationRegex": "([a-zA-Z\\d_][a-zA-Z\\d_\\-\\ ]*)$",
       "type": "String",
       "required": true
     },
@@ -32,7 +31,6 @@
       "name": "rule",
       "displayName": "Rule",
       "description": "Rule to validate",
-      "validationRegex": "^([a-zA-Z\\d_][a-zA-Z\\d_\\-\\ ]*)$",
       "type": "String",
       "required": false
     },
@@ -49,7 +47,7 @@
       "name": "additionalMCProperties",
       "displayName": "Additional MC properties",
       "description": "Additional message context properties to be included in the OPA input. Add these properties in a comma seperated list.",
-      "validationRegex": "([a-zA-Z\\d_][a-zA-Z\\d_\\-\\ ]*)$",
+      "validationRegex": "^([a-zA-Z\\d_][a-zA-Z\\d_\\-\\ ]*)$",
       "type": "String",
       "required": false
     },

--- a/modules/distribution/resources/operation_policies/specifications/opaPolicy.json
+++ b/modules/distribution/resources/operation_policies/specifications/opaPolicy.json
@@ -1,5 +1,5 @@
 {
-  "category": "Mediation",
+  "category": "Security",
   "name": "opaPolicy",
   "displayName": "Validate Request With OPA Policy",
   "description": "With this policy, user can validate requests based on the OPA policy engine",
@@ -9,7 +9,7 @@
       "name": "serverUrl",
       "displayName": "OPA server URL",
       "description": "OPA server's URL",
-      "validationRegex": "([\\w+]+\\:\/\/)?([\\w\\d-]+\\.)*[\\w-]+[\\.\\:]\\w+([\/\\?\\=\\&\\#\\.]?[\\w-]+)*\/?",
+      "validationRegex": "([\\w+]+\\:\/\/)?([\\w\\d-]+\\.)*[\\w-]+[\\.\\:]?\\w+([\/\\?\\=\\&\\#\\.]?[\\w-]+)*\/?",
       "type": "String",
       "required": true
     },
@@ -17,7 +17,6 @@
       "name": "accessKey",
       "displayName": "Access Key",
       "description": "Access key for validation request",
-      "validationRegex": "([a-zA-Z\\d_][a-zA-Z\\d_\\-\\ ]*)$",
       "type": "String",
       "required": false
     },
@@ -33,7 +32,7 @@
       "name": "rule",
       "displayName": "Rule",
       "description": "Rule to validate",
-      "validationRegex": "([a-zA-Z\\d_][a-zA-Z\\d_\\-\\ ]*)$",
+      "validationRegex": "^([a-zA-Z\\d_][a-zA-Z\\d_\\-\\ ]*)$",
       "type": "String",
       "required": false
     },
@@ -58,7 +57,7 @@
       "name": "maxOpenConnections",
       "displayName": "Max open connections",
       "description": "Maximum number of open HTTP connections",
-      "validationRegex": "/^\\d{1,3}$/",
+      "validationRegex": "^\\d{1,3}$",
       "type": "Integer",
       "defaultValue": 500,
       "required": false
@@ -67,7 +66,7 @@
       "name": "maxPerRoute",
       "displayName": "Max per route",
       "description": "Maximum connections per a route",
-      "validationRegex": "/^\\d{1,3}$/",
+      "validationRegex": "^\\d{1,3}$",
       "type": "Integer",
       "defaultValue": 200,
       "required": false
@@ -76,7 +75,7 @@
       "name": "connectionTimeout",
       "displayName": "Connection timeout",
       "description": "Connection timeout",
-      "validationRegex": "/^\\d{1,3}$/",
+      "validationRegex": "^\\d{1,3}$",
       "type": "Integer",
       "defaultValue": 30,
       "required": false
@@ -86,7 +85,8 @@
     "request"
   ],
   "supportedGateways": [
-    "Synapse"
+    "Synapse",
+    "CC"
   ],
   "supportedApiTypes": [
     "HTTP"

--- a/modules/distribution/resources/operation_policies/specifications/opaPolicy.json
+++ b/modules/distribution/resources/operation_policies/specifications/opaPolicy.json
@@ -1,0 +1,94 @@
+{
+  "category": "Mediation",
+  "name": "opaPolicy",
+  "displayName": "Validate Request With OPA Policy",
+  "description": "With this policy, user can validate requests based on the OPA policy engine",
+  "multipleAllowed": true,
+  "policyAttributes": [
+    {
+      "name": "serverUrl",
+      "displayName": "OPA server URL",
+      "description": "OPA server's URL",
+      "validationRegex": "([\\w+]+\\:\/\/)?([\\w\\d-]+\\.)*[\\w-]+[\\.\\:]\\w+([\/\\?\\=\\&\\#\\.]?[\\w-]+)*\/?",
+      "type": "String",
+      "required": true
+    },
+    {
+      "name": "accessKey",
+      "displayName": "Access Key",
+      "description": "Access key for validation request",
+      "validationRegex": "([a-zA-Z\\d_][a-zA-Z\\d_\\-\\ ]*)$",
+      "type": "String",
+      "required": false
+    },
+    {
+      "name": "policy",
+      "displayName": "Policy",
+      "description": "Policy to be validated",
+      "validationRegex": "([a-zA-Z\\d_][a-zA-Z\\d_\\-\\ ]*)$",
+      "type": "String",
+      "required": true
+    },
+    {
+      "name": "rule",
+      "displayName": "Rule",
+      "description": "Rule to validate",
+      "validationRegex": "([a-zA-Z\\d_][a-zA-Z\\d_\\-\\ ]*)$",
+      "type": "String",
+      "required": false
+    },
+    {
+      "name": "sendAccessToken",
+      "displayName": "Send access token",
+      "description": "Select whether to send access token to the OPA payload",
+      "validationRegex": "^(?i)(true|false)$",
+      "type": "Boolean",
+      "defaultValue": false,
+      "required": false
+    },
+    {
+      "name": "additionalMCProperties",
+      "displayName": "Additional MC properties",
+      "description": "Additional message context properties to be included in the OPA input. Add these properties in a comma seperated list.",
+      "validationRegex": "([a-zA-Z\\d_][a-zA-Z\\d_\\-\\ ]*)$",
+      "type": "String",
+      "required": false
+    },
+    {
+      "name": "maxOpenConnections",
+      "displayName": "Max open connections",
+      "description": "Maximum number of open HTTP connections",
+      "validationRegex": "/^\\d{1,3}$/",
+      "type": "Integer",
+      "defaultValue": 500,
+      "required": false
+    },
+    {
+      "name": "maxPerRoute",
+      "displayName": "Max per route",
+      "description": "Maximum connections per a route",
+      "validationRegex": "/^\\d{1,3}$/",
+      "type": "Integer",
+      "defaultValue": 200,
+      "required": false
+    },
+    {
+      "name": "connectionTimeout",
+      "displayName": "Connection timeout",
+      "description": "Connection timeout",
+      "validationRegex": "/^\\d{1,3}$/",
+      "type": "Integer",
+      "defaultValue": 30,
+      "required": false
+    }
+  ],
+  "applicableFlows": [
+    "request"
+  ],
+  "supportedGateways": [
+    "Synapse"
+  ],
+  "supportedApiTypes": [
+    "HTTP"
+  ]
+}

--- a/modules/distribution/resources/operation_policies/specifications/opaPolicy.json
+++ b/modules/distribution/resources/operation_policies/specifications/opaPolicy.json
@@ -41,7 +41,7 @@
       "name": "sendAccessToken",
       "displayName": "Send access token",
       "description": "Select whether to send access token to the OPA payload",
-      "validationRegex": "^(?i)(true|false)$",
+      "validationRegex": "^(true|false)$",
       "type": "Boolean",
       "defaultValue": false,
       "required": false

--- a/modules/distribution/resources/operation_policies/specifications/opaPolicy.json
+++ b/modules/distribution/resources/operation_policies/specifications/opaPolicy.json
@@ -44,9 +44,9 @@
       "required": false
     },
     {
-      "name": "additionalMCProperties",
-      "displayName": "Additional MC properties",
-      "description": "Additional message context properties to be included in the OPA input. Add these properties in a comma seperated list.",
+      "name": "additionalProperties",
+      "displayName": "Additional properties",
+      "description": "Additional message context (request context) properties to be included in the OPA input. Add these properties in a comma seperated list.",
       "validationRegex": "^([a-zA-Z\\d_][a-zA-Z\\d_\\-\\ ]*)$",
       "type": "String",
       "required": false

--- a/modules/distribution/resources/operation_policies/specifications/rewriteResourcePath.json
+++ b/modules/distribution/resources/operation_policies/specifications/rewriteResourcePath.json
@@ -17,7 +17,7 @@
       "name": "includeQueryParams",
       "displayName": "Include Query Parameters?",
       "description": "Select whether to include exiting query params to the new resource path",
-      "validationRegex": "^(?i)(true|false)$",
+      "validationRegex": "^(true|false)$",
       "type": "Boolean",
       "required": false
     }

--- a/modules/distribution/resources/operation_policies/specifications/rewriteResourcePath.json
+++ b/modules/distribution/resources/operation_policies/specifications/rewriteResourcePath.json
@@ -17,6 +17,7 @@
       "name": "includeQueryParams",
       "displayName": "Include Query Parameters?",
       "description": "Select whether to include exiting query params to the new resource path",
+      "validationRegex": "^(?i)(true|false)$",
       "type": "Boolean",
       "required": false
     }

--- a/pom.xml
+++ b/pom.xml
@@ -1286,10 +1286,10 @@
         <project.scm.id>scm-server</project.scm.id>
         <carbon.analytics.common.version>5.2.37</carbon.analytics.common.version>
         <!-- APIM Portals Component Version -->
-        <carbon.apimgt.ui.version>9.0.249</carbon.apimgt.ui.version>
+        <carbon.apimgt.ui.version>9.0.253</carbon.apimgt.ui.version>
 
         <!-- APIM Component Version -->
-        <carbon.apimgt.version>9.18.21</carbon.apimgt.version>
+        <carbon.apimgt.version>9.19.0</carbon.apimgt.version>
 
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 
@@ -1358,7 +1358,7 @@
         <opencsv.version>1.8</opencsv.version>
         <poi.version>3.0-FINAL</poi.version>
         <woden.version>1.0.0.M8-wso2v1</woden.version>
-	    <synapse.version>2.1.7-wso2v253</synapse.version>
+	    <synapse.version>2.1.7-wso2v258</synapse.version>
         <passthru.transport.patch.version>1.0.2</passthru.transport.patch.version>
         <axis2.wso2.version>1.6.1-wso2v76</axis2.wso2.version>
         <axiom.wso2.version>1.2.11-wso2v16</axiom.wso2.version>


### PR DESCRIPTION
This PR adds the opa policy specification, definition and fault handler for APIM. OPA mediator is added via https://github.com/wso2/wso2-synapse/pull/1899

Git issue : https://github.com/wso2/product-apim/issues/11581