### PR TITLE
Refactor websub_api_template for x-www-form-urlencoded requests

### DIFF
--- a/modules/distribution/resources/api_templates/websub_api_template.xml
+++ b/modules/distribution/resources/api_templates/websub_api_template.xml
@@ -40,6 +40,7 @@
                                             <class name="org.wso2.carbon.apimgt.gateway.mediators.webhooks.SubscriberInfoLoader"/>
                                             <property name="TRANSPORT_HEADERS" action="remove" scope="axis2"/>
                                             <property name="REST_URL_POSTFIX" scope="axis2" action="remove"/>
+                                            <property name="link" expression="$ctx:SUBSCRIBER_LINK_HEADER" scope="transport"/>
                                             <header name="To" expression="$ctx:SUBSCRIBER_CALLBACK"/>
                                             <filter source="boolean($ctx:SUBSCRIBER_SECRET)" regex="true">
                                                 <then>
@@ -56,7 +57,7 @@
                                                             <duration>60000</duration>
                                                         </timeout>
                                                         <markForSuspension>
-                                                            <errorCodes>101504, 101505, 101500</errorCodes>
+                                                            <errorCodes>-1</errorCodes>
                                                             <retriesBeforeSuspension>3</retriesBeforeSuspension>
                                                             <retryDelay>1</retryDelay>
                                                         </markForSuspension>
@@ -89,36 +90,101 @@
     </resource>
     <resource methods="POST" url-mapping="/*" binds-to="default">
         <inSequence>
-            <property name="STOP_TARGET_EXECUTION_ON_FAILURE" value="true"/>
-            <clone sequential="true">
-                <target>
-                    <sequence>
-                        <class name="org.wso2.carbon.apimgt.gateway.mediators.webhooks.SubscribersPersistMediator"/>
-                        <property name="NO_ENTITY_BODY" value="true" scope="axis2" type="BOOLEAN" />
-                        <respond/>
-                    </sequence>
-                </target>
-                <target>
-                    <sequence onError="webhooksFaultSequence">
-                        <filter source="fn:lower-case($url:hub.mode)" regex="subscribe">
-                            <then>
-                                <property name="SUBSCRIBER_CALLBACK" expression="$url:hub.callback"/>
-                                <property name="SUBSCRIBER_TOPIC" expression="$url:hub.topic"/>
-                                <property name="SUBSCRIBER_APPLICATION_ID" expression="$ctx:api.ut.application.id"/>
-                                <header name="To" expression="$ctx:SUBSCRIBER_CALLBACK"/>
-                                <call>
-                                    <endpoint>
-                                        <default/>
-                                    </endpoint>
-                                </call>
-                                <class name="org.wso2.carbon.apimgt.gateway.mediators.webhooks.DeliveryStatusUpdater"/>
-                            </then>
-                            <else/>
-                        </filter>
-                        <drop/>
-                    </sequence>
-                </target>
-            </clone>
+            <filter source="fn:contains(fn:lower-case($trp:Content-Type), 'application/x-www-form-urlencoded')" regex="true">
+                <then>
+                    <property name="FORCE_SC_ACCEPTED" value="true" scope="axis2"/>
+                    <property name="SUBSCRIBER_MODE" expression="//xformValues//hub.mode"/>
+                    <property name="SUBSCRIBER_TOPIC" expression="//xformValues//hub.topic"/>
+                    <property name="SUBSCRIBER_CALLBACK" expression="//xformValues//hub.callback"/>
+                    <property name="SUBSCRIBER_LEASE_SECONDS" expression="//xformValues//hub.lease_seconds"/>
+                    <property name="HUB_CHALLENGE" expression="get-property('MessageID')"/>
+                    <property name="QUERY_PARAMS"
+                              expression="fn:concat('hub.mode=', $ctx:SUBSCRIBER_MODE, '&amp;','hub.topic=',$ctx:SUBSCRIBER_TOPIC, '&amp;','hub.challenge=', $ctx:HUB_CHALLENGE, '&amp;','hub.lease_seconds=', $ctx:SUBSCRIBER_LEASE_SECONDS)"
+                              scope="default" type="STRING"/>
+                    <property name="SUBSCRIBER_APPLICATION_ID" expression="$ctx:api.ut.application.id"/>
+
+                    <filter source="fn:contains($ctx:SUBSCRIBER_CALLBACK, '?')" regex="true">
+                        <then>
+                            <property name="uri.var.callback"
+                                      expression="fn:concat($ctx:SUBSCRIBER_CALLBACK,'&amp;', $ctx:QUERY_PARAMS)"
+                                      scope="default" type="STRING"/>
+                        </then>
+                        <else>
+                            <property name="uri.var.callback"
+                                      expression="fn:concat($ctx:SUBSCRIBER_CALLBACK,'?', $ctx:QUERY_PARAMS)"
+                                      scope="default" type="STRING"/>
+                        </else>
+                    </filter>
+                    <property name="messageType" value="application/xml" scope="axis2"/>
+
+                    <call>
+                        <endpoint>
+                            <http method="GET" uri-template="{uri.var.callback}"/>
+                        </endpoint>
+                    </call>
+                    <property name="VERIFICATION_SC" expression="$axis2:HTTP_SC"/>
+
+                    #if($enableSubscriberVerification)
+                    <property name="ECHO_CHALLENGE" expression="json-eval($.text)"/>
+                    <filter source="get-property('HUB_CHALLENGE') = get-property('ECHO_CHALLENGE')" regex="true">
+                        <then>
+                            <log level="custom">
+                                <property name="SUBSCRIBER VERIFICATION STATUS" expression="fn:concat('Passed. ', $ctx:SUBSCRIBER_CALLBACK, ' successfully verified the challenge')"/>
+                            </log>
+                            #end
+                            <class name="org.wso2.carbon.apimgt.gateway.mediators.webhooks.SubscribersPersistMediator"/>
+                            <filter source="fn:lower-case($ctx:SUBSCRIBER_MODE)" regex="subscribe">
+                                <then>
+                                    <property name="HTTP_SC" expression="$ctx:VERIFICATION_SC" scope="axis2"/>
+                                    <class name="org.wso2.carbon.apimgt.gateway.mediators.webhooks.DeliveryStatusUpdater"/>
+                                </then>
+                                <else/>
+                            </filter>
+                            #if($enableSubscriberVerification)
+                        </then>
+                        <else>
+                            <log level="custom">
+                                <property name="SUBSCRIBER VERIFICATION STATUS" expression="fn:concat('Failed. ', $ctx:SUBSCRIBER_CALLBACK, ' failed to verify the challenge')"/>
+                            </log>
+                        </else>
+                    </filter>
+                    #end
+                    <drop/>
+                </then>
+                <else>
+                    <property name="STOP_TARGET_EXECUTION_ON_FAILURE" value="true"/>
+                    <clone sequential="true">
+                        <target>
+                            <sequence>
+                                <class name="org.wso2.carbon.apimgt.gateway.mediators.webhooks.SubscribersPersistMediator"/>
+                                <property name="NO_ENTITY_BODY" value="true" scope="axis2" type="BOOLEAN"/>
+                                <respond/>
+                            </sequence>
+                        </target>
+                        <target>
+                            <sequence onError="webhooksFaultSequence">
+                                <filter source="fn:lower-case($url:hub.mode)" regex="subscribe">
+                                    <then>
+                                        <property name="SUBSCRIBER_CALLBACK" expression="$url:hub.callback"/>
+                                        <property name="SUBSCRIBER_TOPIC" expression="$url:hub.topic"/>
+                                        <property name="SUBSCRIBER_APPLICATION_ID"
+                                                  expression="$ctx:api.ut.application.id"/>
+                                        <header name="To" expression="$ctx:SUBSCRIBER_CALLBACK"/>
+                                        <call>
+                                            <endpoint>
+                                                <default/>
+                                            </endpoint>
+                                        </call>
+                                        <class name="org.wso2.carbon.apimgt.gateway.mediators.webhooks.DeliveryStatusUpdater"/>
+                                    </then>
+                                    <else/>
+                                </filter>
+                                <drop/>
+                            </sequence>
+                        </target>
+                    </clone>
+                </else>
+            </filter>
         </inSequence>
     </resource>
     <handlers>

--- a/modules/integration/tests-common/clients/publisher/api/openapi.yaml
+++ b/modules/integration/tests-common/clients/publisher/api/openapi.yaml
@@ -15854,6 +15854,7 @@ components:
         responseCachingEnabled: true
         type: HTTP
         enableSchemaValidation: false
+        enableSubscriberVerification: false
         context: pizza
         createdTime: createdTime
         id: 01234567-0123-0123-0123-012345678901
@@ -16064,6 +16065,9 @@ components:
           example: 1
           type: integer
         enableSchemaValidation:
+          example: false
+          type: boolean
+        enableSubscriberVerification:
           example: false
           type: boolean
         type:

--- a/modules/integration/tests-common/clients/publisher/docs/APIDTO.md
+++ b/modules/integration/tests-common/clients/publisher/docs/APIDTO.md
@@ -23,6 +23,7 @@ Name | Type | Description | Notes
 **revisionedApiId** | **String** | UUID of the api registry artifact  |  [optional] [readonly]
 **revisionId** | **Integer** |  |  [optional]
 **enableSchemaValidation** | **Boolean** |  |  [optional]
+**enableSubscriberVerification** | **Boolean** | To enable WebSub subscriber intent verification | [optional]
 **type** | [**TypeEnum**](#TypeEnum) | The api creation type to be used. Accepted values are HTTP, WS, SOAPTOREST, GRAPHQL, WEBSUB, SSE, WEBHOOK, ASYNC |  [optional]
 **audience** | [**AudienceEnum**](#AudienceEnum) | The audience of the API. Accepted values are PUBLIC, SINGLE |  [optional]
 **transport** | **List&lt;String&gt;** | Supported transports for the API (http and/or https).  |  [optional]

--- a/modules/integration/tests-common/clients/publisher/src/gen/java/org/wso2/am/integration/clients/publisher/api/v1/dto/APIDTO.java
+++ b/modules/integration/tests-common/clients/publisher/src/gen/java/org/wso2/am/integration/clients/publisher/api/v1/dto/APIDTO.java
@@ -115,6 +115,10 @@ public class APIDTO {
         @SerializedName(SERIALIZED_NAME_ENABLE_SCHEMA_VALIDATION)
             private Boolean enableSchemaValidation;
 
+        public static final String SERIALIZED_NAME_ENABLE_SUBSCRIBER_VERIFICATION = "enableSubscriberVerification";
+        @SerializedName(SERIALIZED_NAME_ENABLE_SUBSCRIBER_VERIFICATION)
+        private Boolean enableSubscriberVerification;
+
             /**
 * The api creation type to be used. Accepted values are HTTP, WS, SOAPTOREST, GRAPHQL, WEBSUB, SSE, WEBHOOK, ASYNC
 */
@@ -953,6 +957,28 @@ public static EndpointImplementationTypeEnum fromValue(String value) {
         this.enableSchemaValidation = enableSchemaValidation;
     }
 
+    public APIDTO enableSubscriberVerification(Boolean enableSubscriberVerification) {
+
+        this.enableSubscriberVerification = enableSubscriberVerification;
+        return this;
+    }
+
+    /**
+     * Get enableSubscriberVerification
+     *
+     * @return enableSubscriberVerification
+     **/
+    @javax.annotation.Nullable
+    @ApiModelProperty(example = "false",
+            value = "")
+
+    public Boolean isEnableSubscriberVerification() {
+        return enableSubscriberVerification;
+    }
+
+    public void setEnableSubscriberVerification(Boolean enableSubscriberVerification) {
+        this.enableSubscriberVerification = enableSubscriberVerification;
+    }
 
         public APIDTO type(TypeEnum type) {
         
@@ -1831,6 +1857,7 @@ public static EndpointImplementationTypeEnum fromValue(String value) {
             Objects.equals(this.revisionedApiId, API.revisionedApiId) &&
             Objects.equals(this.revisionId, API.revisionId) &&
             Objects.equals(this.enableSchemaValidation, API.enableSchemaValidation) &&
+            Objects.equals(this.enableSubscriberVerification, API.enableSubscriberVerification) &&
             Objects.equals(this.type, API.type) &&
             Objects.equals(this.audience, API.audience) &&
             Objects.equals(this.transport, API.transport) &&
@@ -1872,7 +1899,7 @@ public static EndpointImplementationTypeEnum fromValue(String value) {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, description, context, version, provider, lifeCycleStatus, wsdlInfo, wsdlUrl, responseCachingEnabled, cacheTimeout, hasThumbnail, isDefaultVersion, isRevision, revisionedApiId, revisionId, enableSchemaValidation, type, audience, transport, tags, policies, apiThrottlingPolicy, authorizationHeader, securityScheme, maxTps, visibility, visibleRoles, visibleTenants, mediationPolicies, subscriptionAvailability, subscriptionAvailableTenants, additionalProperties, additionalPropertiesMap, monetization, accessControl, accessControlRoles, businessInformation, corsConfiguration, websubSubscriptionConfiguration, workflowStatus, createdTime, lastUpdatedTime, endpointConfig, endpointImplementationType, scopes, operations, threatProtectionPolicies, categories, keyManagers, serviceInfo, advertiseInfo, gatewayVendor, asyncTransportProtocols);
+        return Objects.hash(id, name, description, context, version, provider, lifeCycleStatus, wsdlInfo, wsdlUrl, responseCachingEnabled, cacheTimeout, hasThumbnail, isDefaultVersion, isRevision, revisionedApiId, revisionId, enableSchemaValidation, enableSubscriberVerification, type, audience, transport, tags, policies, apiThrottlingPolicy, authorizationHeader, securityScheme, maxTps, visibility, visibleRoles, visibleTenants, mediationPolicies, subscriptionAvailability, subscriptionAvailableTenants, additionalProperties, additionalPropertiesMap, monetization, accessControl, accessControlRoles, businessInformation, corsConfiguration, websubSubscriptionConfiguration, workflowStatus, createdTime, lastUpdatedTime, endpointConfig, endpointImplementationType, scopes, operations, threatProtectionPolicies, categories, keyManagers, serviceInfo, advertiseInfo, gatewayVendor, asyncTransportProtocols);
     }
 
 
@@ -1897,6 +1924,7 @@ sb.append("class APIDTO {\n");
     sb.append("    revisionedApiId: ").append(toIndentedString(revisionedApiId)).append("\n");
     sb.append("    revisionId: ").append(toIndentedString(revisionId)).append("\n");
     sb.append("    enableSchemaValidation: ").append(toIndentedString(enableSchemaValidation)).append("\n");
+    sb.append("    enableSubscriberVerification: ").append(toIndentedString(enableSubscriberVerification)).append("\n");
     sb.append("    type: ").append(toIndentedString(type)).append("\n");
     sb.append("    audience: ").append(toIndentedString(audience)).append("\n");
     sb.append("    transport: ").append(toIndentedString(transport)).append("\n");

--- a/modules/integration/tests-common/clients/publisher/src/main/resources/publisher-api.yaml
+++ b/modules/integration/tests-common/clients/publisher/src/main/resources/publisher-api.yaml
@@ -8638,6 +8638,9 @@ components:
         enableSchemaValidation:
           type: boolean
           example: false
+        enableSubscriberVerification:
+          type: boolean
+          example: false
         type:
           type: string
           description: The api creation type to be used. Accepted values are HTTP,

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/streamingapis/websub/WebSubAPITestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/streamingapis/websub/WebSubAPITestCase.java
@@ -67,12 +67,10 @@ import java.io.File;
 import java.io.UnsupportedEncodingException;
 import java.net.InetAddress;
 import java.net.MalformedURLException;
-import java.net.URI;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -240,8 +238,8 @@ public class WebSubAPITestCase extends APIMIntegrationBaseTest {
 
         callbackServerServlet.setCallbacksReceived(0);
         String callbackUrl = "http://" + serverHost + ":" + callbackReceiverPort + "/receiver";
-        handleCallbackSubscriptionWithQueryParameters(SUBSCRIBE, apiEndpoint, callbackUrl, DEFAULT_TOPIC, topicSecret, "50000000",
-                accessToken);
+        handleCallbackSubscriptionWithQueryParameters(SUBSCRIBE, apiEndpoint, callbackUrl, DEFAULT_TOPIC, topicSecret,
+                                                      "50000000", accessToken);
         initializeWebhookSender(topicSecret);
         Thread.sleep(5000);
         int noOfEventsToSend = 10;
@@ -249,8 +247,8 @@ public class WebSubAPITestCase extends APIMIntegrationBaseTest {
             webhookSender.send();
             Thread.sleep(5000);
         }
-        handleCallbackSubscriptionWithQueryParameters(UNSUBSCRIBE, apiEndpoint, callbackUrl, DEFAULT_TOPIC, topicSecret, "50000000",
-                accessToken);
+        handleCallbackSubscriptionWithQueryParameters(UNSUBSCRIBE, apiEndpoint, callbackUrl, DEFAULT_TOPIC, topicSecret,
+                                                      "50000000", accessToken);
         Thread.sleep(5000);
         int sent = webhookSender.getWebhooksSent();
         int received = callbackServerServlet.getCallbacksReceived();

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/streamingapis/websub/WebSubAPITestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/streamingapis/websub/WebSubAPITestCase.java
@@ -18,6 +18,12 @@
 
 package org.wso2.am.integration.tests.streamingapis.websub;
 
+import java.util.HashMap;
+import java.util.Map;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.eclipse.jetty.server.Server;
@@ -45,6 +51,7 @@ import org.wso2.am.integration.test.utils.generic.APIMTestCaseUtils;
 import org.wso2.am.integration.tests.streamingapis.StreamingApiTestUtils;
 import org.wso2.am.integration.tests.streamingapis.websub.client.WebhookSender;
 import org.wso2.am.integration.tests.streamingapis.websub.server.CallbackServerServlet;
+import org.wso2.am.integration.tests.streamingapis.websub.server.CallbackServerServletWithSubVerification;
 import org.wso2.carbon.apimgt.api.model.APIIdentifier;
 import org.wso2.carbon.automation.engine.annotations.ExecutionEnvironment;
 import org.wso2.carbon.automation.engine.annotations.SetEnvironment;
@@ -108,6 +115,10 @@ public class WebSubAPITestCase extends APIMIntegrationBaseTest {
     private WebhookSender webhookSender;
     private CallbackServerServlet callbackServerServlet;
     private Server callbackServer;
+    private String accessToken;
+    private CallbackServerServletWithSubVerification callbackServerServletWithSubVerification;
+    private int callbackReceiverWithSubVerificationPort;
+    private Server callbackServerWithSubVerification;
 
     @Factory(dataProvider = "userModeDataProvider")
     public WebSubAPITestCase(TestUserMode userMode) {
@@ -142,6 +153,15 @@ public class WebSubAPITestCase extends APIMIntegrationBaseTest {
         }
         log.info("Selected port " + callbackReceiverPort + " to start callback receiver");
         initializeCallbackReceiver(callbackReceiverPort);
+        Thread.sleep(5000);
+        callbackReceiverWithSubVerificationPort = StreamingApiTestUtils.getAvailablePort(lowerPortLimit, upperPortLimit,
+                                                                                         serverHost);
+        if (callbackReceiverWithSubVerificationPort == -1) {
+            throw new APIManagerIntegrationTestException(
+                    "No available port in the range " + lowerPortLimit + "-" + upperPortLimit + " was found");
+        }
+        log.info("Selected port " + callbackReceiverWithSubVerificationPort + " to start callback receiver");
+        initializeCallbackReceiverWithSubVerification(callbackReceiverWithSubVerificationPort);
         Thread.sleep(5000);
     }
 
@@ -208,29 +228,157 @@ public class WebSubAPITestCase extends APIMIntegrationBaseTest {
         grantTypes.add(APIMIntegrationConstants.GRANT_TYPE.REFRESH_CODE);
         grantTypes.add(APIMIntegrationConstants.GRANT_TYPE.CLIENT_CREDENTIAL);
         ApplicationKeyDTO applicationKeyDTO = restAPIStore.generateKeys(appId, "3600", null,
-                ApplicationKeyGenerateRequestDTO.KeyTypeEnum.PRODUCTION, null, grantTypes);
-        String accessToken = applicationKeyDTO.getToken().getAccessToken();
+                                                                        ApplicationKeyGenerateRequestDTO.KeyTypeEnum.PRODUCTION,
+                                                                        null, grantTypes);
+        accessToken = applicationKeyDTO.getToken().getAccessToken();
+        Assert.assertNotNull(accessToken, "Error occurred while generating the access token");
+    }
 
+    @Test(description = "Test invoke WebSub API when parameters are passed as query parameters",
+            dependsOnMethods = "testInvokeWebSubApi")
+    public void testInvokeWebSubApiWithQueryParameters() throws Exception {
+
+        callbackServerServlet.setCallbacksReceived(0);
         String callbackUrl = "http://" + serverHost + ":" + callbackReceiverPort + "/receiver";
-        handleCallbackSubscription(SUBSCRIBE, apiEndpoint, callbackUrl, DEFAULT_TOPIC, topicSecret, "50000000",
+        handleCallbackSubscriptionWithQueryParameters(SUBSCRIBE, apiEndpoint, callbackUrl, DEFAULT_TOPIC, topicSecret, "50000000",
                 accessToken);
         initializeWebhookSender(topicSecret);
         Thread.sleep(5000);
         int noOfEventsToSend = 10;
         for (int i = 0; i < noOfEventsToSend; i++) {
             webhookSender.send();
-            Thread.sleep(3000);
+            Thread.sleep(5000);
         }
-        handleCallbackSubscription(UNSUBSCRIBE, apiEndpoint, callbackUrl, DEFAULT_TOPIC, topicSecret, "50000000",
+        handleCallbackSubscriptionWithQueryParameters(UNSUBSCRIBE, apiEndpoint, callbackUrl, DEFAULT_TOPIC, topicSecret, "50000000",
                 accessToken);
-
+        Thread.sleep(5000);
         int sent = webhookSender.getWebhooksSent();
         int received = callbackServerServlet.getCallbacksReceived();
         Assert.assertEquals(sent, noOfEventsToSend);
         Assert.assertEquals(sent + 1, received); // no. of events received = no. of events sent + 1 subscribe event
+    }
+
+    @Test(description = "Test invoke WebSub API when parameters are passed as form url encoded data",
+            dependsOnMethods = "testInvokeWebSubApi")
+    public void testInvokeWebSubAPIWithFormUrlEncodedData() throws Exception {
 
         callbackServerServlet.setCallbacksReceived(0);
-        webhookSender.setWebhooksSent(0);
+        String callbackUrl = "http://" + serverHost + ":" + callbackReceiverPort + "/receiver";
+        HttpResponse subResponse = handleCallbackSubscriptionWithFormUrlEncoded(SUBSCRIBE, apiEndpoint, callbackUrl,
+                                                                                DEFAULT_TOPIC, topicSecret, "50000000",
+                                                                                accessToken);
+        Assert.assertEquals(HttpServletResponse.SC_ACCEPTED, subResponse.getResponseCode(),
+                            "Subscribe request failed with a " + subResponse.getResponseCode() + " response");
+        initializeWebhookSender(topicSecret);
+        Thread.sleep(5000);
+        int noOfEventsToSend = 5;
+        for (int i = 0; i < noOfEventsToSend; i++) {
+            webhookSender.send();
+            Thread.sleep(5000);
+        }
+        HttpResponse unSubResponse = handleCallbackSubscriptionWithFormUrlEncoded(UNSUBSCRIBE, apiEndpoint, callbackUrl,
+                                                                                  DEFAULT_TOPIC, topicSecret,
+                                                                                  "50000000", accessToken);
+        Thread.sleep(5000);
+        Assert.assertEquals(HttpServletResponse.SC_ACCEPTED, unSubResponse.getResponseCode(),
+                            "Unsubscribe request failed with a " + unSubResponse.getResponseCode() + " response");
+        int sent = webhookSender.getWebhooksSent();
+        int received = callbackServerServlet.getCallbacksReceived();
+        Assert.assertEquals(sent, noOfEventsToSend, "Webhook sender failed to send all the requests");
+        Assert.assertEquals(sent, received, "Callback server did not receive all the content distribution requests");
+    }
+
+    @Test(description = "Check availability of mandatory parameters",
+            dependsOnMethods = "testInvokeWebSubApi")
+    public void testMandatoryParameters() throws Exception {
+
+        callbackServerServlet.setCallbacksReceived(0);
+        String callbackUrl = "http://" + serverHost + ":" + callbackReceiverPort + "/receiver";
+        handleCallbackSubscriptionWithFormUrlEncoded(SUBSCRIBE, apiEndpoint, callbackUrl, DEFAULT_TOPIC, topicSecret,
+                                                     "50000000", accessToken);
+        initializeWebhookSender(topicSecret);
+        Thread.sleep(5000);
+        Assert.assertEquals(SUBSCRIBE, callbackServerServlet.getHubMode(),
+                            "Callback server did not receive the expected hub.mode parameter");
+        Assert.assertEquals(DEFAULT_TOPIC, callbackServerServlet.getHubTopic(),
+                            "Callback server did not receive the expected hub.topic parameter");
+        Assert.assertTrue(StringUtils.isNotEmpty(callbackServerServlet.getHubChallenge()),
+                          "Callback server did not receive the hub.challenge parameter");
+
+        String hubUrl = "http://localhost:" + TOPIC_PORT;
+        webhookSender.send();
+        Thread.sleep(5000);
+        Assert.assertTrue(callbackServerServlet.getLinkHeader().contains(hubUrl),
+                          "Missing link header in content distribution request");
+        handleCallbackSubscriptionWithFormUrlEncoded(UNSUBSCRIBE, apiEndpoint, callbackUrl, DEFAULT_TOPIC, topicSecret,
+                                                     "50000000", accessToken);
+        Thread.sleep(5000);
+    }
+
+    @Test(description = "Check subscription when mandatory parameters are missing",
+            dependsOnMethods = "testInvokeWebSubApi")
+    public void testMissingMandatoryParameters() throws Exception {
+
+        String callbackUrl = "http://" + serverHost + ":" + callbackReceiverPort + "/receiver";
+        try {
+            handleCallbackSubscriptionWithFormUrlEncoded("", apiEndpoint, callbackUrl, DEFAULT_TOPIC, topicSecret,
+                                                         "50000000", accessToken);
+            Thread.sleep(5000);
+            Assert.fail("WebSub subscription invoked without mandatory parameters.");
+        } catch (AutomationFrameworkException e) {
+            assertTrue(e.getMessage().contains("Server returned HTTP response code: 500"));
+        }
+    }
+
+    @Test(description = "Check subscriber verification",
+            dependsOnMethods = "testInvokeWebSubApi")
+    public void testSubscriberVerification() throws Exception {
+
+        APIDTO apiDto = restAPIPublisher.getAPIByID(apiId);
+        apiDto.setEnableSubscriberVerification(true);
+        restAPIPublisher.updateAPI(apiDto, apiId);
+        createAPIRevisionAndDeployUsingRest(apiId, restAPIPublisher);
+        waitForAPIDeploymentSync(user.getUserName(), apiName, apiVersion, APIMIntegrationConstants.IS_API_EXISTS);
+
+        callbackServerServlet.setCallbacksReceived(0);
+        String callbackUrl = "http://" + serverHost + ":" + callbackReceiverWithSubVerificationPort + "/receiver";
+        handleCallbackSubscriptionWithFormUrlEncoded(SUBSCRIBE, apiEndpoint, callbackUrl, DEFAULT_TOPIC, topicSecret,
+                                                     "50000000", accessToken);
+        initializeWebhookSender(topicSecret);
+        Thread.sleep(5000);
+        int noOfEventsToSend = 5;
+        for (int i = 0; i < noOfEventsToSend; i++) {
+            webhookSender.send();
+            Thread.sleep(5000);
+        }
+        handleCallbackSubscriptionWithFormUrlEncoded(UNSUBSCRIBE, apiEndpoint, callbackUrl, DEFAULT_TOPIC, topicSecret,
+                                                     "50000000", accessToken);
+        Thread.sleep(5000);
+        int sent = webhookSender.getWebhooksSent();
+        int received = callbackServerServletWithSubVerification.getCallbacksReceived();
+        Assert.assertEquals(sent, noOfEventsToSend, "Webhook sender failed to send all the requests");
+        Assert.assertEquals(sent, received, "Callback server did not receive all the content distribution requests");
+    }
+
+    private void initializeCallbackReceiverWithSubVerification(int port) {
+        Server server = new Server(port);
+        ServletHandler servletHandler = new ServletHandler();
+        server.setHandler(servletHandler);
+
+        callbackServerServletWithSubVerification = new CallbackServerServletWithSubVerification();
+        callbackServerWithSubVerification = server;
+        executorService.execute(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    ServletHolder servletHolder = new ServletHolder(callbackServerServletWithSubVerification);
+                    servletHandler.addServletWithMapping(servletHolder, "/receiver");
+                    callbackServerWithSubVerification.start();
+                } catch (Exception e) {
+                    log.error("Failed to start the callback server");
+                }
+            }
+        });
     }
 
     private void initializeCallbackReceiver(int port) {
@@ -258,22 +406,42 @@ public class WebSubAPITestCase extends APIMIntegrationBaseTest {
         String payloadUrl = apiEndpoint.replaceAll(":([0-9]+)/", ":" + TOPIC_PORT + "/") +
                 "/webhooks_events_receiver_resource?topic=" + DEFAULT_TOPIC;
         webhookSender = new WebhookSender(payloadUrl, secret);
+        webhookSender.setWebhooksSent(0);
     }
 
-    private static void handleCallbackSubscription(String hubMode, String webSubApiUrl, String callbackUrl,
-                                                   String hubTopic, String hubSecret, String hubLeaseSeconds,
-                                                   String bearerToken)
+    private static void handleCallbackSubscriptionWithQueryParameters(String hubMode, String webSubApiUrl,
+                                                                      String callbackUrl, String hubTopic,
+                                                                      String hubSecret, String hubLeaseSeconds,
+                                                                      String bearerToken)
             throws UnsupportedEncodingException, MalformedURLException, AutomationFrameworkException {
         String encodedUrl = URLEncoder.encode(callbackUrl, StandardCharsets.UTF_8.toString());
-        String url = webSubApiUrl + "?hub.callback=" + encodedUrl + "&hub.mode=" + hubMode + "&hub.secret=" +
-                hubSecret + "&hub.lease_seconds=" + hubLeaseSeconds + "&hub.topic=" + hubTopic;
-        HttpRequestUtil.doPost(new URL(url), "", Collections.singletonMap("Authorization", "Bearer " + bearerToken));
+        String url = webSubApiUrl + "?hub.callback=" + encodedUrl + "&hub.mode=" + hubMode + "&hub.secret=" + hubSecret
+                + "&hub.lease_seconds=" + hubLeaseSeconds + "&hub.topic=" + hubTopic;
+        Map<String, String> headers = new HashMap<>();
+        headers.put(HttpHeaders.AUTHORIZATION, "Bearer " + bearerToken);
+        headers.put(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+        HttpRequestUtil.doPost(new URL(url), "", headers);
+    }
+
+    private static HttpResponse handleCallbackSubscriptionWithFormUrlEncoded(String hubMode, String url,
+                                                                             String callbackUrl, String hubTopic,
+                                                                             String hubSecret, String hubLeaseSeconds,
+                                                                             String bearerToken)
+            throws UnsupportedEncodingException, MalformedURLException, AutomationFrameworkException {
+        String encodedUrl = URLEncoder.encode(callbackUrl, StandardCharsets.UTF_8.toString());
+        String body = "hub.callback=" + encodedUrl + "&hub.mode=" + hubMode + "&hub.secret=" + hubSecret
+                + "&hub.lease_seconds=" + hubLeaseSeconds + "&hub.topic=" + hubTopic;
+        Map<String, String> headers = new HashMap<>();
+        headers.put(HttpHeaders.AUTHORIZATION, "Bearer " + bearerToken);
+        headers.put(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED);
+        return HttpRequestUtil.doPost(new URL(url), body, headers);
     }
 
     @AfterClass(alwaysRun = true)
     public void destroy() throws Exception {
         serverConfigurationManager.restoreToLastConfiguration(false);
         callbackServer.stop();
+        callbackServerWithSubVerification.stop();
         executorService.shutdownNow();
         super.cleanUp();
     }

--- a/pom.xml
+++ b/pom.xml
@@ -1272,7 +1272,7 @@
         <carbon.apimgt.ui.version>9.0.355</carbon.apimgt.ui.version>
 
         <!-- APIM Component Version -->
-        <carbon.apimgt.version>9.26.50</carbon.apimgt.version>
+        <carbon.apimgt.version>9.26.57</carbon.apimgt.version>
 
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1269,7 +1269,7 @@
         <project.scm.id>scm-server</project.scm.id>
         <carbon.analytics.common.version>5.2.41</carbon.analytics.common.version>
         <!-- APIM Portals Component Version -->
-        <carbon.apimgt.ui.version>9.0.355</carbon.apimgt.ui.version>
+        <carbon.apimgt.ui.version>9.0.374</carbon.apimgt.ui.version>
 
         <!-- APIM Component Version -->
         <carbon.apimgt.version>9.26.57</carbon.apimgt.version>


### PR DESCRIPTION
Add conditional subscriber verification.
Add challenge for subscription requests.

To enable subscription verification .
 - Go to publisher portal and click on API Configurations.
 - Under WebSub Configurations select 'Enable subscriber verification' checkbox.

Improve WebSub integration tests.

Fix https://github.com/wso2/api-manager/issues/775

> Related PRs: https://github.com/wso2/carbon-apimgt/pull/11572, https://github.com/wso2/apim-apps/pull/358