### PR TITLE
Add missing j2 mappings

### DIFF
--- a/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/axis2.xml.j2
+++ b/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/axis2.xml.j2
@@ -102,6 +102,10 @@
     <!-- use this parameter to override autodetected url -->
     <!--<parameter name="httpFrontendHostUrl" locked="false">https://someotherhost/context</parameter>-->
 
+    {% if axis2_transport.parameter.ApplicationXMLBuilder.allowDTD %}
+    <parameter name="ApplicationXMLBuilder.allowDTD">true</parameter>
+    {% endif %}
+
     <!-- ================================================= -->
     <!--                  Listeners                        -->
     <!-- ================================================= -->

--- a/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/axis2.xml.j2
+++ b/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/axis2.xml.j2
@@ -102,9 +102,9 @@
     <!-- use this parameter to override autodetected url -->
     <!--<parameter name="httpFrontendHostUrl" locked="false">https://someotherhost/context</parameter>-->
 
-    {% if axis2_transport.parameter.ApplicationXMLBuilder.allowDTD %}
-    <parameter name="ApplicationXMLBuilder.allowDTD">true</parameter>
-    {% endif %}
+    {% for parameter_key,parameter_value in axis2_transport.parameter.items() %}
+    <parameter name="{{parameter_key}}" locked="false">{{parameter_value}}</parameter>
+    {% endfor %}
 
     <!-- ================================================= -->
     <!--                  Listeners                        -->

--- a/modules/distribution/product/src/main/resources/conf/templates/repository/conf/registry.xml.j2
+++ b/modules/distribution/product/src/main/resources/conf/templates/repository/conf/registry.xml.j2
@@ -130,13 +130,15 @@
         {% for propKey,propValue in handler.properties.items() %}
         <property name="{{propKey}}">{{propValue}}</property>
         {% endfor %}
-        {% if handler.nested_property.enable %}
-        <property name="{{handler.nested_property.name}}" type="{{handler.nested_property.type}}">
-            {% for prop in nested_properties[handler.nested_property.name] %}
+        {% for nestedProperty in handler.nested_property %}
+        {% if nestedProperty.enable %}
+        <property name="{{nestedProperty.name}}" type="{{nestedProperty.type}}">
+            {% for prop in nestedProperty[nestedProperty.name] %}
                 <{{prop.tag}} {% if prop.key is defined %} key="{{prop.key}}" {% endif %}>{{prop.value}}</{{prop.tag}}>
             {% endfor %}
         </property>
         {% endif %}
+        {% endfor %}
         <filter class="{{handler.filter_class}}">
             {% for filterPropKey,filterPropValue in handler.filter_properties.items() %}
             <property name="{{filterPropKey}}">{{filterPropValue}}</property>

--- a/modules/distribution/product/src/main/resources/conf/templates/repository/deployment/server/synapse-configs/default/inbound-endpoints/SecureWebSocketInboundEndpoint.xml.j2
+++ b/modules/distribution/product/src/main/resources/conf/templates/repository/deployment/server/synapse-configs/default/inbound-endpoints/SecureWebSocketInboundEndpoint.xml.j2
@@ -27,5 +27,8 @@
         {% if apim.wss.ciphers is defined %}
         <parameter name="wss.ssl.cipher.suites">{{apim.wss.ciphers}}</parameter>
         {% endif %}
+        {%if apim.wss.pass_through_control_frames is defined %}
+        <parameter name="ws.pass.through.control.frames">{{apim.wss.pass_through_control_frames}}</parameter>
+        {%endif%}
     </parameters>
 </inboundEndpoint>

--- a/modules/distribution/product/src/main/resources/conf/templates/repository/deployment/server/synapse-configs/default/inbound-endpoints/WebSocketInboundEndpoint.xml.j2
+++ b/modules/distribution/product/src/main/resources/conf/templates/repository/deployment/server/synapse-configs/default/inbound-endpoints/WebSocketInboundEndpoint.xml.j2
@@ -19,5 +19,8 @@
         {%if apim.ws.outflow.dispatch.idleTime is defined %}
         <parameter name="ws.outflow.dispatch.idleTime">{{apim.ws.outflow.dispatch.idleTime}}</parameter>
         {%endif%}
+        {%if apim.ws.pass_through_control_frames is defined %}
+        <parameter name="ws.pass.through.control.frames">{{apim.ws.pass_through_control_frames}}</parameter>
+        {%endif%}
     </parameters>
 </inboundEndpoint> 


### PR DESCRIPTION
This PR resolves https://github.com/wso2/api-manager/issues/910 and https://github.com/wso2/api-manager/issues/949 by adding j2 mappings for `axis2.xml.j2` and `registry.xml.j2`.

To set `ApplicationXMLBuilder.allowDTD` parameter in `axis2.xml`, following config should be added to the deployment.toml.
```
[axis2_transport.parameter]
'ApplicationXMLBuilder.allowDTD' = true
```

Also, this PR contains changes for `SecureWebSocketInboundEndpoint.xml.j2` and `WebSocketInboundEndpoint.xml.j2` to add pass through control frames config for web sockets. Related deployment.toml config is as follows.
```
[apim.ws]
pass_through_control_frames = true

[apim.wss]
pass_through_control_frames = true
```