### PR TITLE
Adding common XMLSchema.xsd file to the distribution

### DIFF
--- a/modules/distribution/product/src/main/assembly/bin.xml
+++ b/modules/distribution/product/src/main/assembly/bin.xml
@@ -443,6 +443,14 @@
                 <include>**/**.jmx</include>
             </includes>
         </fileSet>
+        <!-- Adding common XMLSchema.xsd file -->
+        <fileSet>
+            <directory>../resources/xsds</directory>
+            <outputDirectory>wso2am-${pom.version}/repository/resources/xsds</outputDirectory>
+            <includes>
+                <include>**/*.xsd</include>
+            </includes>
+        </fileSet>
         <!-- API Templates -->
         <fileSet>
             <directory>../resources/api_templates</directory>


### PR DESCRIPTION
### Purpose
Complete porting the resources added with https://github.com/wso2-support/update-artifacts/pull/591 PR related to https://github.com/wso2-support/carbon-apimgt/pull/2209 by adding when creating the distribution.

### Goal
Fixes: https://github.com/wso2/product-apim/issues/12650