### PR TITLE
Upgrade CXF version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1321,7 +1321,7 @@
         <saml.common.util.version.range>[1.0.0,2.0.0)</saml.common.util.version.range>
 
         <!-- carbon deployment -->
-        <carbon.deployment.version>4.11.4</carbon.deployment.version>
+        <carbon.deployment.version>4.11.6</carbon.deployment.version>
 
 
 
@@ -1383,7 +1383,7 @@
         <carbon.automation.version>4.4.10</carbon.automation.version>
         <carbon.automationutils.version>4.5.3</carbon.automationutils.version>
         <testng.version>6.11</testng.version>
-        <org.apache.cxf.version>3.5.0</org.apache.cxf.version>
+        <org.apache.cxf.version>3.5.5</org.apache.cxf.version>
         <org.apache.axis2.transport.version>2.0.0-wso2v66</org.apache.axis2.transport.version> <!-- not used -->
         <org.springframework.version>5.1.13.RELEASE</org.springframework.version>
         <org.apache.tomcat>7.0.96</org.apache.tomcat>


### PR DESCRIPTION
Upgrades CXF version to 3.5.5.

Related carbon-deployment PR : https://github.com/wso2/carbon-deployment/pull/382
Related carbon-apimgt PR : https://github.com/wso2/carbon-apimgt/pull/11782
Git issue : https://github.com/wso2/api-manager/issues/1227