### PR TITLE
Update carbon-deployment version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1316,7 +1316,7 @@
         <saml.common.util.version.range>[1.0.0,2.0.0)</saml.common.util.version.range>
 
         <!-- carbon deployment -->
-        <carbon.deployment.version>4.11.3</carbon.deployment.version>
+        <carbon.deployment.version>4.11.4</carbon.deployment.version>
 
 
         <!--jaggery-->


### PR DESCRIPTION
This PR updates the carbon-deployment version in order to upgrade the Spring version used in the product.

Related PR: https://github.com/wso2/carbon-deployment/pull/373