### PR TITLE
Fix basic auth property appending to non secured resources in API products

### DIFF
--- a/modules/distribution/resources/api_templates/api_product_template.xml
+++ b/modules/distribution/resources/api_templates/api_product_template.xml
@@ -34,7 +34,7 @@
         #set( $endpointsecurity = $endpoint_security.get("${type}"))
 
         ## IF endpoint secured
-        #if($endpointsecurity.enabled)
+        #if($endpoint_security.get("$type").enabled)
         #if($endpointsecurity.type == "basic" || $endpointsecurity.type == "BASIC")
         #if($isSecureVaultEnabled)
 <property xmlns="http://ws.apache.org/ns/synapse" name="password" expression="wso2:vault-lookup('$endpointsecurity.alias')"/>


### PR DESCRIPTION
This PR fixes Basic Auth property appending to non secured backend resources in API Products.

Fixes https://github.com/wso2/product-apim/issues/12562