### PR TITLE
Configure only to build org.wso2.am.integration.common.test.utils module

### DIFF
--- a/product-scenarios/test.sh
+++ b/product-scenarios/test.sh
@@ -98,7 +98,7 @@ else
     PRODUCT_VERSION="-$PRODUCT_VERSION"
 fi
 
-cd $HOME/../modules/integration/tests-common
+cd $HOME/../modules/integration/tests-common/integration-test-utils
 mvn clean install -Dmaven.test.skip=true
 cd $HOME
 


### PR DESCRIPTION
Only build org.wso2.am.integration.common.test.utils component since other components in the tests-common are available in public mvn repo