### PR TITLE
Adding support for the WS to handle inbound and outbound idle connectin timeout

### DIFF
--- a/modules/distribution/product/src/main/resources/conf/templates/repository/deployment/server/synapse-configs/default/inbound-endpoints/SecureWebSocketInboundEndpoint.xml.j2
+++ b/modules/distribution/product/src/main/resources/conf/templates/repository/deployment/server/synapse-configs/default/inbound-endpoints/SecureWebSocketInboundEndpoint.xml.j2
@@ -14,6 +14,12 @@
         <parameter name="ws.outflow.dispatch.fault.sequence">{{apim.wss.outflow.dispatch.fault.sequence}}</parameter>
         <parameter name="ws.client.side.broadcast.level">{{apim.wss.client.side.broadcast.level}}</parameter>
         <parameter name="ws.use.port.offset">true</parameter>
+        {%if apim.wss.dispatch.idleTime is defined %}
+        <parameter name="ws.dispatch.idleTime">{{apim.wss.dispatch.idleTime}}</parameter>
+        {%endif%}
+        {%if apim.wss.outflow.dispatch.idleTime is defined %}
+        <parameter name="ws.outflow.dispatch.idleTime">{{apim.wss.outflow.dispatch.idleTime}}</parameter>
+        {%endif%}
         <parameter name="wss.ssl.key.store.file">{{apim.wss.keystore.location}}</parameter>
         <parameter name="wss.ssl.key.store.pass">{{apim.wss.keystore.password}}</parameter>
         <parameter name="wss.ssl.cert.pass">{{apim.wss.keystore.key_password}}</parameter>

--- a/modules/distribution/product/src/main/resources/conf/templates/repository/deployment/server/synapse-configs/default/inbound-endpoints/WebSocketInboundEndpoint.xml.j2
+++ b/modules/distribution/product/src/main/resources/conf/templates/repository/deployment/server/synapse-configs/default/inbound-endpoints/WebSocketInboundEndpoint.xml.j2
@@ -13,5 +13,11 @@
         <parameter name="ws.outflow.dispatch.fault.sequence">{{apim.ws.outflow.dispatch.fault.sequence}}</parameter>
         <parameter name="ws.client.side.broadcast.level">{{apim.ws.client.side.broadcast.level}}</parameter>
         <parameter name="ws.use.port.offset">true</parameter>
+        {%if apim.ws.dispatch.idleTime is defined %}
+        <parameter name="ws.dispatch.idleTime">{{apim.ws.dispatch.idleTime}}</parameter>
+        {%endif%}
+        {%if apim.ws.outflow.dispatch.idleTime is defined %}
+        <parameter name="ws.outflow.dispatch.idleTime">{{apim.ws.outflow.dispatch.idleTime}}</parameter>
+        {%endif%}
     </parameters>
 </inboundEndpoint> 


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-apim/issues/12444

## Approach
Refer https://netty.io/4.0/api/io/netty/handler/timeout/IdleStateHandler.html for more information regarding these params.

Considering the event time in seconds,
* For inbound WS calls, override `apim.ws.dispatch.idleTime` in deployment.toml
* For inbound WSS calls, override `apim.wss.dispatch.idleTime` in deployment.toml
* For outbound WS calls, override `apim.ws.outflow.dispatch.idleTime` in deployment.toml
* For outbound WSS calls, override `apim.wss.outflow.dispatch.idleTime` in deployment.toml

You may have to override the "userEventTriggered" of "WebsocketHandler" class after extending from it.

Example:

An example that terminates when there is no outbound traffic and inbound traffic based on the param values set above

```java
package com.bnymellon.ess.wso2.apimgt.gateway.handlers;

import io.netty.channel.ChannelHandlerContext;
import io.netty.handler.timeout.IdleState;
import io.netty.handler.timeout.IdleStateEvent;
import org.apache.commons.logging.Log;
import org.apache.commons.logging.LogFactory;
import org.wso2.carbon.apimgt.gateway.handlers.WebsocketHandler;

/**
 * Websocket handler implementing the idle connection timeout netty functions.
 *
 * @since 1.0.0
 */
public class XWebSocketHandler extends WebsocketHandler {

    private static final Log log = LogFactory.getLog(XWebSocketHandler.class);

    @Override
    public void userEventTriggered(ChannelHandlerContext channelHandlerContext, Object event) throws Exception {
        super.userEventTriggered(channelHandlerContext, event);
        if (event instanceof IdleStateEvent) {
            IdleStateEvent idleStateEvent = (IdleStateEvent) event;
            if (idleStateEvent.state() == IdleState.READER_IDLE) {
                channelHandlerContext.close();
            }
            if (idleStateEvent.state() == IdleState.WRITER_IDLE) {
                channelHandlerContext.close();
            }
        }
    }
}

```