### PR TITLE
Add apim-is-plugin source code

### DIFF
--- a/modules/distribution/apim-is-plugin/README.md
+++ b/modules/distribution/apim-is-plugin/README.md
@@ -1,0 +1,22 @@
+# WSO2 APIM IS Plugin - 4.1.0-SNAPSHOT
+
+## Prerequisites:
+1. Download WSO2 IS product
+2. Download WSO2 APIM IS Plugin product
+
+## Installation Steps:
+1. Extract WSO2 IS product. Let's call it `<WSO2_IS_HOME>`.
+2. Extract WSO2 APIM IS Plugin. Lets call it `<WSO2_APIM_IS_PLUGIN_HOME>`.
+3. Navigate to `<WSO2_APIM_IS_PLUGIN_HOME>` directory and execute `./bin/merge.sh` command by providing `<WSO2_IS_HOME>` as argument. This will copy the key manager artifacts to the WSO2 IS.
+
+## Audit Logs:
+- Running `merge.sh` script creates an audit log folder in the product home. Structure of it looks like below;
+
+    ``` sh
+    apim-is-plugin
+    ├── backup
+    │   ├── dropins
+    │   └── webapps
+    └── merge_audit.log
+    ```
+- `backup` folder contains the files that were originally there in the IS product before running the plugin. Please note that only the last state will be there.

--- a/modules/distribution/apim-is-plugin/assembly/bin.xml
+++ b/modules/distribution/apim-is-plugin/assembly/bin.xml
@@ -1,0 +1,42 @@
+<!--
+ ~ Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com). All Rights Reserved.
+ ~
+ ~ This software is the property of WSO2 Inc. and its suppliers, if any.
+ ~ Dissemination of any information or reproduction of any material contained
+ ~ herein is strictly forbidden, unless permitted by WSO2 in accordance with
+ ~ the WSO2 Commercial License available at http://wso2.com/licenses.
+ ~ For specific language governing the permissions and limitations under this
+ ~ license, please see the license as well as any agreement you’ve entered into
+ ~ with WSO2 governing the purchase of this software and any associated services.
+-->
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+    <id>wso2.apim.is.plugin</id>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <formats>
+        <format>zip</format>
+    </formats>
+    <fileSets>
+        <fileSet>
+            <directory>${project.basedir}/target/apim-is-plugin-resources</directory>
+            <outputDirectory>wso2apim-is-plugin-${project.version}/</outputDirectory>
+        </fileSet>
+        <fileSet>
+            <directory>${project.basedir}/bin</directory>
+            <outputDirectory>wso2apim-is-plugin-${project.version}/bin</outputDirectory>
+        </fileSet>
+    </fileSets>
+    <files>
+        <file>
+            <source>${project.basedir}/README.md</source>
+            <outputDirectory>wso2apim-is-plugin-${project.version}/</outputDirectory>
+        </file>
+        <file>
+            <source>${project.basedir}/updates/product.txt</source>
+            <outputDirectory>wso2apim-is-plugin-${project.version}/updates</outputDirectory>
+            <filtered>true</filtered>
+            <fileMode>644</fileMode>
+        </file>
+    </files>
+</assembly>

--- a/modules/distribution/apim-is-plugin/bin/merge.bat
+++ b/modules/distribution/apim-is-plugin/bin/merge.bat
@@ -1,0 +1,118 @@
+@echo off
+REM ---------------------------------------------------------------------------
+REM        Copyright 2022 WSO2, Inc. http://www.wso2.org
+REM
+REM  Licensed under the Apache License, Version 2.0 (the "License");
+REM  you may not use this file except in compliance with the License.
+REM  You may obtain a copy of the License at
+REM
+REM      http://www.apache.org/licenses/LICENSE-2.0
+REM
+REM  Unless required by applicable law or agreed to in writing, software
+REM  distributed under the License is distributed on an "AS IS" BASIS,
+REM  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+REM  See the License for the specific language governing permissions and
+REM  limitations under the License.
+
+REM merge.sh script copy the APIM-IS-PLUGIN artifacts on top of WSO2 IS
+REM
+REM merge.bat IS-HOME
+
+if ""%1""=="""" (
+	echo [ERROR] IS_HOME is not specified, please try again with correct arguments
+	exit /b 1
+)
+set IS_HOME=%1
+echo [INFO] Product IS home is: %IS_HOME%
+
+FOR %%A IN ("%~dp0.") DO set APIM_IS_PLUGIN_HOME=%%~dpA
+echo [INFO WSO2 IS-APIM Plugin home is: %APIM_IS_PLUGIN_HOME%
+
+if exist %IS_HOME%\repository\components\ (
+	echo [INFO] Valid carbon product path
+) else (
+	echo [ERROR] Specified product path is not a valid carbon product path
+	exit /b 1
+)
+
+rem create the is-apim-plugin folder in product home, if not exist
+set APIM_IS_PLUGIN_AUDIT=%IS_HOME%\is-apim-plugin
+set APIM_IS_PLUGIN_AUDIT_BACKUP=%APIM_IS_PLUGIN_AUDIT%\backup
+
+if exist %APIM_IS_PLUGIN_AUDIT% (
+	echo [INFO] APIM-IS-PLUGIN audit folder is present at %APIM_IS_PLUGIN_AUDIT%
+	if exist %APIM_IS_PLUGIN_AUDIT_BACKUP% (
+	    del /q %APIM_IS_PLUGIN_AUDIT_BACKUP%\webapps\*
+	    del /q %APIM_IS_PLUGIN_AUDIT_BACKUP%\dropins\*
+	)
+) else (
+	mkdir %APIM_IS_PLUGIN_AUDIT_BACKUP%
+	mkdir %APIM_IS_PLUGIN_AUDIT_BACKUP%\webapps
+   	mkdir %APIM_IS_PLUGIN_AUDIT_BACKUP%\dropins
+	echo [INFO] APIM-IS-PLUGIN audit folder %APIM_IS_PLUGIN_AUDIT% is created
+)
+
+echo [INFO] Backup original product files..
+if exist %APIM_IS_PLUGIN_AUDIT_BACKUP%\webapps\keymanager-operations\ (
+	rmdir /s /q %APIM_IS_PLUGIN_AUDIT_BACKUP%\webapps\keymanager-operations
+	echo [INFO] Removed old keymanager-operations directory from %APIM_IS_PLUGIN_AUDIT_BACKUP%\webapps
+)
+
+if exist %IS_HOME%\repository\deployment\server\webapps\keymanager-operations\ (
+	xcopy /i /e %IS_HOME%\repository\deployment\server\webapps\keymanager-operations %APIM_IS_PLUGIN_AUDIT_BACKUP%\webapps\keymanager-operations\
+)
+
+if exist %IS_HOME%\repository\deployment\server\webapps\keymanager-operations.war (
+	copy %IS_HOME%\repository\deployment\server\webapps\keymanager-operations.war %APIM_IS_PLUGIN_AUDIT_BACKUP%\webapps
+)
+
+if exist %IS_HOME%\repository\components\dropins\wso2is.key.manager.core-1.0.16*.jar (
+	copy %IS_HOME%\repository\components\dropins\wso2is.key.manager.core-1.0.16*.jar %APIM_IS_PLUGIN_AUDIT_BACKUP%\dropins
+)
+if exist %IS_HOME%\repository\components\dropins\wso2is.key.manager.core_1.0.16*.jar (
+	copy %IS_HOME%\repository\components\dropins\wso2is.key.manager.core_1.0.16*.jar %APIM_IS_PLUGIN_AUDIT_BACKUP%\dropins
+)
+
+if exist %IS_HOME%\repository\components\dropins\wso2is.notification.event.handlers-1.0.16*.jar (
+	copy %IS_HOME%\repository\components\dropins\wso2is.notification.event.handlers-1.0.16*.jar %APIM_IS_PLUGIN_AUDIT_BACKUP%\dropins
+)
+if exist %IS_HOME%\repository\components\dropins\wso2is.notification.event.handlers_1.0.16*.jar (
+	copy %IS_HOME%\repository\components\dropins\wso2is.notification.event.handlers_1.0.16*.jar %APIM_IS_PLUGIN_AUDIT_BACKUP%\dropins
+)
+
+echo [INFO] Clean up extracted webapps..
+if exist %IS_HOME%\repository\deployment\server\webapps\keymanager-operations\ (
+	rmdir /s /q %IS_HOME%\repository\deployment\server\webapps\keymanager-operations\
+)
+
+echo [INFO] Clean up keymanager-operations.war
+if exist %IS_HOME%\repository\deployment\server\webapps\keymanager-operations.war (
+	del %IS_HOME%\repository\deployment\server\webapps\keymanager-operations.war
+)
+
+echo [INFO] Clean up key-manager jars from dropins..
+if exist %IS_HOME%\repository\components\dropins\wso2is.key.manager.core-1.0.16*.jar (
+	del %IS_HOME%\repository\components\dropins\wso2is.key.manager.core-1.0.16*.jar
+)
+echo [INFO] Clean up key-manager jars from dropins..
+if exist %IS_HOME%\repository\components\dropins\wso2is.key.manager.core_1.0.16*.jar (
+	del %IS_HOME%\repository\components\dropins\wso2is.key.manager.core_1.0.16*.jar
+)
+
+if exist %IS_HOME%\repository\components\dropins\wso2is.notification.event.handlers-1.0.16*.jar (
+	del %IS_HOME%\repository\components\dropins\wso2is.notification.event.handlers-1.0.16*.jar
+)
+if exist %IS_HOME%\repository\components\dropins\wso2is.notification.event.handlers_1.0.16*.jar (
+	del %IS_HOME%\repository\components\dropins\wso2is.notification.event.handlers_1.0.16*.jar
+)
+
+echo [INFO] Copying APIM Key Manager connector artifacts to dropins
+echo ================================================
+xcopy /i /s /y %APIM_IS_PLUGIN_HOME%dropins %IS_HOME%\repository\components\dropins\
+
+echo [INFO] Copying APIM Key Manager connector artifacts to webapps
+echo ================================================
+copy %APIM_IS_PLUGIN_HOME%webapps\keymanager-operations.war %IS_HOME%\repository\deployment\server\webapps\
+
+echo [INFO] Completed!
+echo %date% - %USERNAME% - "WSO2 APIM-IS Plugin 4.1.0" >> %APIM_IS_PLUGIN_AUDIT%\merge_audit.log

--- a/modules/distribution/apim-is-plugin/bin/merge.sh
+++ b/modules/distribution/apim-is-plugin/bin/merge.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# ------------------------------------------------------------------------
+#
+# Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 Inc. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained
+# herein is strictly forbidden, unless permitted by WSO2 in accordance with
+# the WSO2 Commercial License available at http://wso2.com/licenses. For specific
+# language governing the permissions and limitations under this license,
+# please see the license as well as any agreement you’ve entered into with
+# WSO2 governing the purchase of this software and any associated services.
+#
+# ------------------------------------------------------------------------
+
+# merge.sh script copy the APIM-IS-PLUGIN artifacts on top of WSO2 IS
+#
+# merge.sh <IS-HOME>
+
+IS_HOME=$1
+
+# set APIM-IS-PLUGIN_HOME home
+cd ../
+APIM_IS_PLUGIN_HOME=$(pwd)
+echo "[INFO] WSO2 APIM-IS Plugin home is: ${APIM_IS_PLUGIN_HOME}"
+
+# set product home
+if [ "${IS_HOME}" == "" ];
+  then
+    echo "[ERROR] IS_HOME is not specified, please try again with correct arguments";
+    exit 2;
+fi
+echo "[INFO] Product IS home is: ${IS_HOME}"
+
+# validate product home
+if [ ! -d "${IS_HOME}/repository/components" ]; then
+  echo "[ERROR] Specified product path is not a valid carbon product path";
+  exit 2;
+else
+  echo "[INFO] Valid carbon product path";
+fi
+
+# create the apim-IS-plugin folder in product home, if not exist
+APIM_IS_PLUGIN_AUDIT="${IS_HOME}"/apim-is-plugin
+APIM_IS_PLUGIN_AUDIT_BACKUP="${APIM_IS_PLUGIN_AUDIT}"/backup
+if [ ! -d  "${APIM_IS_PLUGIN_AUDIT}" ]; then
+   mkdir -p "${APIM_IS_PLUGIN_AUDIT_BACKUP}"
+   mkdir -p "${APIM_IS_PLUGIN_AUDIT_BACKUP}"/webapps
+   mkdir -p "${APIM_IS_PLUGIN_AUDIT_BACKUP}"/dropins
+   echo "[INFO] APIM-IS-PLUGIN audit folder [""${APIM_IS_PLUGIN_AUDIT}""] is created";
+else
+   echo "[INFO] APIM-IS-PLUGIN audit folder is present at [""${APIM_IS_PLUGIN_AUDIT}""]";
+   if [ -d  "${APIM_IS_PLUGIN_AUDIT_BACKUP}" ]; then
+     rm -rf "${APIM_IS_PLUGIN_AUDIT_BACKUP}"/webapps/*
+     rm -rf "${APIM_IS_PLUGIN_AUDIT_BACKUP}"/dropins/*
+   fi
+fi
+
+echo "[INFO] Backup original product files.."
+cp -R "${IS_HOME}"/repository/deployment/server/webapps/keymanager-operations/ "${APIM_IS_PLUGIN_AUDIT_BACKUP}"/webapps/keymanager-operations 2>/dev/null
+cp "${IS_HOME}"/repository/deployment/server/webapps/keymanager-operations.war "${APIM_IS_PLUGIN_AUDIT_BACKUP}"/webapps 2>/dev/null
+cp "${IS_HOME}"/repository/components/dropins/wso2is.key.manager.core-1.0.16*.jar "${APIM_IS_PLUGIN_AUDIT_BACKUP}"/dropins 2>/dev/null
+cp "${IS_HOME}"/repository/components/dropins/wso2is.key.manager.core_1.0.16*.jar "${APIM_IS_PLUGIN_AUDIT_BACKUP}"/dropins 2>/dev/null
+cp "${IS_HOME}"/repository/components/dropins/wso2is.notification.event.handlers-1.0.16*.jar "${APIM_IS_PLUGIN_AUDIT_BACKUP}"/dropins 2>/dev/null
+cp "${IS_HOME}"/repository/components/dropins/wso2is.notification.event.handlers_1.0.16*.jar "${APIM_IS_PLUGIN_AUDIT_BACKUP}"/dropins 2>/dev/null
+
+echo "[INFO] Clean up extracted webapps.."
+rm -rf "${IS_HOME}"/repository/deployment/server/webapps/keymanager-operations/
+
+echo "[INFO] Clean up keymanager-operations.war"
+rm -f "${IS_HOME}"/repository/deployment/server/webapps/keymanager-operations.war
+
+echo "[INFO] Clean up key-manager jars from dropins.."
+rm -f "${IS_HOME}"/repository/components/dropins/wso2is.key.manager.core-1.0.16*.jar
+rm -f "${IS_HOME}"/repository/components/dropins/wso2is.notification.event.handlers-1.0.16*.jar
+rm -f "${IS_HOME}"/repository/components/dropins/wso2is.key.manager.core_1.0.16*.jar
+rm -f "${IS_HOME}"/repository/components/dropins/wso2is.notification.event.handlers_1.0.16*.jar
+
+echo "[INFO] Copying APIM Key Manager connector artifacts to dropins"
+echo "================================================"
+cp -r "${APIM_IS_PLUGIN_HOME}"/dropins/* "${IS_HOME}/repository/components/dropins"/
+
+echo "[INFO] Copying APIM Key Manager connector artifacts to webapps"
+echo "================================================"
+cp -r "${APIM_IS_PLUGIN_HOME}"/webapps/keymanager-operations.war "${IS_HOME}/repository/deployment/server/webapps"/
+
+echo "[INFO] Completed!"
+echo "$(date)" - "$USER" - "WSO2 APIM-IS Plugin 4.1.0" | tee -a "${APIM_IS_PLUGIN_AUDIT}"/merge_audit.log >/dev/null

--- a/modules/distribution/apim-is-plugin/pom.xml
+++ b/modules/distribution/apim-is-plugin/pom.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+  ~  Copyright (c) 2022, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+  ~
+  ~  WSO2 Inc. licenses this file to you under the Apache License,
+  ~  Version 2.0 (the "License"); you may not use this file except
+  ~  in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing,
+  ~  software distributed under the License is distributed on an
+  ~  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~  KIND, either express or implied.  See the License for the
+  ~  specific language governing permissions and limitations
+  ~  under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.wso2.am</groupId>
+        <artifactId>am-parent</artifactId>
+        <version>4.1.0-SNAPSHOT</version>
+        <relativePath>../../../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>wso2apim-is-plugin</artifactId>
+    <packaging>pom</packaging>
+    <name>WSO2 API Manager - APIM IS Plugin Module</name>
+    <url>http://wso2.com/products/api-manager</url>
+
+    <licenses>
+        <license>
+            <name>Apache License Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+        </license>
+    </licenses>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-is-km-core-jar</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.wso2.km.ext.wso2is</groupId>
+                                    <artifactId>wso2is.key.manager.core</artifactId>
+                                    <version>${wso2is.km.version}</version>
+                                    <type>jar</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>target/apim-is-plugin-resources/dropins</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.wso2.km.ext.wso2is</groupId>
+                                    <artifactId>wso2is.notification.event.handlers</artifactId>
+                                    <version>${wso2is.km.version}</version>
+                                    <type>jar</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>target/apim-is-plugin-resources/dropins</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.wso2.km.ext.wso2is</groupId>
+                                    <artifactId>org.wso2.is.key.manager.operations.endpoint</artifactId>
+                                    <version>${wso2is.km.version}</version>
+                                    <type>war</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>target/apim-is-plugin-resources/webapps</outputDirectory>
+                                    <destFileName>keymanager-operations.war</destFileName>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <appendAssemblyId>false</appendAssemblyId>
+                            <descriptors>
+                                <descriptor>assembly/bin.xml</descriptor>
+                            </descriptors>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <product.version>${project.version}</product.version>
+    </properties>
+</project>

--- a/modules/distribution/apim-is-plugin/updates/product.txt
+++ b/modules/distribution/apim-is-plugin/updates/product.txt
@@ -1,0 +1,1 @@
+wso2apim-is-plugin-${product.version}


### PR DESCRIPTION
This PR adds apim-is-plugin source code to product-apim repo. This plugin can be used to install (U2 updated) key-manager artefacts on top of an WSO2 IS pack, as a step in configuring IS as key manager for APIM ([Doc](https://apim.docs.wso2.com/en/3.2.0/install-and-setup/setup/distributed-deployment/configuring-wso2-identity-server-as-a-key-manager/#step-4-configure-wso2-is-with-wso2-api-m)).

The generated zip file will contain:

``` sh
wso2apim-is-plugin-x.x.x
├── LICENSE.txt
├── README.md
├── bin
│     ├── merge.bat
│     ├── merge.sh
│     ├── wso2update_darwin
│     ├── wso2update_linux
│     └── wso2update_windows.exe
├── updates
│     └── product.txt
├── dropins
│     ├── wso2is.key.manager.core-x.x.x.jar
│     └── wso2is.notification.event.handlers-x.x.x.jar
└── webapps
      └── keymanager-operations.war
```