### PR TITLE
Adding configuration to disable the http_access logs

### DIFF
--- a/modules/distribution/product/src/main/resources/conf/default.json
+++ b/modules/distribution/product/src/main/resources/conf/default.json
@@ -269,6 +269,7 @@
   "http_access_log.prefix": "http_access_",
   "http_access_log.suffix": ".log",
   "http_access_log.pattern": "%h %l %u %t %r %s %b %{Referer}i %{User-Agent}i %T",
+  "http_access_log.enabled": true,
   "server.hide_menu_items": [
     "claim_mgt_menu",
     "identity_mgt_emailtemplate_menu",

--- a/modules/distribution/product/src/main/resources/conf/templates/repository/conf/tomcat/catalina-server.xml.j2
+++ b/modules/distribution/product/src/main/resources/conf/templates/repository/conf/tomcat/catalina-server.xml.j2
@@ -83,7 +83,7 @@
                 {% else %}
                 <Valve className="org.apache.catalina.valves.AccessLogValve" directory="{{http_access_log.directory}}"
                        prefix="{{http_access_log.prefix}}" suffix="{{http_access_log.suffix}}" pattern="{{http_access_log.pattern}}"
-                       maxDays="{{http_access_log.maxDays}}"/>
+                       maxDays="{{http_access_log.maxDays}}" enabled="{{http_access_log.enabled}}"/>
                 {% endif %}
                 <Valve className="org.wso2.carbon.tomcat.ext.valves.CarbonStuckThreadDetectionValve" threshold="600"/>
                 <Valve className="org.wso2.carbon.tomcat.ext.valves.CompositeValve"/>

--- a/modules/is-km/default.json
+++ b/modules/is-km/default.json
@@ -211,6 +211,7 @@
   "http_access_log.prefix": "http_access_",
   "http_access_log.suffix": ".log",
   "http_access_log.pattern": "%h %l %u %t %r %s %b %{Referer}i %{User-Agent}i %T",
+  "http_access_log.enabled": true,
   "server.hide_menu_items": [
     "claim_mgt_menu",
     "identity_mgt_emailtemplate_menu",


### PR DESCRIPTION
This improvement is to enable/disable http access log valve. The following config in repository/conf/deployment.toml can be used to enable/disable the access log valve in catalina-server.xml file.

```
[http_access_log]
enabled = false
```