### PR TITLE
Kernel 4.8.0-m2 Update

### DIFF
--- a/modules/distribution/product/src/main/assembly/filter.properties
+++ b/modules/distribution/product/src/main/assembly/filter.properties
@@ -3,7 +3,7 @@ product.key=AM
 product.version=4.2.0
 product.wum.name=wso2am
 
-carbon.version=4.8.0-m1
+carbon.version=4.8.0-m2
 am.version=4.2.0
 default.server.role=APIManager
 bundle.creators=org.wso2.carbon.mediator.bridge.MediatorBundleCreator

--- a/modules/p2-profile/product/carbon.product
+++ b/modules/p2-profile/product/carbon.product
@@ -2,7 +2,7 @@
 <?pde version="3.5"?>
 
 <product name="Carbon Product" uid="carbon.product.id" id="carbon.product" application="carbon.application"
-version="4.8.0.m1" useFeatures="true" includeLaunchers="true">
+version="4.8.0.m2" useFeatures="true" includeLaunchers="true">
 
    <configIni use="default">
    </configIni>
@@ -14,7 +14,7 @@ version="4.8.0.m1" useFeatures="true" includeLaunchers="true">
    </plugins>
 
    <features>
-      <feature id="org.wso2.carbon.core.runtime" version="4.8.0.m1"/>
+      <feature id="org.wso2.carbon.core.runtime" version="4.8.0.m2"/>
    </features>
 
   <configurations>

--- a/pom.xml
+++ b/pom.xml
@@ -1268,12 +1268,12 @@
     <properties>
 
         <project.scm.id>scm-server</project.scm.id>
-        <carbon.analytics.common.version>5.2.48</carbon.analytics.common.version>
+        <carbon.analytics.common.version>5.3.1</carbon.analytics.common.version>
         <!-- APIM Portals Component Version -->
         <carbon.apimgt.ui.version>9.0.390</carbon.apimgt.ui.version>
 
         <!-- APIM Component Version -->
-        <carbon.apimgt.version>9.28.7</carbon.apimgt.version>
+        <carbon.apimgt.version>9.28.8</carbon.apimgt.version>
 
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 
@@ -1286,12 +1286,12 @@
         <carbon.governance.version>4.8.29</carbon.governance.version>
 
         <!--carbon versions-->
-        <carbon.kernel.version>4.8.0-m1</carbon.kernel.version>
+        <carbon.kernel.version>4.8.0-m2</carbon.kernel.version>
         <apimserver.version>4.2.0-SNAPSHOT</apimserver.version>
 
         <cipher.tool.version>1.1.20</cipher.tool.version>
 
-        <carbon.commons.version>4.9.0</carbon.commons.version>
+        <carbon.commons.version>4.9.2</carbon.commons.version>
         <carbon.kernel.imp.pkg.version>[4.5.0, 5.0.0)</carbon.kernel.imp.pkg.version>
 
         <!-- carbon mediation -->
@@ -1409,7 +1409,7 @@
         <carbon.metrics.version>1.3.12</carbon.metrics.version>
         <!-- MB Features -->
         <carbon.messaging.version>3.3.26</carbon.messaging.version>
-        <carbon.event-processing.version>2.3.4</carbon.event-processing.version>
+        <carbon.event-processing.version>2.3.5</carbon.event-processing.version>
         <andes.version>3.3.24</andes.version>
         <orbit.version.geronimo-jms_1.1_spec>1.1.1.wso2v1</orbit.version.geronimo-jms_1.1_spec>
         <commons-digester.version>1.8.1</commons-digester.version>


### PR DESCRIPTION
Related to
https://github.com/wso2/api-manager/issues/973

In order to work correctly with new 4.8.0-m2 version of Kernel, some other versions should be bumped.

> carbon.analytics.commons
> carbon.commons
> carbon.event.processing
> carbon.apimgt which includes kernel:4.8.0-m2

Those versions will also be updated alongside Kernel in this PR