### PR TITLE
Upgrade carbon-analytics-common Version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1269,7 +1269,7 @@
     <properties>
 
         <project.scm.id>scm-server</project.scm.id>
-        <carbon.analytics.common.version>5.2.40</carbon.analytics.common.version>
+        <carbon.analytics.common.version>5.2.41</carbon.analytics.common.version>
         <!-- APIM Portals Component Version -->
         <carbon.apimgt.ui.version>9.0.283</carbon.apimgt.ui.version>
 


### PR DESCRIPTION
## Purpose
Upgrade carbon-analytics-common version from 5.2.37 to 5.2.41

## Related PRs
carbon-apimgt - https://github.com/wso2/carbon-apimgt/pull/11169