### PR TITLE
syntax error fix

### DIFF
--- a/modules/distribution/product/src/main/extensions/error.jsp
+++ b/modules/distribution/product/src/main/extensions/error.jsp
@@ -45,7 +45,7 @@
 <%-- Data for the layout from the page --%>
 <%
     layoutData.put("containerSize", "large");
-
+%>
 <!doctype html>
 <html>
 <head>


### PR DESCRIPTION
Fix for the issue :No Validation for Wrong Username Formats in "Forgot Password" Option and Throw a Exception When Trying with a Username with"@"