### PR TITLE
Add Catalina remoteIpValve Configuration to the Product

### DIFF
--- a/modules/distribution/product/src/main/resources/conf/templates/repository/conf/tomcat/catalina-server.xml.j2
+++ b/modules/distribution/product/src/main/resources/conf/templates/repository/conf/tomcat/catalina-server.xml.j2
@@ -60,6 +60,20 @@
 
             <Host name="localhost" unpackWARs="true" deployOnStartup="false" autoDeploy="false"
                   appBase="${carbon.home}/repository/deployment/server/webapps/">
+                {% if catalinaValves.remoteIpValve.enable is sameas true %}
+                <!-- This should be defined before the AuthenticationValve to get the real client IP addresses via request headers. -->
+                <Valve
+                    className="org.apache.catalina.valves.RemoteIpValve"
+                    internalProxies="{{catalinaValves.remoteIpValve.internalProxies}}"
+                    remoteIpHeader="{{catalinaValves.remoteIpValve.remoteIpHeader}}"
+                    protocolHeader="{{catalinaValves.remoteIpValve.protocolHeader}}"
+                    proxiesHeader="{{catalinaValves.remoteIpValve.proxiesHeader}}"
+                    trustedProxies="{{catalinaValves.remoteIpValve.trustedProxies}}"
+                    {% for property,value in catalinaValves.remoteIpValve.properties.items() %}
+                    {{property}}="{{value}}"
+                    {% endfor %}
+                />
+                {% endif %}
                 <Valve className="org.wso2.carbon.tomcat.ext.valves.RequestCorrelationIdValve"
                        headerToCorrelationIdMapping="{'activityid':'Correlation-ID'}" queryToCorrelationIdMapping="{'RelayState':'Correlation-ID'}"/>
                 <Valve className="org.wso2.carbon.tomcat.ext.valves.CarbonContextCreatorValve"/>


### PR DESCRIPTION
## Purpose
- With `org.apache.catalina.valves.RemoteIpValve` [1], the real client IP addresses can be added to request headers instead of IP addresses presented by a proxy or a load balancer. This valve can be enabled by the `deployment.toml` file by adding the following configuration.
```
[catalinaValves.remoteIpValve]
enable=true
remoteIpHeader="X-Forwarded-For"
protocolHeader="X-Forwarded-Proto"
proxiesHeader="X-Forwarded-By"
```
- Users can add custom properties to RemoteIpValve config by adding the following configuration in the `deployment.toml`
```
[catalinaValves.remoteIpValve.properties]
customProperty1 = "customVal1"
customProperty2 = "customVal2"
```

- Related Issue: https://github.com/wso2/product-apim/issues/12859



[1] https://tomcat.apache.org/tomcat-8.5-doc/api/org/apache/catalina/valves/RemoteIpValve.html