### PR TITLE
Upgrade synapse version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1340,7 +1340,7 @@
         <opencsv.version>1.8</opencsv.version>
         <poi.version>3.0-FINAL</poi.version>
         <woden.version>1.0.0.M8-wso2v1</woden.version>
-        <synapse.version>4.0.0-wso2v5</synapse.version>
+        <synapse.version>4.0.0-wso2v9</synapse.version>
         <passthru.transport.patch.version>1.0.2</passthru.transport.patch.version>
         <axis2.wso2.version>1.6.1-wso2v85</axis2.wso2.version>
         <axiom.wso2.version>1.2.11-wso2v25</axiom.wso2.version>


### PR DESCRIPTION
Upgrades synapse version to reflect the okio and okhttp version upgrade in [1]. Fixes [2].

[1]. https://github.com/wso2/wso2-synapse/pull/2041
[2]. https://github.com/wso2/api-manager/issues/1225