### PR TITLE
Update Gson dependancy version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1392,7 +1392,7 @@
         <rampart.wso2.version>1.6.1-wso2v43</rampart.wso2.version>
         <slf4j.api.version>1.7.28</slf4j.api.version>
         <org.slf4j.version>1.7.30</org.slf4j.version>
-        <google.code.gson.version>2.8.9</google.code.gson.version>
+        <google.code.gson.version>2.9.1</google.code.gson.version>
         <carbon.extension.identity.oauth2.grantType.token.exchange>1.0.1</carbon.extension.identity.oauth2.grantType.token.exchange>
 
         <!-- Developer Portal -->
@@ -1424,7 +1424,7 @@
         <maven-plugin-version>1.0.0</maven-plugin-version>
         <log4j.version>1.2.13</log4j.version>
         <com.squareup.okhttp.version>2.7.5</com.squareup.okhttp.version>
-        <com.google.code.gson.version>2.7</com.google.code.gson.version>
+        <com.google.code.gson.version>2.9.1</com.google.code.gson.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 


### PR DESCRIPTION
This PR contains a commit which updates com.google.code.gson version to 2.9.1
