### PR TITLE
Fix Self SignUp Issue on the Response Message

### DIFF
--- a/modules/distribution/product/src/main/extensions/self-registration-complete.jsp
+++ b/modules/distribution/product/src/main/extensions/self-registration-complete.jsp
@@ -107,7 +107,7 @@
             } else {
                 if (isEmailNotificationEnabled) {
             %>
-            <p><%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "Confirmation.sent.to.mail")%>
+            <p><%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "User.registration.completed.successfully")%>
             </p>
             <% } else {%>
             <p><%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle,


### PR DESCRIPTION
Message comes from IS product. Since we are directly registering users when self sign up, our passing prop for IS is wrong. Changed it the appropriate one. 

New Screenshot - 
<img width="841" alt="image" src="https://user-images.githubusercontent.com/38649090/201663805-3b2cdabc-ae07-48ae-b21e-fdcc444f5dcf.png">
