### PR TITLE
Add an integration test for correlation logging

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/logging/CorrelationLoggingTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/logging/CorrelationLoggingTest.java
@@ -284,7 +284,7 @@ public class CorrelationLoggingTest extends APIManagerLifecycleBaseTest {
         HttpClient client = HttpClientBuilder.create().setHostnameVerifier(new AllowAllHostnameVerifier()).build();
         HttpGet request = new HttpGet(getAPIInvocationURLHttp(API_CONTEXT, API_VERSION));
         request.setHeader("Authorization", "Bearer " + accessToken);
-        request.setHeader("activityid", "9e3ec6ed-2a37-4b20-8dd4-d5fbc754a7d9");
+        request.setHeader("activityid", CORRELATION_ID);
         org.apache.http.HttpResponse response = client.execute(request);
         assertEquals(response.getStatusLine().getStatusCode(), HTTP_RESPONSE_CODE_OK,
                 "Invocation fails for GET request");

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/logging/CorrelationLoggingTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/logging/CorrelationLoggingTest.java
@@ -1,0 +1,386 @@
+/*
+ * Copyright (c) 2022, WSO2 LLC (http://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.am.integration.tests.logging;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.conn.ssl.AllowAllHostnameVerifier;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+import org.wso2.am.integration.clients.store.api.v1.dto.ApplicationDTO;
+import org.wso2.am.integration.clients.store.api.v1.dto.ApplicationKeyDTO;
+import org.wso2.am.integration.clients.store.api.v1.dto.ApplicationKeyGenerateRequestDTO;
+import org.wso2.am.integration.test.utils.base.APIMIntegrationConstants;
+import org.wso2.am.integration.test.utils.bean.APIRequest;
+import org.wso2.am.integration.test.utils.http.HTTPSClientUtils;
+import org.wso2.am.integration.tests.api.lifecycle.APIManagerLifecycleBaseTest;
+import org.wso2.am.integration.tests.restapi.RESTAPITestConstants;
+import org.wso2.carbon.automation.engine.context.AutomationContext;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.carbon.automation.test.utils.http.client.HttpResponse;
+import org.wso2.carbon.integration.common.utils.mgt.ServerConfigurationManager;
+import org.wso2.carbon.utils.ServerConstants;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.assertEquals;
+
+public class CorrelationLoggingTest extends APIManagerLifecycleBaseTest {
+    private static final Log log = LogFactory.getLog(CorrelationLoggingTest.class);
+    private String apiId;
+    private String applicationId;
+    private ServerConfigurationManager serverConfigurationManager;
+
+
+    private Map<String, String> header = new HashMap<>();
+    BufferedReader bufferedReader;
+
+    private final String API_CONTEXT = "correlationloggingtest";
+    private final String API_VERSION = "1.0.0";
+    private final String APPLICATION_NAME = "CorrelationTestApp";
+    private final String API_END_POINT_POSTFIX_URL = "xmlapi";
+    private String accessToken;
+    private Boolean httpLog,jdbcLog,synapseLog,methodCallsLog;
+
+    @Factory(dataProvider = "userModeDataProvider")
+    public CorrelationLoggingTest(TestUserMode userMode) throws Exception {
+        this.userMode = userMode;
+        byte[] encodedBytes = Base64.encodeBase64(RESTAPITestConstants.BASIC_AUTH_HEADER.getBytes(StandardCharsets.UTF_8));
+        header.put("Authorization", "Basic " + new String(encodedBytes, StandardCharsets.UTF_8));
+        header.put("Content-Type", "application/json");
+        header.put("Accept","application/json" );
+        String correlationLogFilePath =
+                System.getProperty(ServerConstants.CARBON_HOME) + File.separator + "repository" + File.separator
+                        + "logs" + File.separator + "correlation.log";
+        bufferedReader = new BufferedReader(new FileReader(correlationLogFilePath));
+    }
+
+    @DataProvider
+    public static Object[][] userModeDataProvider() {
+        return new Object[][]{new Object[]{TestUserMode.SUPER_TENANT_ADMIN}, new Object[]{TestUserMode.TENANT_ADMIN}};
+    }
+
+    @BeforeClass(alwaysRun = true)
+    public void initialize() throws Exception {
+        super.init();
+        AutomationContext superTenantKeyManagerContext =
+                new AutomationContext(APIMIntegrationConstants.AM_PRODUCT_GROUP_NAME,
+                        APIMIntegrationConstants.AM_KEY_MANAGER_INSTANCE, TestUserMode.SUPER_TENANT_ADMIN);
+        serverConfigurationManager = new ServerConfigurationManager(superTenantKeyManagerContext);
+    }
+
+    @Test(groups = {"wso2.am" }, description = "Testing the default correlation configs using the devops API ")
+    public void testRetrieveDefaultCorrelationLoggingConfigsTest() throws Exception {
+
+        //Retrieve default correlation logs configs from the GET method of the configs resource in devops API
+        HttpResponse loggingResponse =
+                HTTPSClientUtils.doGet(getStoreURLHttps() + "api/am/devops/v0/config/correlation", header);
+
+        String expectedResponse = "{\"components\":[{\"name\":\"http\",\"enabled\":\"false\",\"properties\":[]}," +
+            "{\"name\":\"jdbc\",\"enabled\":\"false\",\"properties\":[{\"name\":\"deniedThreads\",\"value\":" +
+            "[\"MessageDeliveryTaskThreadPool\",\"HumanTaskServer\",\"BPELServer\",\"CarbonDeploymentSchedulerThread\"]}]}," +
+            "{\"name\":\"ldap\",\"enabled\":\"false\",\"properties\":[]}," +
+            "{\"name\":\"synapse\",\"enabled\":\"false\",\"properties\":[]}," +
+            "{\"name\":\"method-calls\",\"enabled\":\"false\",\"properties\":[]}]}";
+        Assert.assertEquals(loggingResponse.getData(),expectedResponse);
+
+        String logLine;
+        while ((logLine = bufferedReader.readLine()) != null) {
+            log.info("Start log : " + logLine);
+        }
+
+        // Create an application
+        log.info("Creating an application");
+        HttpResponse applicationResponse = restAPIStore.createApplication(APPLICATION_NAME,
+                "Test Application for Correlation Logs Test", APIMIntegrationConstants.APPLICATION_TIER.UNLIMITED,
+                ApplicationDTO.TokenTypeEnum.JWT);
+        applicationId = applicationResponse.getData();
+
+        // Create an API and subscribe to it using created application
+        log.info("Creating a test API for CorrelationLoggingTest ");
+        APIRequest apiRequest;
+        String apiEndPointUrl = getAPIInvocationURLHttp(API_END_POINT_POSTFIX_URL, API_VERSION);
+        log.info("Creating an API request ");
+        String API_NAME = "CorrelationLoggingTestAPI";
+        apiRequest = new APIRequest(API_NAME, API_CONTEXT, new URL(apiEndPointUrl));
+        apiRequest.setVersion(API_VERSION);
+        apiRequest.setTiersCollection(APIMIntegrationConstants.API_TIER.UNLIMITED);
+        apiRequest.setTier(APIMIntegrationConstants.API_TIER.UNLIMITED);
+        String API_TAGS = "testTag1, testTag2, testTag3";
+        apiRequest.setTags(API_TAGS);
+        apiRequest.setProvider(user.getUserName());
+        log.info("Creating an API and Publishing");
+        apiId = createPublishAndSubscribeToAPIUsingRest(apiRequest, restAPIPublisher, restAPIStore,
+                applicationId, APIMIntegrationConstants.API_TIER.UNLIMITED);
+
+        ArrayList<String> grantTypes = new ArrayList<>();
+        grantTypes.add("client_credentials");
+        log.info("Generating keys");
+        ApplicationKeyDTO applicationKeyDTO = restAPIStore.generateKeys(applicationId, "3600", null,
+                ApplicationKeyGenerateRequestDTO.KeyTypeEnum.PRODUCTION, null, grantTypes);
+        assertNotNull(applicationKeyDTO.getToken());
+        accessToken = applicationKeyDTO.getToken().getAccessToken();
+    }
+
+
+    @Test(groups = {"wso2.am" }, description = "Testing enabling all correlation configs using the devops API ",
+    dependsOnMethods = { "testRetrieveDefaultCorrelationLoggingConfigsTest" })
+    public void testEnableAllCorrelationLoggingConfigsTest() throws Exception {
+
+        configureCorrelationLoggingComponent(new String[] {"http", "jdbc", "synapse", "ldap", "method-calls"}, true);
+
+        InvokeTestAPI();
+        // Validate Correlation Logs
+        String logLine = bufferedReader.readLine();
+        log.info(logLine);
+        HTTPSClientUtils.doGet(getStoreURLHttps() + "api/am/devops/v0/config/correlation", header);
+        Thread.sleep(5000);
+        resetAllLogs();
+        while ((logLine = bufferedReader.readLine()) != null) {
+            log.info("Enabled ALL Logs Components : " + logLine);
+            assertTrue(isSynapseLogLine(logLine) || isHTTPLogLine(logLine) ||
+                    isJDBCLogLine(logLine) || isMethodCallsLogLine(logLine) || logLine.contains("Started log handler"));
+        }
+        assertTrue(httpLog && jdbcLog && synapseLog && methodCallsLog);
+
+        configureCorrelationLoggingComponent(new String[] {"http", "jdbc", "synapse", "ldap", "method-calls"}, false);
+        Thread.sleep(5000);
+        while ((logLine = bufferedReader.readLine()) != null) {
+            log.info("Disabled ALL Logs Components : " + logLine);
+        }
+    }
+
+
+    @Test(groups = {"wso2.am" }, description = "Testing enabling specific correlation configs using the devops API ",
+            dependsOnMethods = { "testEnableAllCorrelationLoggingConfigsTest" })
+    public void testSpecificCorrelationLoggingConfigsTest() throws Exception {
+
+        //Test HTTP
+        log.info("Enabling HTTP component correlation logs");
+        configureCorrelationLoggingComponent(new String[]{"http"}, true);
+        String logLine;
+        InvokeTestAPI();
+        while ((logLine = bufferedReader.readLine()) != null) {
+            log.info("HTTP Logs Check " + logLine);
+            assertTrue(isHTTPLogLine(logLine));
+        }
+        log.info("Disabling HTTP component correlation logs");
+        configureCorrelationLoggingComponent(new String[] { "http" }, false);
+        Thread.sleep(1000);
+        while ((logLine = bufferedReader.readLine()) != null) {
+            assertTrue(isHTTPLogLine(logLine));
+        }
+
+        //test JDBC
+        log.info("Enabling JDBC component correlation logs");
+        configureCorrelationLoggingComponent(new String[] { "jdbc" }, true);
+        while ((logLine = bufferedReader.readLine()) != null) {
+            assertTrue(isJDBCLogLine(logLine));
+        }
+        log.info("Disabling JDBC component correlation logs");
+        configureCorrelationLoggingComponent(new String[] { "jdbc" }, false);
+        Thread.sleep(1000);
+        while ((logLine = bufferedReader.readLine()) != null) {
+            assertTrue(isJDBCLogLine(logLine));
+        }
+
+        //test Method-calls
+        log.info("Enabling Method-calls component correlation logs");
+        configureCorrelationLoggingComponent(new String[] { "method-calls" }, true);
+        InvokeTestAPI();
+        while ((logLine = bufferedReader.readLine()) != null) {
+            assertTrue(isMethodCallsLogLine(logLine));
+        }
+        log.info("Disabling Method-calls component correlation logs");
+        configureCorrelationLoggingComponent(new String[] { "method-calls" }, false);
+        Thread.sleep(1000);
+        while ((logLine = bufferedReader.readLine()) != null) {
+            assertTrue(isMethodCallsLogLine(logLine));
+        }
+
+        //test Synapse
+        log.info("Enabling Synapse component correlation logs");
+        configureCorrelationLoggingComponent(new String[] { "synapse" }, true);
+        InvokeTestAPI();
+        while ((logLine = bufferedReader.readLine()) != null) {
+            assertTrue(isSynapseLogLine(logLine));
+        }
+        log.info("Disabling Synapse component correlation logs");
+        configureCorrelationLoggingComponent(new String[] { "synapse" }, false);
+        Thread.sleep(1000);
+        while ((logLine = bufferedReader.readLine()) != null) {
+            assertTrue(isSynapseLogLine(logLine));
+        }
+    }
+
+    @Test(groups = {"wso2.am" }, description = "Testing persisted correlation component configurations ",
+            dependsOnMethods = { "testSpecificCorrelationLoggingConfigsTest" })
+    public void testPersistedCorrelationConfigs() throws Exception {
+        log.info("Enabling http, method-calls correlation component logs before a restart");
+        configureCorrelationLoggingComponent(new String[] { "http", "method-calls" }, true);
+        HTTPSClientUtils.doGet(getStoreURLHttps() + "api/am/devops/v0/config/correlation", header);
+        InvokeTestAPI();
+        String logLine;
+        resetAllLogs();
+        while ((logLine = bufferedReader.readLine()) != null) {
+            assertTrue(isHTTPLogLine(logLine) || isMethodCallsLogLine(logLine));
+        }
+
+        serverConfigurationManager.restartGracefully();
+        Thread.sleep(10000);
+
+        while ((logLine = bufferedReader.readLine()) != null) {
+            if (logLine.contains("Started log handler")) {
+                break;
+            }
+        }
+
+        resetAllLogs();
+        while ((logLine = bufferedReader.readLine()) != null) {
+            assertTrue(isHTTPLogLine(logLine) || isMethodCallsLogLine(logLine));
+        }
+        assertTrue(httpLog && methodCallsLog);
+
+        configureCorrelationLoggingComponent(new String[] { "http", "method-calls" }, false);
+        while ((logLine = bufferedReader.readLine()) != null) {
+            assertTrue(isHTTPLogLine(logLine) || isMethodCallsLogLine(logLine));
+        }
+    }
+
+    private void InvokeTestAPI() throws Exception {
+        HttpClient client = HttpClientBuilder.create().setHostnameVerifier(new AllowAllHostnameVerifier()).build();
+        HttpGet request = new HttpGet(getAPIInvocationURLHttp(API_CONTEXT, API_VERSION));
+        request.setHeader("Authorization", "Bearer " + accessToken);
+        org.apache.http.HttpResponse response = client.execute(request);
+        assertEquals(response.getStatusLine().getStatusCode(), HTTP_RESPONSE_CODE_OK,
+                "Invocation fails for GET request");
+        Thread.sleep(500);
+    }
+
+    private void configureCorrelationLoggingComponent(String[] componentNames, Boolean enable) throws Exception {
+        String[] DEFAULT_DENIED_THREADS = {"MessageDeliveryTaskThreadPool", "HumanTaskServer",
+                "BPELServer", "CarbonDeploymentSchedulerThread"};
+        String[] DEFAULT_COMPONENTS  = {"http", "jdbc", "ldap", "synapse", "method-calls"};
+
+        List<String> components = Arrays.asList(componentNames);
+
+        JSONObject payload = new JSONObject();
+        JSONArray componentArray = new JSONArray();
+        for (String c: DEFAULT_COMPONENTS) {
+            JSONObject componentConfigs = new JSONObject();
+            componentConfigs.put("name", c);
+            if (components.contains(c)) {
+                componentConfigs.put("enabled", Boolean.toString(enable));
+            } else {
+                componentConfigs.put("enabled", "false");
+            }
+
+            JSONArray properties = new JSONArray();
+            if (c.equals("jdbc")) {
+                JSONObject property = new JSONObject();
+                JSONArray deniedThreads = new JSONArray();
+                property.put("name", "deniedThreads");
+                for (String s : DEFAULT_DENIED_THREADS) {
+                    deniedThreads.put(s);
+                }
+                property.put("value", deniedThreads);
+                properties.put(property);
+            }
+            componentConfigs.put("properties", properties);
+            componentArray.put(componentConfigs);
+        }
+
+        payload.put("components", componentArray);
+        HttpResponse httpResponse =  HTTPSClientUtils.doPut(getStoreURLHttps() + "api/am/devops/v0/config/correlation",
+                header, payload.toString());
+
+        assertEquals(httpResponse.getData(), payload.toString());
+
+        httpResponse =
+                HTTPSClientUtils.doGet(getStoreURLHttps() + "api/am/devops/v0/config/correlation", header);
+        assertEquals(httpResponse.getData(), payload.toString());
+        Thread.sleep(1000);
+    }
+
+
+    private boolean isSynapseLogLine(String logLine) {
+        Boolean status =  (logLine.contains("HTTP State Transition")   ||  logLine.contains("ROUND-TRIP LATENCY")  ||
+                logLine.contains("Thread switch latency")   ||  logLine.contains("BACKEND LATENCY"));
+        if (status) {
+            synapseLog = true;
+        }
+        return status;
+    }
+
+    private boolean isHTTPLogLine(String logLine) {
+        Boolean status =  (logLine.contains("HTTP-In-"));
+        if (status) {
+            httpLog = true;
+        }
+        return status;
+    }
+
+    private boolean isJDBCLogLine(String logLine) {
+        Boolean status =  (logLine.contains("jdbc"));
+        if (status) {
+            jdbcLog = true;
+        }
+        return status;
+    }
+
+    private boolean isMethodCallsLogLine(String logLine) {
+        boolean status =  (logLine.contains("METHOD") || logLine.contains(APPLICATION_NAME));
+        if (status) {
+            methodCallsLog = true;
+        }
+        return status;
+    }
+
+    private void resetAllLogs() {
+        httpLog = false;
+        synapseLog = false;
+        jdbcLog = false;
+        methodCallsLog = false;
+    }
+
+    @AfterClass(alwaysRun = true)
+    void destroy() throws Exception {
+        restAPIStore.deleteApplication(applicationId);
+        restAPIPublisher.deleteAPI(apiId);
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -427,6 +427,7 @@
         <parameter name="group" value="group1"/>
         <classes>
             <class name="org.wso2.am.integration.tests.logging.APILoggingTest"/>
+            <class name="org.wso2.am.integration.tests.logging.CorrelationLoggingTest"/>
         </classes>
     </test>
     <test name="apim-revoke-one-time-token-flow-tests" preserve-order="true" parallel="false" group-by-instances="true">

--- a/modules/integration/tests-integration/tests-benchmark/src/test/java/org/wso2/am/integration/tests/logging/CorrelationLoggingSystemEnabledTest.java
+++ b/modules/integration/tests-integration/tests-benchmark/src/test/java/org/wso2/am/integration/tests/logging/CorrelationLoggingSystemEnabledTest.java
@@ -1,0 +1,273 @@
+package org.wso2.am.integration.tests.logging;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.ws.rs.core.Response;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+import org.wso2.am.integration.clients.store.api.v1.dto.ApplicationDTO;
+import org.wso2.am.integration.clients.store.api.v1.dto.ApplicationKeyDTO;
+import org.wso2.am.integration.clients.store.api.v1.dto.ApplicationKeyGenerateRequestDTO;
+import org.wso2.am.integration.test.utils.base.APIMIntegrationBaseTest;
+import org.wso2.am.integration.test.utils.base.APIMIntegrationConstants;
+import org.wso2.am.integration.test.utils.bean.APILifeCycleAction;
+import org.wso2.am.integration.test.utils.bean.APIRequest;
+import org.wso2.am.integration.test.utils.http.HTTPSClientUtils;
+import org.wso2.am.integration.tests.restapi.RESTAPITestConstants;
+import org.wso2.carbon.automation.engine.annotations.ExecutionEnvironment;
+import org.wso2.carbon.automation.engine.annotations.SetEnvironment;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.carbon.automation.test.utils.http.client.HttpResponse;
+import org.wso2.carbon.utils.ServerConstants;
+
+@SetEnvironment(executionEnvironments = {
+        ExecutionEnvironment.STANDALONE }) public class CorrelationLoggingSystemEnabledTest
+        extends APIMIntegrationBaseTest {
+    private static final Log log = LogFactory.getLog(CorrelationLoggingSystemEnabledTest.class);
+    private final String API_VERSION_1_0_0 = "1.0.0";
+    private final String CORRELATION_CONFIG_PATH = "api/am/devops/v0/config/correlation";
+    private final String CORRELATION_ID = "9e3ec6ed-2a37-4b20-8dd4-d5fbc754a7d9";
+    private final String API_END_POINT_POSTFIX_URL = "am/sample/pizzashack/v1/api/menu";
+    private final String correlationLogFilePath =
+            System.getProperty(ServerConstants.CARBON_HOME) + File.separator + "repository" + File.separator + "logs"
+                    + File.separator + "correlation.log";
+    BufferedReader bufferedReader;
+    private String apiId;
+    ;
+    private String applicationId;
+    private String accessToken;
+    private String context = "context_correlation";
+    private Map<String, String> header = new HashMap<>();
+    private Map<String, String> requestHeaders = new HashMap<>();
+    private String apiEndPointUrl, providerName;
+    private Boolean httpLog, jdbcLog, synapseLog, methodCallsLog, correlationIDLog;
+
+    @Factory(dataProvider = "userModeDataProvider") public CorrelationLoggingSystemEnabledTest(TestUserMode userMode)
+            throws Exception {
+        this.userMode = userMode;
+        byte[] encodedBytes =
+                Base64.encodeBase64(RESTAPITestConstants.BASIC_AUTH_HEADER.getBytes(StandardCharsets.UTF_8));
+        header.put("Authorization", "Basic " + new String(encodedBytes, StandardCharsets.UTF_8));
+        header.put("Content-Type", "application/json");
+        header.put("Accept", "application/json");
+    }
+
+    @DataProvider public static Object[][] userModeDataProvider() {
+        return new Object[][] { new Object[] { TestUserMode.SUPER_TENANT_ADMIN },
+                new Object[] { TestUserMode.TENANT_ADMIN } };
+    }
+
+    @BeforeClass(alwaysRun = true) public void initialize() throws Exception {
+        super.init();
+        apiEndPointUrl = gatewayUrlsWrk.getWebAppURLHttp() + API_END_POINT_POSTFIX_URL;
+        providerName = user.getUserName();
+        CreateTestAPI();
+    }
+
+    @Test(groups = {
+            "wso2.am" }, description = "Testing the default correlation configs using the devops API ") public void testRetrieveDefaultCorrelationLoggingConfigsTest()
+            throws Exception {
+
+        //Retrieve default correlation logs configs from the GET method of the configs resource in devops API
+        HttpResponse loggingResponse = HTTPSClientUtils.doGet(getStoreURLHttps() + CORRELATION_CONFIG_PATH, header);
+
+        String expectedResponse = "{\"components\":[{\"name\":\"http\",\"enabled\":\"false\",\"properties\":[]},"
+                + "{\"name\":\"jdbc\",\"enabled\":\"false\",\"properties\":[{\"name\":\"deniedThreads\",\"value\":"
+                + "[\"MessageDeliveryTaskThreadPool\",\"HumanTaskServer\",\"BPELServer\",\"CarbonDeploymentSchedulerThread\"]}]},"
+                + "{\"name\":\"ldap\",\"enabled\":\"false\",\"properties\":[]},"
+                + "{\"name\":\"synapse\",\"enabled\":\"false\",\"properties\":[]},"
+                + "{\"name\":\"method-calls\",\"enabled\":\"false\",\"properties\":[]}]}";
+        Assert.assertEquals(loggingResponse.getData(), expectedResponse);
+
+        InvokeTestAPI();
+        Thread.sleep(5000);
+        bufferedReader = new BufferedReader(new FileReader(correlationLogFilePath));
+        while (bufferedReader.readLine() != null) {
+        }
+    }
+
+    @Test(groups = {
+            "wso2.am" }, description = "Testing the priroity of the correlation logging system parameter ", dependsOnMethods = {
+            "testRetrieveDefaultCorrelationLoggingConfigsTest" }) public void testPriorityCorrelationLoggingConfigsTest()
+            throws Exception {
+        String logLine;
+
+        // Enabling all the correlation components using the DevOps API and testing whether logs are still logging.
+        configureCorrelationLoggingComponent(new String[] { "http", "jdbc", "synapse", "ldap", "method-calls" }, true);
+        InvokeTestAPI();
+        Thread.sleep(10000);
+        resetAllLogs();
+        while ((logLine = bufferedReader.readLine()) != null) {
+            assertTrue(isSynapseLogLine(logLine) || isHTTPLogLine(logLine) || isJDBCLogLine(logLine)
+                    || isMethodCallsLogLine(logLine) || logLine.contains("Started log handler"));
+            if (logLine.contains(CORRELATION_ID)) {
+                correlationIDLog = true;
+            }
+        }
+        assertTrue(httpLog && jdbcLog && synapseLog && methodCallsLog && correlationIDLog);
+
+        // Disabling all the correlation components using the DevOps API and testing whether logs are still logging.
+        configureCorrelationLoggingComponent(new String[] { "http", "jdbc", "synapse", "ldap", "method-calls" }, false);
+        InvokeTestAPI();
+        Thread.sleep(10000);
+        resetAllLogs();
+        while ((logLine = bufferedReader.readLine()) != null) {
+            assertTrue(isSynapseLogLine(logLine) || isHTTPLogLine(logLine) || isJDBCLogLine(logLine)
+                    || isMethodCallsLogLine(logLine) || logLine.contains("Started log handler"));
+            if (logLine.contains(CORRELATION_ID)) {
+                correlationIDLog = true;
+            }
+        }
+        assertTrue(httpLog && jdbcLog && synapseLog && methodCallsLog && correlationIDLog);
+    }
+
+    private void InvokeTestAPI() throws Exception {
+        HttpResponse invokeResponse =
+                HTTPSClientUtils.doGet(getAPIInvocationURLHttps(context, API_VERSION_1_0_0) + "", requestHeaders);
+        assertEquals(invokeResponse.getResponseCode(), 200, "Response code mismatched");
+    }
+
+    private void CreateTestAPI() throws Exception {
+
+        APIRequest apiRequest;
+        String apiName = "CorrelationLogTest";
+
+        ArrayList grantTypes = new ArrayList();
+        apiRequest = new APIRequest(apiName, context, new URL(apiEndPointUrl));
+        apiRequest.setVersion(API_VERSION_1_0_0);
+        apiRequest.setTiersCollection(APIMIntegrationConstants.API_TIER.UNLIMITED);
+        apiRequest.setTier(APIMIntegrationConstants.API_TIER.UNLIMITED);
+        apiRequest.setProvider(providerName);
+        //Add the API using the API publisher.
+        HttpResponse apiResponse = restAPIPublisher.addAPI(apiRequest);
+        apiId = apiResponse.getData();
+        assertEquals(apiResponse.getResponseCode(), Response.Status.CREATED.getStatusCode(),
+                "Create API Response Code is invalid." + apiId);
+        assertNotNull(apiId, "Api ID is null");
+
+        grantTypes.add(APIMIntegrationConstants.GRANT_TYPE.CLIENT_CREDENTIAL);
+        restAPIPublisher.changeAPILifeCycleStatus(apiId, APILifeCycleAction.PUBLISH.getAction(), null);
+        createAPIRevisionAndDeployUsingRest(apiId, restAPIPublisher);
+        waitForAPIDeployment();
+        HttpResponse applicationResponse =
+                restAPIStore.createApplication("Application_Test", "Test Application For Correlation Logs",
+                        APIMIntegrationConstants.APPLICATION_TIER.UNLIMITED, ApplicationDTO.TokenTypeEnum.JWT);
+        applicationId = applicationResponse.getData();
+        assertNotNull(applicationId);
+        restAPIStore.subscribeToAPI(apiId, applicationId, APIMIntegrationConstants.APPLICATION_TIER.UNLIMITED);
+        ApplicationKeyDTO apiKeyDTO = restAPIStore.generateKeys(applicationId, "3600", null,
+                ApplicationKeyGenerateRequestDTO.KeyTypeEnum.PRODUCTION, null, grantTypes);
+        assertNotNull(apiKeyDTO);
+        accessToken = apiKeyDTO.getToken().getAccessToken();
+        assertNotNull(accessToken);
+        requestHeaders.put("Authorization", "Bearer " + accessToken);
+        requestHeaders.put("activityID", CORRELATION_ID);
+    }
+
+    private void configureCorrelationLoggingComponent(String[] componentNames, Boolean enable) throws Exception {
+        String[] DEFAULT_DENIED_THREADS =
+                { "MessageDeliveryTaskThreadPool", "HumanTaskServer", "BPELServer", "CarbonDeploymentSchedulerThread" };
+        String[] DEFAULT_COMPONENTS = { "http", "jdbc", "ldap", "synapse", "method-calls" };
+
+        List<String> components = Arrays.asList(componentNames);
+
+        JSONObject payload = new JSONObject();
+        JSONArray componentArray = new JSONArray();
+        for (String c : DEFAULT_COMPONENTS) {
+            JSONObject componentConfigs = new JSONObject();
+            componentConfigs.put("name", c);
+            if (components.contains(c)) {
+                componentConfigs.put("enabled", Boolean.toString(enable));
+            } else {
+                componentConfigs.put("enabled", "false");
+            }
+
+            JSONArray properties = new JSONArray();
+            if (c.equals("jdbc")) {
+                JSONObject property = new JSONObject();
+                JSONArray deniedThreads = new JSONArray();
+                property.put("name", "deniedThreads");
+                for (String s : DEFAULT_DENIED_THREADS) {
+                    deniedThreads.put(s);
+                }
+                property.put("value", deniedThreads);
+                properties.put(property);
+            }
+            componentConfigs.put("properties", properties);
+            componentArray.put(componentConfigs);
+        }
+
+        payload.put("components", componentArray);
+        HttpResponse httpResponse =
+                HTTPSClientUtils.doPut(getStoreURLHttps() + CORRELATION_CONFIG_PATH, header, payload.toString());
+        assertEquals(httpResponse.getData(), payload.toString());
+
+        Thread.sleep(1000);
+    }
+
+    private boolean isSynapseLogLine(String logLine) {
+        Boolean status = (logLine.contains("HTTP State Transition") || logLine.contains("ROUND-TRIP LATENCY")
+                || logLine.contains("Thread switch latency") || logLine.contains("BACKEND LATENCY"));
+        if (status) {
+            synapseLog = true;
+        }
+        return status;
+    }
+
+    private boolean isHTTPLogLine(String logLine) {
+        Boolean status = (logLine.contains("HTTP-In-"));
+        if (status) {
+            httpLog = true;
+        }
+        return status;
+    }
+
+    private boolean isJDBCLogLine(String logLine) {
+        Boolean status = (logLine.contains("jdbc"));
+        if (status) {
+            jdbcLog = true;
+        }
+        return status;
+    }
+
+    private boolean isMethodCallsLogLine(String logLine) {
+        boolean status = (logLine.contains("METHOD") || logLine.contains("Application_Test"));
+        if (status) {
+            methodCallsLog = true;
+        }
+        return status;
+    }
+
+    private void resetAllLogs() {
+        httpLog = false;
+        synapseLog = false;
+        jdbcLog = false;
+        methodCallsLog = false;
+        correlationIDLog = false;
+    }
+
+    @AfterClass(alwaysRun = true) void destroy() throws Exception {
+        restAPIStore.deleteApplication(applicationId);
+        restAPIPublisher.deleteAPI(apiId);
+    }
+}

--- a/modules/integration/tests-integration/tests-benchmark/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-benchmark/src/test/resources/testng.xml
@@ -25,4 +25,11 @@
             <class name="org.wso2.am.integration.tests.benchmarktest.BenchmarkTestCase"/>
         </classes>
     </test>
+
+    <test name="apim-integration-correlation-logging" preserve-order="true" parallel="false" group-by-instances="true">
+        <classes>
+            <class name="org.wso2.am.integration.tests.logging.CorrelationLoggingSystemEnabledTest"/>
+        </classes>
+    </test>
+
 </suite>


### PR DESCRIPTION
An integration test is added for the feature enable correlation
logs without a server restart for the apim product.

> Fix: wso2/api-manager#275
> Fix: wso2/api-manager#532