### PR TITLE
Revert test cases changes for responsesObject 

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/APIM4765ResourceOrderInSwagger.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/APIM4765ResourceOrderInSwagger.java
@@ -90,21 +90,17 @@ public class APIM4765ResourceOrderInSwagger extends APIManagerLifecycleBaseTest 
 
         String resourceOrder = "\"paths\" : {"+ lineSeparator + "    \"/*\" : {"+ lineSeparator + "      \"get\" : {" + lineSeparator
                 + "        \"parameters\" : [ ],"+ lineSeparator + "        \"responses\" : {"+ lineSeparator + "          \"200\" : { }" + lineSeparator
-                + "        },"+ lineSeparator + "        \"responsesObject\" : {"+ lineSeparator + "          \"200\" : { }" + lineSeparator
                 + "        },"+ lineSeparator + "        \"security\" : [ {"+ lineSeparator + "          \"default\" : [ ]" + lineSeparator + "        } ]," + lineSeparator
                 + "        \"x-auth-type\" : \"Application \"," + lineSeparator + "        \"x-throttling-tier\" : \"10KPerMin\"" + lineSeparator
                 + "      }"+ lineSeparator + "    },"+ lineSeparator + "    \"/post\" : {"+ lineSeparator + "      \"get\" : {"+ lineSeparator
                 + "        \"parameters\" : [ ],"+ lineSeparator + "        \"responses\" : {"+ lineSeparator + "          \"200\" : { }"+ lineSeparator
-                + "        },"+ lineSeparator + "        \"responsesObject\" : {"+ lineSeparator + "          \"200\" : { }" + lineSeparator
                 + "        },"+ lineSeparator + "        \"security\" : [ {"+ lineSeparator + "          \"default\" : [ ]"+ lineSeparator + "        } ],"+ lineSeparator
                 + "        \"x-auth-type\" : \"Application \","+ lineSeparator + "        \"x-throttling-tier\" : \"10KPerMin\""+ lineSeparator
                 + "      }"+ lineSeparator + "    },"+ lineSeparator + "    \"/list\" : {"+ lineSeparator + "      \"get\" : {"+ lineSeparator
                 + "        \"parameters\" : [ ],"+ lineSeparator + "        \"responses\" : {"+ lineSeparator + "          \"200\" : { }"+ lineSeparator
-                + "        },"+ lineSeparator + "        \"responsesObject\" : {"+ lineSeparator + "          \"200\" : { }" + lineSeparator
                 + "        },"+ lineSeparator + "        \"security\" : [ {"+ lineSeparator + "          \"default\" : [ ]"+ lineSeparator + "        } ],"+ lineSeparator
                 + "        \"x-auth-type\" : \"Application \","+ lineSeparator + "        \"x-throttling-tier\" : \"10KPerMin\""+ lineSeparator
                 + "      }"+ lineSeparator + "    }"+ lineSeparator + "  }";
-
 
         restAPIPublisher.updateSwagger(apiId, swagger);
         //get swagger doc.


### PR DESCRIPTION
## Purpose
As $subject, this will revert the added test case changes## for responsesObject field in swagger2.

### Related PRs
- https://github.com/wso2/carbon-apimgt/pull/11163
- 
### Fixes
- https://github.com/wso2/product-apim/issues/12561