### PR TITLE
Fix GraphQL test cases to read a JSON array on error response

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/graphql/GraphqlSubscriptionTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/graphql/GraphqlSubscriptionTestCase.java
@@ -811,7 +811,8 @@ public class GraphqlSubscriptionTestCase extends APIMIntegrationBaseTest {
             assertTrue(errorJson.containsKey("id"));
             assertEquals(errorJson.get("id"), "1");
             assertTrue(errorJson.containsKey("payload"));
-            org.json.simple.JSONObject payload = (org.json.simple.JSONObject) errorJson.get("payload");
+            org.json.simple.JSONObject payload =
+                    (org.json.simple.JSONObject) ((org.json.simple.JSONArray) errorJson.get("payload")).get(0);
             assertTrue(payload.containsKey("message"));
             assertTrue(payload.containsKey("code"));
             assertEquals(payload.get("message"), "User is NOT authorized to access the Resource: liftStatusChange. "
@@ -865,7 +866,8 @@ public class GraphqlSubscriptionTestCase extends APIMIntegrationBaseTest {
             assertTrue(errorJson.containsKey("id"));
             assertEquals(errorJson.get("id"), "1");
             assertTrue(errorJson.containsKey("payload"));
-            org.json.simple.JSONObject payload = (org.json.simple.JSONObject) errorJson.get("payload");
+            org.json.simple.JSONObject payload =
+                    (org.json.simple.JSONObject) ((org.json.simple.JSONArray) errorJson.get("payload")).get(0);
             assertTrue(payload.containsKey("message"));
             assertTrue(payload.containsKey("code"));
             assertTrue(((String) payload.get("message")).contains("QUERY TOO COMPLEX"),
@@ -920,7 +922,8 @@ public class GraphqlSubscriptionTestCase extends APIMIntegrationBaseTest {
             assertTrue(errorJson.containsKey("id"));
             assertEquals(errorJson.get("id"), "1");
             assertTrue(errorJson.containsKey("payload"));
-            org.json.simple.JSONObject payload = (org.json.simple.JSONObject) errorJson.get("payload");
+            org.json.simple.JSONObject payload =
+                    (org.json.simple.JSONObject) ((org.json.simple.JSONArray) errorJson.get("payload")).get(0);
             assertTrue(payload.containsKey("message"));
             assertTrue(payload.containsKey("code"));
             assertTrue(((String) payload.get("message")).contains("QUERY TOO DEEP"),
@@ -975,7 +978,8 @@ public class GraphqlSubscriptionTestCase extends APIMIntegrationBaseTest {
             assertTrue(errorJson.containsKey("id"));
             assertEquals(errorJson.get("id"), "1");
             assertTrue(errorJson.containsKey("payload"));
-            org.json.simple.JSONObject payload = (org.json.simple.JSONObject) errorJson.get("payload");
+            org.json.simple.JSONObject payload =
+                    (org.json.simple.JSONObject) ((org.json.simple.JSONArray) errorJson.get("payload")).get(0);
             assertTrue(payload.containsKey("message"));
             assertTrue(payload.containsKey("code"));
             assertTrue(((String) payload.get("message")).contains("INVALID QUERY"),
@@ -1041,7 +1045,8 @@ public class GraphqlSubscriptionTestCase extends APIMIntegrationBaseTest {
                     assertTrue(errorJson.containsKey("id"));
                     assertEquals(errorJson.get("id"), "2");
                     assertTrue(errorJson.containsKey("payload"));
-                    org.json.simple.JSONObject payload = (org.json.simple.JSONObject) errorJson.get("payload");
+                    org.json.simple.JSONObject payload =
+                            (org.json.simple.JSONObject) ((org.json.simple.JSONArray) errorJson.get("payload")).get(0);
                     assertTrue(payload.containsKey("message"));
                     assertTrue(payload.containsKey("code"));
                     assertTrue(((String) payload.get("message")).contains("Websocket frame throttled out"),


### PR DESCRIPTION
To fix GraphQL test cases to accomadate changes in https://github.com/wso2/carbon-apimgt/pull/11439
