### PR TITLE
Add custom message builders and formatters to axis2_client.xml.j2

### DIFF
--- a/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/axis2_client.xml.j2
+++ b/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/axis2_client.xml.j2
@@ -114,6 +114,12 @@
                           class="org.apache.axis2.json.JSONBadgerfishMessageFormatter"/>
         <messageFormatter contentType="text/javascript"
                           class="org.apache.axis2.json.JSONMessageFormatter"/>
+
+    {% for message_formatter in custom_message_formatters %}
+        <messageFormatter contentType="{{message_formatter.content_type}}"
+                          class="{{message_formatter.class}}"/>
+    {% endfor %}
+
     </messageFormatters>
 
     <!-- ================================================= -->
@@ -137,6 +143,12 @@
         Please uncomment to Receive messages in multipart/form-data format-->
         <!--<messageBuilder contentType="multipart/form-data"-->
         <!--class="org.apache.axis2.builder.MultipartFormDataBuilder"/>-->
+
+    {% for message_builder in custom_message_builders %}
+        <messageBuilder contentType="{{message_builder.content_type}}"
+                          class="{{message_builder.class}}"/>
+    {% endfor %}
+
     </messageBuilders>
 
     <!-- ================================================= -->


### PR DESCRIPTION
## Purpose

- Resolves https://github.com/wso2/product-apim/issues/12216

This PR adds the capability to add custom message builders and formatters through the template file of axis2_client.xml.

To enable custom message builders or formatters, we can utilize the following configurations:

```
[[custom_message_builders]]
content_type = "<content_type>"
class = "<message_builder_class>"

[[custom_message_formatters]]
content_type = "<content_type>"
class = "<message_formatter_class>"
```