### PR TITLE
Bumping the carbon-kernel to 4.8.0-m2

### DIFF
--- a/modules/distribution/product/src/main/assembly/filter.properties
+++ b/modules/distribution/product/src/main/assembly/filter.properties
@@ -3,7 +3,7 @@ product.key=AM
 product.version=4.2.0
 product.wum.name=wso2am
 
-carbon.version=4.8.0-m1
+carbon.version=4.8.0-m2
 am.version=4.2.0
 default.server.role=APIManager
 bundle.creators=org.wso2.carbon.mediator.bridge.MediatorBundleCreator

--- a/modules/p2-profile/product/carbon.product
+++ b/modules/p2-profile/product/carbon.product
@@ -2,7 +2,7 @@
 <?pde version="3.5"?>
 
 <product name="Carbon Product" uid="carbon.product.id" id="carbon.product" application="carbon.application"
-version="4.8.0.m1" useFeatures="true" includeLaunchers="true">
+version="4.8.0.m2" useFeatures="true" includeLaunchers="true">
 
    <configIni use="default">
    </configIni>
@@ -14,7 +14,7 @@ version="4.8.0.m1" useFeatures="true" includeLaunchers="true">
    </plugins>
 
    <features>
-      <feature id="org.wso2.carbon.core.runtime" version="4.8.0.m1"/>
+      <feature id="org.wso2.carbon.core.runtime" version="4.8.0.m2"/>
    </features>
 
   <configurations>

--- a/pom.xml
+++ b/pom.xml
@@ -1273,7 +1273,7 @@
         <carbon.apimgt.ui.version>9.0.387</carbon.apimgt.ui.version>
 
         <!-- APIM Component Version -->
-        <carbon.apimgt.version>9.27.8</carbon.apimgt.version>
+        <carbon.apimgt.version>9.27.10</carbon.apimgt.version>
 
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 
@@ -1286,7 +1286,7 @@
         <carbon.governance.version>4.8.28</carbon.governance.version>
 
         <!--carbon versions-->
-        <carbon.kernel.version>4.8.0-m1</carbon.kernel.version>
+        <carbon.kernel.version>4.8.0-m2</carbon.kernel.version>
         <apimserver.version>4.2.0-SNAPSHOT</apimserver.version>
 
         <cipher.tool.version>1.1.15</cipher.tool.version>


### PR DESCRIPTION
## Purpose
Bump the carbon-kernel version to 4.8.0-m2
Related to https://github.com/wso2/api-manager/issues/973