### PR TITLE
Bumping the identity, identity inbound and synapse versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1293,7 +1293,7 @@
         <carbon.mediation.version>4.7.131</carbon.mediation.version>
 
         <!-- carbon identity -->
-        <carbon.identity.version>5.18.250</carbon.identity.version>
+        <carbon.identity.version>5.18.251</carbon.identity.version>
         <carbon.identity.governance.version>1.4.100</carbon.identity.governance.version>
         <carbon.identity.event.handler.account.lock.version>1.4.37</carbon.identity.event.handler.account.lock.version>
         <carbon.identity.event.handler.notification.version>1.3.29</carbon.identity.event.handler.notification.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1297,7 +1297,7 @@
         <carbon.identity.governance.version>1.4.100</carbon.identity.governance.version>
         <carbon.identity.event.handler.account.lock.version>1.4.37</carbon.identity.event.handler.account.lock.version>
         <carbon.identity.event.handler.notification.version>1.3.29</carbon.identity.event.handler.notification.version>
-        <carbon.identity-inbound-auth-oauth.version>6.4.176</carbon.identity-inbound-auth-oauth.version>
+        <carbon.identity-inbound-auth-oauth.version>6.4.177</carbon.identity-inbound-auth-oauth.version>
         <carbon.identity-inbound-auth-sts.version>5.6.21</carbon.identity-inbound-auth-sts.version>
         <carbon.identity-data-publisher-oauth.version>1.3.5</carbon.identity-data-publisher-oauth.version>
         <carbon.identity-user-ws.version>5.4.6</carbon.identity-user-ws.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1336,7 +1336,7 @@
         <opencsv.version>1.8</opencsv.version>
         <poi.version>3.0-FINAL</poi.version>
         <woden.version>1.0.0.M8-wso2v1</woden.version>
-        <synapse.version>2.1.7-wso2v287</synapse.version>
+        <synapse.version>2.1.7-wso2v290</synapse.version>
         <passthru.transport.patch.version>1.0.2</passthru.transport.patch.version>
         <axis2.wso2.version>1.6.1-wso2v76</axis2.wso2.version>
         <axiom.wso2.version>1.2.11-wso2v16</axiom.wso2.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1267,7 +1267,7 @@
         <carbon.apimgt.ui.version>9.0.311</carbon.apimgt.ui.version>
 
         <!-- APIM Component Version -->
-        <carbon.apimgt.version>9.22.5</carbon.apimgt.version>
+        <carbon.apimgt.version>9.22.7</carbon.apimgt.version>
 
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1267,7 +1267,7 @@
         <carbon.apimgt.ui.version>9.0.311</carbon.apimgt.ui.version>
 
         <!-- APIM Component Version -->
-        <carbon.apimgt.version>9.22.7</carbon.apimgt.version>
+        <carbon.apimgt.version>9.22.8</carbon.apimgt.version>
 
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 
@@ -1336,7 +1336,7 @@
         <opencsv.version>1.8</opencsv.version>
         <poi.version>3.0-FINAL</poi.version>
         <woden.version>1.0.0.M8-wso2v1</woden.version>
-        <synapse.version>2.1.7-wso2v290</synapse.version>
+        <synapse.version>2.1.7-wso2v289</synapse.version>
         <passthru.transport.patch.version>1.0.2</passthru.transport.patch.version>
         <axis2.wso2.version>1.6.1-wso2v76</axis2.wso2.version>
         <axiom.wso2.version>1.2.11-wso2v16</axiom.wso2.version>


### PR DESCRIPTION
## Purpose
Bumping the identity, identity inbound and synapse versions with regard to the changes done in [1], [2] and [3] accordingly.

## Goals
Bumping the identity, identity inbound and synapse versions.

## Approach
- Bumped the carbon identity version to reflect the change in [1].
- Bumped the identity inbound version to reflect the change in [2].
- Bumped the synapse version to reflect the change in [3].

## Related PRs
- https://github.com/wso2/carbon-apimgt/pull/11295

[1] https://github.com/wso2/carbon-identity-framework/pull/4066
[2] https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/1858
[3] https://github.com/wso2/wso2-synapse/pull/1966
