### PR TITLE
Exclude cassandra and sso.agent Jars

### DIFF
--- a/modules/distribution/product/src/main/assembly/bin.xml
+++ b/modules/distribution/product/src/main/assembly/bin.xml
@@ -108,6 +108,8 @@
                 </exclude>
 
                 <exclude>**/repository/components/plugins/cassandra-thrift_1.2.13.wso2v4.jar</exclude>
+                <exclude>**/repository/components/plugins/org.wso2.carbon.event.output.adapter.cassandra_*.jar</exclude>
+                <exclude>**/repository/components/plugins/org.wso2.carbon.identity.sso.agent_*.jar</exclude>
 
                 <exclude>**/repository/components/plugins/netty-all_4.0.23.wso2v1.jar</exclude>
                 <exclude>**/repository/components/plugins/org.wso2.carbon.apimgt.rest.api.util_*.jar</exclude>


### PR DESCRIPTION
## Purpose
This PR excludes the `org.wso2.carbon.event.output.adapter.cassandra` and `org.wso2.carbon.identity.sso.agent` from the product pack as there are no use-cases of these jars in the product.

## Approach
Added the above mentioned two jars within the `<exclude>` tag in the `assembly/bin.xml` file.