### PR TITLE
Remove multiple allowed property from policy specifications 

### DIFF
--- a/modules/distribution/resources/operation_policies/specifications/addHeader.json
+++ b/modules/distribution/resources/operation_policies/specifications/addHeader.json
@@ -3,7 +3,6 @@
   "name": "addHeader",
   "displayName": "Add Header",
   "description": "With this policy, user can add a new header to the request",
-  "multipleAllowed": true,
   "policyAttributes": [
     {
       "name": "headerName",

--- a/modules/distribution/resources/operation_policies/specifications/addLogMessage.json
+++ b/modules/distribution/resources/operation_policies/specifications/addLogMessage.json
@@ -3,7 +3,6 @@
   "name": "addLogMessage",
   "displayName": "Log Policy",
   "description": "Using this policy, you can log the important details of the request",
-  "multipleAllowed": false,
   "applicableFlows": [
     "request",
     "response",

--- a/modules/distribution/resources/operation_policies/specifications/addQueryParam.json
+++ b/modules/distribution/resources/operation_policies/specifications/addQueryParam.json
@@ -3,7 +3,6 @@
   "name": "addQueryParam",
   "displayName": "Add Query Param",
   "description": "Add a query parameter to the request",
-  "multipleAllowed": true,
   "policyAttributes": [
     {
       "name": "paramKey",

--- a/modules/distribution/resources/operation_policies/specifications/applyAcceptHeader.json
+++ b/modules/distribution/resources/operation_policies/specifications/applyAcceptHeader.json
@@ -3,7 +3,6 @@
   "name": "applyAcceptHeader",
   "displayName": "Apply Accept Header",
   "description": "Apply accept header",
-  "multipleAllowed": false,
   "applicableFlows": [
     "request"
   ],

--- a/modules/distribution/resources/operation_policies/specifications/changeHTTPMethod.json
+++ b/modules/distribution/resources/operation_policies/specifications/changeHTTPMethod.json
@@ -3,7 +3,6 @@
   "name": "changeHTTPMethod",
   "displayName": "Change HTTP Method",
   "description": "With this policy, user can change the HTTP Method",
-  "multipleAllowed": false,
   "policyAttributes": [
     {
       "name": "httpMethod",

--- a/modules/distribution/resources/operation_policies/specifications/debugJsonFault.json
+++ b/modules/distribution/resources/operation_policies/specifications/debugJsonFault.json
@@ -3,7 +3,6 @@
   "name": "debugJsonFault",
   "displayName": "Debug JSON Fault",
   "description": "Debug the fault payload in JSON format",
-  "multipleAllowed": false,
   "applicableFlows": [
     "fault"
   ],

--- a/modules/distribution/resources/operation_policies/specifications/debugRequestFlow.json
+++ b/modules/distribution/resources/operation_policies/specifications/debugRequestFlow.json
@@ -3,7 +3,6 @@
   "name": "debugRequestFlow",
   "displayName": "Debug Request Flow",
   "description": "For debugging purposes, log the special properties of the request message",
-  "multipleAllowed": false,
   "applicableFlows": [
     "request"
   ],

--- a/modules/distribution/resources/operation_policies/specifications/debugResponseFlow.json
+++ b/modules/distribution/resources/operation_policies/specifications/debugResponseFlow.json
@@ -3,7 +3,6 @@
   "name": "debugResponseFlow",
   "displayName": "Debug Response Flow",
   "description": "For debugging purposes, log the special properties of the response message",
-  "multipleAllowed": false,
   "applicableFlows": [
     "response"
   ],

--- a/modules/distribution/resources/operation_policies/specifications/disableChunking.json
+++ b/modules/distribution/resources/operation_policies/specifications/disableChunking.json
@@ -3,7 +3,6 @@
   "name": "disableChunking",
   "displayName": "Disable Chunking",
   "description": "Disable chunking of the payload",
-  "multipleAllowed": false,
   "applicableFlows": [
     "request",
     "response"

--- a/modules/distribution/resources/operation_policies/specifications/jsonFault.json
+++ b/modules/distribution/resources/operation_policies/specifications/jsonFault.json
@@ -3,7 +3,6 @@
   "name": "jsonFault",
   "displayName": "JSON Fault",
   "description": "Output the fault message in JSON",
-  "multipleAllowed": false,
   "applicableFlows": [
     "fault"
   ],

--- a/modules/distribution/resources/operation_policies/specifications/jsonToXML.json
+++ b/modules/distribution/resources/operation_policies/specifications/jsonToXML.json
@@ -3,7 +3,6 @@
   "name": "jsonToXML",
   "displayName": "JSON to XML",
   "description": "With this policy, user can change the payload from JSON to XML",
-  "multipleAllowed": false,
   "applicableFlows": [
     "request",
     "response"

--- a/modules/distribution/resources/operation_policies/specifications/jsonValidator.json
+++ b/modules/distribution/resources/operation_policies/specifications/jsonValidator.json
@@ -3,7 +3,6 @@
   "name": "jsonValidator",
   "displayName": "JSON Validator",
   "description": "With this policy, you can validate the JSON payload for the request",
-  "multipleAllowed": false,
   "applicableFlows": [
     "request"
   ],

--- a/modules/distribution/resources/operation_policies/specifications/opaPolicy.json
+++ b/modules/distribution/resources/operation_policies/specifications/opaPolicy.json
@@ -3,7 +3,6 @@
   "name": "opaPolicy",
   "displayName": "Validate Request With OPA Policy",
   "description": "With this policy, user can validate requests based on the OPA policy engine",
-  "multipleAllowed": true,
   "policyAttributes": [
     {
       "name": "serverUrl",

--- a/modules/distribution/resources/operation_policies/specifications/preserveAcceptHeader.json
+++ b/modules/distribution/resources/operation_policies/specifications/preserveAcceptHeader.json
@@ -3,7 +3,6 @@
   "name": "preserveAcceptHeader",
   "displayName": "Preserve Accept Header",
   "description": "Preserve the accept header",
-  "multipleAllowed": false,
   "applicableFlows": [
     "request"
   ],

--- a/modules/distribution/resources/operation_policies/specifications/regexPolicy.json
+++ b/modules/distribution/resources/operation_policies/specifications/regexPolicy.json
@@ -3,7 +3,6 @@
   "name": "regexPolicy",
   "displayName": "Regex Policy",
   "description": "Regex policy",
-  "multipleAllowed": true,
   "applicableFlows": [
     "request"
   ],

--- a/modules/distribution/resources/operation_policies/specifications/removeHeader.json
+++ b/modules/distribution/resources/operation_policies/specifications/removeHeader.json
@@ -3,7 +3,6 @@
   "name": "removeHeader",
   "displayName": "Remove Header",
   "description": "Remove a header from the request",
-  "multipleAllowed": true,
   "policyAttributes": [
     {
       "name": "headerName",

--- a/modules/distribution/resources/operation_policies/specifications/rewriteResourcePath.json
+++ b/modules/distribution/resources/operation_policies/specifications/rewriteResourcePath.json
@@ -3,7 +3,6 @@
   "name": "rewriteResourcePath",
   "displayName": "Rewrite Resource Path",
   "description": "Rewrite the resource path of a request",
-  "multipleAllowed": false,
   "policyAttributes": [
     {
       "name": "newResourcePath",

--- a/modules/distribution/resources/operation_policies/specifications/setToHeader.json
+++ b/modules/distribution/resources/operation_policies/specifications/setToHeader.json
@@ -3,7 +3,6 @@
   "name": "setToHeader",
   "displayName": "Set To Header",
   "description": "With this policy, user can set To Header",
-  "multipleAllowed": true,
   "policyAttributes": [
     {
       "name": "value",

--- a/modules/distribution/resources/operation_policies/specifications/xmlToJson.json
+++ b/modules/distribution/resources/operation_policies/specifications/xmlToJson.json
@@ -3,7 +3,6 @@
   "name": "XMLtoJson",
   "displayName": "XML to JSON",
   "description": "With this policy, user can change the payload from XML to JSON",
-  "multipleAllowed": false,
   "applicableFlows": [
     "request",
     "response"

--- a/modules/distribution/resources/operation_policies/specifications/xmlToJson.json
+++ b/modules/distribution/resources/operation_policies/specifications/xmlToJson.json
@@ -1,6 +1,6 @@
 {
   "category": "Mediation",
-  "name": "XMLtoJson",
+  "name": "xmlToJson",
   "displayName": "XML to JSON",
   "description": "With this policy, user can change the payload from XML to JSON",
   "applicableFlows": [

--- a/modules/distribution/resources/operation_policies/specifications/xmlValidator.json
+++ b/modules/distribution/resources/operation_policies/specifications/xmlValidator.json
@@ -3,7 +3,6 @@
   "name": "xmlValidator",
   "displayName": "XML Validator",
   "description": "With this policy, you can validate the XML payload for the request",
-  "multipleAllowed": false,
   "applicableFlows": [
     "request"
   ],

--- a/pom.xml
+++ b/pom.xml
@@ -1274,7 +1274,7 @@
         <carbon.apimgt.ui.version>9.0.256</carbon.apimgt.ui.version>
 
         <!-- APIM Component Version -->
-        <carbon.apimgt.version>9.20.2</carbon.apimgt.version>
+        <carbon.apimgt.version>9.20.4</carbon.apimgt.version>
 
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 


### PR DESCRIPTION
From PR https://github.com/wso2/carbon-apimgt/pull/11098, we have removed the multiple allowed field from policy spec.