### PR TITLE
Fixing the web sub tests to not use Endpoint URL

### DIFF
--- a/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/utils/bean/APIRequest.java
+++ b/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/utils/bean/APIRequest.java
@@ -302,6 +302,18 @@ public class APIRequest extends AbstractRequest {
         }
     }
 
+    public APIRequest(String apiName, String context) {
+        this.name = apiName;
+        this.context = context;
+        this.corsConfiguration = new JSONObject("{\"corsConfigurationEnabled\" : false, " +
+                "\"accessControlAllowOrigins\" : [\"*\"], " +
+                "\"accessControlAllowCredentials\" : true, " +
+                "\"accessControlAllowHeaders\" : " +
+                "[\"Access-Control-Allow-Origin\", \"authorization\", " +
+                "\"Content-Type\"], \"accessControlAllowMethods\" : [\"POST\", " +
+                "\"PATCH\", \"GET\", \"DELETE\", \"OPTIONS\", \"PUT\"]}");
+    }
+
     public APIRequest(String apiName, String context, URI productionEndpointUri, URI sandboxEndpointUri)
             throws APIManagerIntegrationTestException {
         this.name = apiName;

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/streamingapis/websub/FailedWebSubSubscriptionTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/streamingapis/websub/FailedWebSubSubscriptionTestCase.java
@@ -150,10 +150,8 @@ public class FailedWebSubSubscriptionTestCase extends APIMIntegrationBaseTest {
     public void testPublishWebSubApi() throws Exception {
         provider = user.getUserName();
 
-        URI endpointUri = new URI("http://" + serverHost + ":" + callbackReceiverPort + "/receiver");
-
         //Create the api creation request object
-        apiRequest = new APIRequest(apiName, apiContext, endpointUri, endpointUri);
+        apiRequest = new APIRequest(apiName, apiContext);
         apiRequest.setVersion(apiVersion);
         apiRequest.setTiersCollection(APIMIntegrationConstants.API_TIER.ASYNC_WH_UNLIMITED);
         apiRequest.setProvider(provider);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/streamingapis/websub/LeaseTimeSubscriptionTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/streamingapis/websub/LeaseTimeSubscriptionTestCase.java
@@ -149,10 +149,8 @@ public class LeaseTimeSubscriptionTestCase extends APIMIntegrationBaseTest {
     public void testPublishWebSubApi() throws Exception {
         provider = user.getUserName();
 
-        URI endpointUri = new URI("http://" + serverHost + ":" + callbackReceiverPort + "/receiver");
-
         //Create the api creation request object
-        apiRequest = new APIRequest(apiName, apiContext, endpointUri, endpointUri);
+        apiRequest = new APIRequest(apiName, apiContext);
         apiRequest.setVersion(apiVersion);
         apiRequest.setTiersCollection(APIMIntegrationConstants.API_TIER.ASYNC_WH_UNLIMITED);
         apiRequest.setProvider(provider);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/streamingapis/websub/MultipleWebSubSubcriptionTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/streamingapis/websub/MultipleWebSubSubcriptionTestCase.java
@@ -165,10 +165,8 @@ public class MultipleWebSubSubcriptionTestCase extends APIMIntegrationBaseTest {
     public void testPublishWebSubApi() throws Exception {
         provider = user.getUserName();
 
-        URI endpointUri = new URI("http://" + serverHost + ":" + callbackReceiverPort1 + "/receiver");
-
         //Create the api creation request object
-        apiRequest = new APIRequest(apiName, apiContext, endpointUri, endpointUri);
+        apiRequest = new APIRequest(apiName, apiContext);
         apiRequest.setVersion(apiVersion);
         apiRequest.setTiersCollection(APIMIntegrationConstants.API_TIER.ASYNC_WH_UNLIMITED);
         apiRequest.setProvider(provider);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/streamingapis/websub/SecretValidationTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/streamingapis/websub/SecretValidationTestCase.java
@@ -148,10 +148,8 @@ public class SecretValidationTestCase extends APIMIntegrationBaseTest {
     public void testPublishWebSubApi() throws Exception {
         provider = user.getUserName();
 
-        URI endpointUri = new URI("http://" + serverHost + ":" + callbackReceiverPort + "/receiver");
-
         //Create the api creation request object
-        apiRequest = new APIRequest(apiName, apiContext, endpointUri, endpointUri);
+        apiRequest = new APIRequest(apiName, apiContext);
         apiRequest.setVersion(apiVersion);
         apiRequest.setTiersCollection(APIMIntegrationConstants.API_TIER.ASYNC_WH_UNLIMITED);
         apiRequest.setProvider(provider);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/streamingapis/websub/ThrottlingTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/streamingapis/websub/ThrottlingTestCase.java
@@ -206,11 +206,8 @@ public class ThrottlingTestCase extends APIMIntegrationBaseTest {
     public void testPublishWebSubApi() throws Exception {
         provider = user.getUserName();
 
-        URI endpointUri = new URI("http://" + serverHost + ":" + callbackReceiverPort + "/receiver");
-
-
         //Create the api creation request object
-        apiRequest = new APIRequest(apiName, apiContext, endpointUri, endpointUri);
+        apiRequest = new APIRequest(apiName, apiContext);
         apiRequest.setVersion(apiVersion);
         apiRequest.setTiersCollection(subPolicyName);
         apiRequest.setProvider(provider);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/streamingapis/websub/WebSubAPITestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/streamingapis/websub/WebSubAPITestCase.java
@@ -149,10 +149,8 @@ public class WebSubAPITestCase extends APIMIntegrationBaseTest {
     public void testPublishWebSubApi() throws Exception {
         provider = user.getUserName();
 
-        URI endpointUri = new URI("http://" + serverHost + ":" + callbackReceiverPort + "/receiver");
-
         //Create the api creation request object
-        apiRequest = new APIRequest(apiName, apiContext, endpointUri, endpointUri);
+        apiRequest = new APIRequest(apiName, apiContext);
         apiRequest.setVersion(apiVersion);
         apiRequest.setTiersCollection(APIMIntegrationConstants.API_TIER.ASYNC_WH_UNLIMITED);
         apiRequest.setProvider(provider);


### PR DESCRIPTION
## Related PRs
- https://github.com/wso2/carbon-apimgt/pull/11208