### PR TITLE
Upgrade nimbus version for 4.2.0 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1273,7 +1273,7 @@
         <carbon.apimgt.ui.version>9.0.408</carbon.apimgt.ui.version>
 
         <!-- APIM Component Version -->
-        <carbon.apimgt.version>9.28.49</carbon.apimgt.version>
+        <carbon.apimgt.version>9.28.54</carbon.apimgt.version>
 
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 
@@ -1302,7 +1302,7 @@
         <carbon.identity.governance.version>1.7.2</carbon.identity.governance.version>
         <carbon.identity.event.handler.account.lock.version>1.7.1</carbon.identity.event.handler.account.lock.version>
         <carbon.identity.event.handler.notification.version>1.6.0</carbon.identity.event.handler.notification.version>
-        <carbon.identity-inbound-auth-oauth.version>6.9.4</carbon.identity-inbound-auth-oauth.version>
+        <carbon.identity-inbound-auth-oauth.version>6.9.5</carbon.identity-inbound-auth-oauth.version>
         <carbon.identity-data-publisher-oauth.version>1.5.1</carbon.identity-data-publisher-oauth.version>
         <carbon.identity-user-ws.version>5.6.1</carbon.identity-user-ws.version>
         <carbon.identity-inbound-auth-openid.version>5.8.0</carbon.identity-inbound-auth-openid.version>


### PR DESCRIPTION
This PR updates the carbon-apimgt version and identity-inbound-auth-oauth version for nimbus upgrade

Related issue: https://github.com/wso2/api-manager/issues/1234