### PR TITLE
Add JSON array claims to backend JWT test cases

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/jwt/FederatedUserJWTTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/jwt/FederatedUserJWTTestCase.java
@@ -288,6 +288,9 @@ public class FederatedUserJWTTestCase extends APIManagerLifecycleBaseTest {
             assertTrue("JWT claim givenname  not received" + claim, claim.contains("first name".concat(endUser)));
             claim = jsonObject.getString("http://wso2.org/claims/lastname");
             assertTrue("JWT claim lastname  not received" + claim, claim.contains("last name".concat(endUser)));
+            claim = jsonObject.getString("http://wso2.org/claims/region");
+            assertTrue("JWT claim region not received" + claim,
+                    claim.contains("[{\"areaId\":\"71224\",\"areaName\":\"20-NYU\"}]"));
             claim = jsonObject.getString("mobile");
             assertTrue("JWT claim mobile  not received" + claim, claim.contains("94123456987"));
             claim = jsonObject.getString("organization");
@@ -532,6 +535,8 @@ public class FederatedUserJWTTestCase extends APIManagerLifecycleBaseTest {
             remoteUserStoreManagerServiceClient.setUserClaimValue(user,
                     "http://wso2.org/claims/lastname", "last name".concat(user), DEFAULT_PROFILE);
             remoteUserStoreManagerServiceClient.setUserClaimValue(user,
+                    "http://wso2.org/claims/region", "[{'areaId':'71224','areaName':'20-NYU'}]", DEFAULT_PROFILE);
+            remoteUserStoreManagerServiceClient.setUserClaimValue(user,
                     "http://wso2.org/claims/organization", "ABC".concat(user), DEFAULT_PROFILE);
             remoteUserStoreManagerServiceClient.setUserClaimValue(user,
                     "http://wso2.org/claims/mobile", "94123456987", DEFAULT_PROFILE);
@@ -660,7 +665,7 @@ public class FederatedUserJWTTestCase extends APIManagerLifecycleBaseTest {
             throws OAuthAdminServiceIdentityOAuthAdminException, RemoteException,
             IdentityApplicationManagementServiceIdentityApplicationManagementException {
         String[] requestedClaims = { "http://wso2.org/claims/givenname", "http://wso2.org/claims/lastname",
-                "http://wso2.org/claims/mobile", "http://wso2.org/claims/organization",
+                "http://wso2.org/claims/region", "http://wso2.org/claims/mobile", "http://wso2.org/claims/organization",
                 "http://wso2.org/claims/telephone", "http://wso2.org/claims/emailaddress" };
         OAuthConsumerAppDTO oAuthApplicationData = oAuthAdminServiceClient.getOAuthApplicationData(consumerKey);
         String applicationName = oAuthApplicationData.getApplicationName();

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/jwt/JWTTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/jwt/JWTTestCase.java
@@ -297,6 +297,9 @@ public class JWTTestCase extends APIManagerLifecycleBaseTest {
             assertTrue("JWT claim givenname  not received" + claim, claim.contains("first name".concat(endUser)));
             claim = jsonObject.getString("http://wso2.org/claims/lastname");
             assertTrue("JWT claim lastname  not received" + claim, claim.contains("last name".concat(endUser)));
+            claim = jsonObject.getString("http://wso2.org/claims/region");
+            assertTrue("JWT claim region not received" + claim,
+                    claim.contains("[{\"areaId\":\"71224\",\"areaName\":\"20-NYU\"}]"));
             claim = jsonObject.getString("mobile");
             assertTrue("JWT claim mobile  not received" + claim, claim.contains("94123456987"));
             claim = jsonObject.getString("organization");
@@ -524,6 +527,8 @@ public class JWTTestCase extends APIManagerLifecycleBaseTest {
             remoteUserStoreManagerServiceClient.setUserClaimValue(user,
                     "http://wso2.org/claims/lastname", "last name".concat(user), DEFAULT_PROFILE);
             remoteUserStoreManagerServiceClient.setUserClaimValue(user,
+                    "http://wso2.org/claims/region", "[{'areaId':'71224','areaName':'20-NYU'}]", DEFAULT_PROFILE);
+            remoteUserStoreManagerServiceClient.setUserClaimValue(user,
                     "http://wso2.org/claims/organization", "ABC".concat(user), DEFAULT_PROFILE);
             remoteUserStoreManagerServiceClient.setUserClaimValue(user,
                     "http://wso2.org/claims/mobile", "94123456987", DEFAULT_PROFILE);
@@ -545,8 +550,8 @@ public class JWTTestCase extends APIManagerLifecycleBaseTest {
     private void updateServiceProviderWithRequiredClaims(String consumerKey)
             throws OAuthAdminServiceIdentityOAuthAdminException, RemoteException,
             IdentityApplicationManagementServiceIdentityApplicationManagementException {
-        String[] requestedClaims = {"http://wso2.org/claims/givenname","http://wso2.org/claims/lastname","http://wso2" +
-                ".org/claims/organization","http://wso2.org/claims/mobile"};
+        String[] requestedClaims = {"http://wso2.org/claims/givenname","http://wso2.org/claims/lastname",
+                "http://wso2.org/claims/region","http://wso2.org/claims/organization","http://wso2.org/claims/mobile"};
         OAuthConsumerAppDTO oAuthApplicationData = oAuthAdminServiceClient.getOAuthApplicationData(consumerKey);
         String applicationName = oAuthApplicationData.getApplicationName();
         ServiceProvider application = applicationManagementClient.getApplication(applicationName);
@@ -707,6 +712,9 @@ public class JWTTestCase extends APIManagerLifecycleBaseTest {
         assertTrue("JWT claim givenname  not received" + claim, claim.contains("first name".concat(endUser)));
         claim = decodedJWTJSONObject.getString("http://wso2.org/claims/lastname");
         assertTrue("JWT claim lastname  not received" + claim, claim.contains("last name".concat(endUser)));
+        claim = decodedJWTJSONObject.getString("http://wso2.org/claims/region");
+        assertTrue("JWT claim region not received" + claim,
+                claim.contains("[{\"areaId\":\"71224\",\"areaName\":\"20-NYU\"}]"));
         claim = decodedJWTJSONObject.getString("http://wso2.org/claims/mobile");
         assertTrue("JWT claim mobile  not received" + claim, claim.contains("94123456987"));
         claim = decodedJWTJSONObject.getString("http://wso2.org/claims/organization");

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/jwt/urlsafe/URLSafeJWTTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/jwt/urlsafe/URLSafeJWTTestCase.java
@@ -166,6 +166,9 @@ public class URLSafeJWTTestCase extends APIManagerLifecycleBaseTest {
         assertTrue("JWT claim givenname  not received" + claim, claim.contains("first name"));
         claim = jsonObject.getString("http://wso2.org/claims/lastname");
         assertTrue("JWT claim lastname  not received" + claim, claim.contains("last name"));
+        claim = jsonObject.getString("http://wso2.org/claims/region");
+        assertTrue("JWT claim region not received" + claim,
+                claim.contains("[{\"areaId\":\"71224\",\"areaName\":\"20-NYU\"}]"));
         boolean bExceptionOccured = false;
         try {
             jsonObject.getString("http://wso2.org/claims/wrongclaim");
@@ -276,6 +279,8 @@ public class URLSafeJWTTestCase extends APIManagerLifecycleBaseTest {
                 "http://wso2.org/claims/givenname", "first name", DEFAULT_PROFILE);
         remoteUserStoreManagerServiceClient.setUserClaimValue(enduserName,
                 "http://wso2.org/claims/lastname", "last name", DEFAULT_PROFILE);
+        remoteUserStoreManagerServiceClient.setUserClaimValue(enduserName,
+                "http://wso2.org/claims/region", "[{'areaId':'71224','areaName':'20-NYU'}]", DEFAULT_PROFILE);
 
     }
 


### PR DESCRIPTION
This PR adds the JSON array claims to backend JWT test cases.

Related issue https://github.com/wso2/api-manager/issues/997