### PR TITLE
Adding the support for JDK 17

### DIFF
--- a/.github/workflows/Build-pack.yml
+++ b/.github/workflows/Build-pack.yml
@@ -23,11 +23,11 @@ jobs:
         path: ~/.m2
         key: ${{ runner.os }}-m2
         restore-keys: ${{ runner.os }}-m2
-    - name: Set up JDK 1.8
+    - name: Set up JDK 11
       uses: actions/setup-java@v2
       with:
-        java-version: 8.0.282+8
-        distribution: 'adopt'
+        java-version: 11.0.16+8
+        distribution: 'temurin'
     - uses: actions/setup-node@v1
       with:
         node-version: '10.x'

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -34,11 +34,11 @@ jobs:
         path: ~/.m2
         key: ${{ runner.os }}-m2
         restore-keys: ${{ runner.os }}-m2
-    - name: Set up JDK 1.8
+    - name: Set up JDK 11
       uses: actions/setup-java@v2
       with:
-        java-version: 8.0.282+8
-        distribution: 'adopt'
+        java-version: 11.0.16+8
+        distribution: 'temurin'
     - uses: actions/setup-node@v1
       with:
         node-version: '10.x'
@@ -78,11 +78,11 @@ jobs:
           path: ~/.m2
           key: ${{ runner.os }}-m2
           restore-keys: ${{ runner.os }}-m2
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
-          java-version: 8.0.282+8
-          distribution: 'adopt'
+          java-version: 11.0.16+8
+          distribution: 'temurin'
       - uses: actions/setup-node@v1
         with:
           node-version: '10.x'

--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -84,7 +84,7 @@ System Requirements
 5. To compile and run the sample clients in <APIM_HOME>/samples, an Ant version is required. Ant 1.7.0
    version is recommended
 6. To build WSO2 APIM from the Source distribution, it is necessary that you have
-   JDK 1.8 version and Maven 3.0.4 or later
+   JDK 11 version and Maven 3.0.4 or later
 
 For more details see
    https://apim.docs.wso2.com/en/next/install-and-setup/install/installation-prerequisites/

--- a/modules/distribution/product/src/main/startup-scripts/api-manager.bat
+++ b/modules/distribution/product/src/main/startup-scripts/api-manager.bat
@@ -172,13 +172,13 @@ set CMD=RUN %*
 :checkJdk17
 PATH %PATH%;%JAVA_HOME%\bin\
 for /f tokens^=2-5^ delims^=.-_^" %%j in ('java -fullversion 2^>^&1') do set "JAVA_VERSION=%%j%%k"
-if %JAVA_VERSION% LSS 17 goto unknownJdk
-if %JAVA_VERSION% GTR 110 goto unknownJdk
+if %JAVA_VERSION% LSS 110 goto unknownJdk
+if %JAVA_VERSION% GTR 170 goto unknownJdk
 goto jdk17
 
 :unknownJdk
 echo Starting WSO2 Carbon (in unsupported JDK)
-echo [ERROR] CARBON is supported only on JDK 1.7, 1.8, 9, 10 and 11
+echo [ERROR] CARBON is supported only between JDK 11 and JDK 17
 goto jdk17
 
 :jdk17
@@ -203,7 +203,7 @@ set CARBON_CLASSPATH=".\lib\*";%CARBON_CLASSPATH%
 if %JAVA_VERSION% GEQ 110 set CARBON_CLASSPATH=".\lib\endorsed\*";%CARBON_CLASSPATH%
 
 if %JAVA_VERSION% LEQ 18 set JAVA_VER_BASED_OPTS=-Djava.endorsed.dirs=".\lib\endorsed";"%JAVA_HOME%\jre\lib\endorsed";"%JAVA_HOME%\lib\endorsed"
-if %JAVA_VERSION% GEQ 110 set JAVA_VER_BASED_OPTS=--add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens java.rmi/sun.rmi.transport=ALL-UNNAMED
+if %JAVA_VERSION% GEQ 110 set JAVA_VER_BASED_OPTS=--add-opens=java.naming/com.sun.jndi.ldap=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens java.rmi/sun.rmi.transport=ALL-UNNAMED  --add-opens=java.base/java.io=ALL-UNNAMED
 
 set CMD_LINE_ARGS=-Xbootclasspath/a:%CARBON_XBOOTCLASSPATH% -Xms256m -Xmx1024m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath="%CARBON_HOME%\repository\logs\heap-dump.hprof"
 set CMD_LINE_ARGS=%CMD_LINE_ARGS% -Dcom.sun.management.jmxremote -classpath %CARBON_CLASSPATH% %JAVA_OPTS% %JAVA_VER_BASED_OPTS%

--- a/modules/distribution/product/src/main/startup-scripts/api-manager.sh
+++ b/modules/distribution/product/src/main/startup-scripts/api-manager.sh
@@ -235,9 +235,9 @@ fi
 # ---------- Handle the SSL Issue with proper JDK version --------------------
 java_version=$("$JAVACMD" -version 2>&1 | awk -F '"' '/version/ {print $2}')
 java_version_formatted=$(echo "$java_version" | awk -F. '{printf("%02d%02d",$1,$2);}')
-if [ $java_version_formatted -lt 0107 ] || [ $java_version_formatted -gt 1100 ]; then
+if [ $java_version_formatted -lt 1100 ] || [ $java_version_formatted -gt 1700 ]; then
    echo " Starting WSO2 Carbon (in unsupported JDK)"
-   echo " [ERROR] CARBON is supported only on JDK 1.7, 1.8, 9, 10 and 11"
+   echo " [ERROR] CARBON is supported only between JDK 11 and JDK 17"
 fi
 
 CARBON_XBOOTCLASSPATH=""
@@ -307,11 +307,10 @@ echo "Using Java memory options: $JVM_MEM_OPTS"
 #To monitor a Carbon server in remote JMX mode on linux host machines, set the below system property.
 #   -Djava.rmi.server.hostname="your.IP.goes.here"
 
-JAVA_VER_BASED_OPTS=""
+JAVA_VER_BASED_OPTS="--add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens java.rmi/sun.rmi.transport=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED"
 
-
-if [ $java_version_formatted -ge 1100 ]; then
-    JAVA_VER_BASED_OPTS="--add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens java.rmi/sun.rmi.transport=ALL-UNNAMED"
+if [ $java_version_formatted -ge 1700 ]; then
+    JAVA_VER_BASED_OPTS=$JAVA_VER_BASED_OPTS "--add-opens=java.naming/com.sun.jndi.ldap=ALL-UNNAMED"
 fi
 
 while [ "$status" = "$START_EXIT_STATUS" ]

--- a/modules/integration/tests-common/backend-service/monitor-app/pom.xml
+++ b/modules/integration/tests-common/backend-service/monitor-app/pom.xml
@@ -90,7 +90,7 @@ under the License.
         <plugins>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.2</version>
+                <version>3.3.2</version>
                 <configuration>
                     <webResources>
                         <resource>

--- a/modules/integration/tests-common/backend-service/monitor-app/war/META-INF/maven/ArtifactDeploymentMonitor/ArtifactDeploymentMonitor/pom.xml
+++ b/modules/integration/tests-common/backend-service/monitor-app/war/META-INF/maven/ArtifactDeploymentMonitor/ArtifactDeploymentMonitor/pom.xml
@@ -123,7 +123,7 @@ under the License.
 
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.2</version>
+                <version>3.3.2</version>
                 <configuration>
                     <packagingExcludes>WEB-INF/lib/*.jar,WEB-INF/modules/addressing-1.6.1-wso2v11.mar,WEB-INF/lib/</packagingExcludes>
                     <!--<webResources>-->

--- a/modules/integration/tests-integration/tests-backend/pom.xml
+++ b/modules/integration/tests-integration/tests-backend/pom.xml
@@ -85,7 +85,14 @@ under the License.
                         <version>3.0.0-M5</version>
                         <inherited>false</inherited>
                         <configuration>
-                            <argLine>-Xmx2048m</argLine>
+                            <argLine>-Xmx2048m
+                                --add-opens=java.base/java.lang=ALL-UNNAMED
+                                --add-opens=java.base/java.util=ALL-UNNAMED
+                                --add-opens java.xml/jdk.xml.internal=ALL-UNNAMED
+                                --add-opens=java.base/java.io=ALL-UNNAMED
+                                --add-opens=java.base/sun.nio.fs=ALL-UNNAMED
+                                --add-opens=java.naming/com.sun.jndi.ldap=ALL-UNNAMED
+                            </argLine>
                             <suiteXmlFiles>
                                 <suiteXmlFile>src/test/resources/testng-server-mgt.xml</suiteXmlFile>
                                 <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
@@ -303,7 +310,14 @@ under the License.
                         <inherited>false</inherited>
                         <version>2.22.1</version>
                         <configuration>
-                            <argLine>-Xmx2048m</argLine>
+                            <argLine>-Xmx2048m
+                                --add-opens=java.base/java.lang=ALL-UNNAMED
+                                --add-opens=java.base/java.util=ALL-UNNAMED
+                                --add-opens java.xml/jdk.xml.internal=ALL-UNNAMED
+                                --add-opens=java.base/java.io=ALL-UNNAMED
+                                --add-opens=java.base/sun.nio.fs=ALL-UNNAMED
+                                --add-opens=java.naming/com.sun.jndi.ldap=ALL-UNNAMED
+                            </argLine>
                             <suiteXmlFiles>
                                 <suiteXmlFile>src/test/resources/testng-server-mgt.xml</suiteXmlFile>
                                 <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>

--- a/modules/integration/tests-integration/tests-benchmark/pom.xml
+++ b/modules/integration/tests-integration/tests-benchmark/pom.xml
@@ -74,7 +74,7 @@ under the License.
                         <version>3.0.0-M5</version>
                         <inherited>false</inherited>
                         <configuration>
-                            <argLine>-Xmx1024m -XX:PermSize=256m -XX:MaxPermSize=512m</argLine>
+                            <argLine>-Xmx1024m</argLine>
                             <suiteXmlFiles>
                                 <suiteXmlFile>src/test/resources/testng-server-mgt.xml</suiteXmlFile>
                                 <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
@@ -215,7 +215,7 @@ under the License.
                         <inherited>false</inherited>
                         <version>2.22.1</version>
                         <configuration>
-                            <argLine>-Xmx1024m -XX:PermSize=256m -XX:MaxPermSize=512m</argLine>
+                            <argLine>-Xmx1024m</argLine>
                             <suiteXmlFiles>
                                 <suiteXmlFile>src/test/resources/testng-server-mgt.xml</suiteXmlFile>
                                 <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
@@ -313,7 +313,7 @@ under the License.
                         <inherited>false</inherited>
                         <version>2.22.1</version>
                         <configuration>
-                            <argLine>-Xmx1024m -XX:PermSize=256m -XX:MaxPermSize=512m</argLine>
+                            <argLine>-Xmx1024m</argLine>
                             <suiteXmlFiles>
                                 <suiteXmlFile>src/test/resources/testng-server-mgt.xml</suiteXmlFile>
                                 <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>

--- a/pom.xml
+++ b/pom.xml
@@ -1409,7 +1409,7 @@
 
         <maven-resources-plugin.version>2.5</maven-resources-plugin.version>
         <eclipse.version>3.2.0</eclipse.version>
-        <jacoco.agent.version>0.8.2</jacoco.agent.version>
+        <jacoco.agent.version>0.8.8</jacoco.agent.version>
         <google.guava.version>27.0-jre</google.guava.version>
 
         <carbon.metrics.version>1.3.12</carbon.metrics.version>


### PR DESCRIPTION
## Purpose 
Fixes: https://github.com/wso2/api-manager/issues/494

## Goals
Adding the support to run with JDK 17 (Also, tests can be run using JDK 17 as well)

## Test environment
- OpenJDK 11.0.16+8
- OpenJDK 17.0.4+8