### PR TITLE
Fix missing J2 configurations in the registry.xml.j2 file

### DIFF
--- a/modules/distribution/product/src/main/resources/conf/templates/repository/conf/registry.xml.j2
+++ b/modules/distribution/product/src/main/resources/conf/templates/repository/conf/registry.xml.j2
@@ -301,6 +301,9 @@
 
     <!-- This defines index configuration which is used in meta data search feature of the registry -->
     <indexingConfiguration>
+        {% if indexing.skip_roles_regex is defined %}
+        <skipRolesByRegex>{{indexing.skip_roles_regex}}</skipRolesByRegex>
+        {% endif %}
         <startIndexing>{{indexing.enable}}</startIndexing>
         <skipCache>true</skipCache>
         <startingDelayInSeconds>{{indexing.starting_delay}}</startingDelayInSeconds>


### PR DESCRIPTION
### Purpose
To fix missing J2 configurations in the registry.xml.j2 file for indexingConfiguration to set skipRolesByRegex.

### Goal
Fixes: https://github.com/wso2/api-manager/issues/1195

### Instructions
Add the below part in the deployment.toml to set the property value.
```
[indexing]
skip_roles_regex = "application\\/.*"
```