### PR TITLE
Remove opensaml_3.3.1.wso2v4.jar from APIM distribution

### DIFF
--- a/modules/distribution/product/src/main/assembly/bin.xml
+++ b/modules/distribution/product/src/main/assembly/bin.xml
@@ -169,6 +169,7 @@
                 <exclude>**/repository/components/plugins/commons-io_2.4.0.wso2v1.jar</exclude>
                 <exclude>**/repository/components/plugins/opensaml_3.3.1.wso2v1.jar</exclude>
                 <exclude>**/repository/components/plugins/opensaml_3.3.1.wso2v2.jar</exclude>
+                <exclude>**/repository/components/plugins/opensaml_3.3.1.wso2v4.jar</exclude>
                 <exclude>**/lib/xalan*.jar</exclude>
             </excludes>
         </fileSet>


### PR DESCRIPTION
Fixes https://github.com/wso2/api-manager/issues/1268 by removing redundant opensaml_3.3.1.wso2v4.jar 