### PR TITLE
Upgrade component dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1270,10 +1270,10 @@
         <project.scm.id>scm-server</project.scm.id>
         <carbon.analytics.common.version>5.2.48</carbon.analytics.common.version>
         <!-- APIM Portals Component Version -->
-        <carbon.apimgt.ui.version>9.0.391</carbon.apimgt.ui.version>
+        <carbon.apimgt.ui.version>9.0.390</carbon.apimgt.ui.version>
 
         <!-- APIM Component Version -->
-        <carbon.apimgt.version>9.28.3</carbon.apimgt.version>
+        <carbon.apimgt.version>9.28.5</carbon.apimgt.version>
 
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1268,28 +1268,28 @@
     <properties>
 
         <project.scm.id>scm-server</project.scm.id>
-        <carbon.analytics.common.version>5.2.45</carbon.analytics.common.version>
+        <carbon.analytics.common.version>5.2.48</carbon.analytics.common.version>
         <!-- APIM Portals Component Version -->
-        <carbon.apimgt.ui.version>9.0.387</carbon.apimgt.ui.version>
+        <carbon.apimgt.ui.version>9.0.391</carbon.apimgt.ui.version>
 
         <!-- APIM Component Version -->
-        <carbon.apimgt.version>9.27.16</carbon.apimgt.version>
+        <carbon.apimgt.version>9.28.3</carbon.apimgt.version>
 
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 
         <!-- Carbon Registry -->
-        <carbon.registry.version>4.8.3</carbon.registry.version>
+        <carbon.registry.version>4.8.9</carbon.registry.version>
         <carbon.registry.package.import.version.range>[4.7.0, 5.0.0)</carbon.registry.package.import.version.range>
 
 
         <!-- Carbon Governance -->
-        <carbon.governance.version>4.8.28</carbon.governance.version>
+        <carbon.governance.version>4.8.29</carbon.governance.version>
 
         <!--carbon versions-->
         <carbon.kernel.version>4.8.0-m1</carbon.kernel.version>
         <apimserver.version>4.2.0-SNAPSHOT</apimserver.version>
 
-        <cipher.tool.version>1.1.15</cipher.tool.version>
+        <cipher.tool.version>1.1.20</cipher.tool.version>
 
         <carbon.commons.version>4.9.0</carbon.commons.version>
         <carbon.kernel.imp.pkg.version>[4.5.0, 5.0.0)</carbon.kernel.imp.pkg.version>
@@ -1326,9 +1326,9 @@
 
 
         <!-- Carbon Multitenancy version-->
-        <carbon.multitenancy.version>4.9.10</carbon.multitenancy.version>
+        <carbon.multitenancy.version>4.9.20</carbon.multitenancy.version>
 
-        <siddhi.version>3.2.8</siddhi.version>
+        <siddhi.version>3.2.9</siddhi.version>
 
         <axis2-transports.wso2.version>2.0.0-wso2v42</axis2-transports.wso2.version>
         <cxf-bundle.version>2.6.1.wso2v2</cxf-bundle.version>
@@ -1340,9 +1340,9 @@
         <opencsv.version>1.8</opencsv.version>
         <poi.version>3.0-FINAL</poi.version>
         <woden.version>1.0.0.M8-wso2v1</woden.version>
-        <synapse.version>2.1.7-wso2v313</synapse.version>
+        <synapse.version>2.1.7-wso2v314</synapse.version>
         <passthru.transport.patch.version>1.0.2</passthru.transport.patch.version>
-        <axis2.wso2.version>1.6.1-wso2v83</axis2.wso2.version>
+        <axis2.wso2.version>1.6.1-wso2v85</axis2.wso2.version>
         <axiom.wso2.version>1.2.11-wso2v25</axiom.wso2.version>
         <servlet-api.version>2.5</servlet-api.version>
         <log4j.version>1.2.13</log4j.version>


### PR DESCRIPTION
This PR upgrades component dependencies for APIM 4.2.0 alpha release.

Fixes https://github.com/wso2/api-manager/issues/986