### PR TITLE
Increase polling interval to 5 seconds

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/logging/CorrelationLoggingTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/logging/CorrelationLoggingTest.java
@@ -177,7 +177,7 @@ public class CorrelationLoggingTest extends APIManagerLifecycleBaseTest {
         // Validate Correlation Logs
         /* await() is from Awaitility library which is used to read correlation.log file within a timeout period as
         there is varying delay in file writing */
-        with().pollInterval(1, TimeUnit.SECONDS).await().atMost(30, TimeUnit.SECONDS).untilAsserted(()-> {
+        with().pollInterval(5, TimeUnit.SECONDS).await().atMost(30, TimeUnit.SECONDS).untilAsserted(()-> {
             resetAllLogs();
             InvokeTestAPI();
             String logLine;
@@ -189,15 +189,15 @@ public class CorrelationLoggingTest extends APIManagerLifecycleBaseTest {
                 isMethodCallsLogLine(logLine);
                 isCorrelationIDLogLine(logLine);
             }
-            log.info(String.format("***testEnableAllCorrelationLoggingConfigsTest: httpLog:%b, synapseLog:%b, " +
-                            "methodCallsLog:%b, correlationIDLog:%b", httpLog, synapseLog, methodCallsLog,
+            log.info(String.format("***testEnableAllCorrelationLoggingConfigsTest:Enable: httpLog:%b, jdbc:%b, synapseLog:%b, " +
+                            "methodCallsLog:%b, correlationIDLog:%b", httpLog, jdbcLog, synapseLog, methodCallsLog,
                     correlationIDLog));
             assertTrue(httpLog && jdbcLog && synapseLog && methodCallsLog && correlationIDLog);
         });
 
         // Disabling all correlation log components for next tests
         configureCorrelationLoggingComponent(new String[] {"http", "jdbc", "synapse", "ldap", "method-calls"}, false);
-        with().pollInterval(1, TimeUnit.SECONDS).await().atMost(30, TimeUnit.SECONDS).untilAsserted(()-> {
+        with().pollInterval(5, TimeUnit.SECONDS).await().atMost(30, TimeUnit.SECONDS).untilAsserted(()-> {
             resetAllLogs();
             InvokeTestAPI();
             String logLine;
@@ -209,7 +209,7 @@ public class CorrelationLoggingTest extends APIManagerLifecycleBaseTest {
                 isMethodCallsLogLine(logLine);
                 isCorrelationIDLogLine(logLine);
             }
-            log.info(String.format("***testEnableAllCorrelationLoggingConfigsTest: httpLog:%b,  jdbc:%b, synapseLog:%b, " +
+            log.info(String.format("***testEnableAllCorrelationLoggingConfigsTest:Disable: httpLog:%b, jdbc:%b, synapseLog:%b, " +
                             "methodCallsLog:%b, correlationIDLog:%b", httpLog, jdbcLog, synapseLog, methodCallsLog,
                     correlationIDLog));
             assertFalse(httpLog || jdbcLog || synapseLog || methodCallsLog || correlationIDLog);
@@ -226,7 +226,7 @@ public class CorrelationLoggingTest extends APIManagerLifecycleBaseTest {
         // Test HTTP
         log.info("Enabling HTTP component correlation logs");
         configureCorrelationLoggingComponent(new String[]{ "http" }, true);
-        with().pollInterval(1, TimeUnit.SECONDS).await().atMost(30, TimeUnit.SECONDS).untilAsserted(()-> {
+        with().pollInterval(5, TimeUnit.SECONDS).await().atMost(30, TimeUnit.SECONDS).untilAsserted(()-> {
             httpLog = false;
             InvokeTestAPI();
             String logLine;
@@ -238,7 +238,7 @@ public class CorrelationLoggingTest extends APIManagerLifecycleBaseTest {
         });
         log.info("Disabling HTTP component correlation logs");
         configureCorrelationLoggingComponent(new String[] { "http" }, false);
-        with().pollInterval(1, TimeUnit.SECONDS).await().atMost(30, TimeUnit.SECONDS).untilAsserted(()-> {
+        with().pollInterval(5, TimeUnit.SECONDS).await().atMost(30, TimeUnit.SECONDS).untilAsserted(()-> {
             httpLog = false;
             InvokeTestAPI();
             String logLine;
@@ -253,7 +253,7 @@ public class CorrelationLoggingTest extends APIManagerLifecycleBaseTest {
         // Test JDBC
         log.info("Enabling JDBC component correlation logs");
         configureCorrelationLoggingComponent(new String[] { "jdbc" }, true);
-        with().pollInterval(1, TimeUnit.SECONDS).await().atMost(30, TimeUnit.SECONDS).untilAsserted(()-> {
+        with().pollInterval(5, TimeUnit.SECONDS).await().atMost(30, TimeUnit.SECONDS).untilAsserted(()-> {
             jdbcLog = false;
             InvokeTestAPI();
             String logLine;
@@ -265,7 +265,7 @@ public class CorrelationLoggingTest extends APIManagerLifecycleBaseTest {
         });
         log.info("Disabling JDBC component correlation logs");
         configureCorrelationLoggingComponent(new String[] { "jdbc" }, false);
-        with().pollInterval(1, TimeUnit.SECONDS).await().atMost(30, TimeUnit.SECONDS).untilAsserted(()-> {
+        with().pollInterval(5, TimeUnit.SECONDS).await().atMost(30, TimeUnit.SECONDS).untilAsserted(()-> {
             jdbcLog = false;
             InvokeTestAPI();
             String logLine;
@@ -279,7 +279,7 @@ public class CorrelationLoggingTest extends APIManagerLifecycleBaseTest {
         // Test Method-calls
         log.info("Enabling Method-calls component correlation logs");
         configureCorrelationLoggingComponent(new String[] { "method-calls" }, true);
-        with().pollInterval(1, TimeUnit.SECONDS).await().atMost(30, TimeUnit.SECONDS).untilAsserted(()-> {
+        with().pollInterval(5, TimeUnit.SECONDS).await().atMost(30, TimeUnit.SECONDS).untilAsserted(()-> {
             methodCallsLog = false;
             InvokeTestAPI();
             String logLine;
@@ -291,7 +291,7 @@ public class CorrelationLoggingTest extends APIManagerLifecycleBaseTest {
         });
         log.info("Disabling Method-calls component correlation logs");
         configureCorrelationLoggingComponent(new String[] { "method-calls" }, false);
-        with().pollInterval(1, TimeUnit.SECONDS).await().atMost(30, TimeUnit.SECONDS).untilAsserted(()-> {
+        with().pollInterval(5, TimeUnit.SECONDS).await().atMost(30, TimeUnit.SECONDS).untilAsserted(()-> {
             methodCallsLog = false;
             InvokeTestAPI();
             String logLine;
@@ -305,7 +305,7 @@ public class CorrelationLoggingTest extends APIManagerLifecycleBaseTest {
         // Test Synapse
         log.info("Enabling Synapse component correlation logs");
         configureCorrelationLoggingComponent(new String[] { "synapse" }, true);
-        with().pollInterval(1, TimeUnit.SECONDS).await().atMost(30, TimeUnit.SECONDS).untilAsserted(()-> {
+        with().pollInterval(5, TimeUnit.SECONDS).await().atMost(30, TimeUnit.SECONDS).untilAsserted(()-> {
             synapseLog = false;
             InvokeTestAPI();
             String logLine;
@@ -317,7 +317,7 @@ public class CorrelationLoggingTest extends APIManagerLifecycleBaseTest {
         });
         log.info("Disabling Synapse component correlation logs");
         configureCorrelationLoggingComponent(new String[] { "synapse" }, false);
-        with().pollInterval(1, TimeUnit.SECONDS).await().atMost(30, TimeUnit.SECONDS).untilAsserted(()-> {
+        with().pollInterval(5, TimeUnit.SECONDS).await().atMost(30, TimeUnit.SECONDS).untilAsserted(()-> {
             synapseLog = false;
             InvokeTestAPI();
             String logLine;
@@ -334,7 +334,7 @@ public class CorrelationLoggingTest extends APIManagerLifecycleBaseTest {
     public void testPersistedCorrelationConfigs() throws Exception {
         log.info("Enabling http, method-calls correlation component logs before a restart");
         configureCorrelationLoggingComponent(new String[] { "http", "method-calls" }, true);
-        with().pollInterval(1, TimeUnit.SECONDS).await().atMost(30, TimeUnit.SECONDS).untilAsserted(()-> {
+        with().pollInterval(5, TimeUnit.SECONDS).await().atMost(30, TimeUnit.SECONDS).untilAsserted(()-> {
             httpLog = false;
             methodCallsLog = false;
             InvokeTestAPI();
@@ -348,7 +348,7 @@ public class CorrelationLoggingTest extends APIManagerLifecycleBaseTest {
         });
 
         serverConfigurationManager.restartGracefully();
-        with().pollInterval(1, TimeUnit.SECONDS).await().atMost(60, TimeUnit.SECONDS).untilAsserted(()-> {
+        with().pollInterval(5, TimeUnit.SECONDS).await().atMost(60, TimeUnit.SECONDS).untilAsserted(()-> {
             logHandlerStarted = false;
             String logLine;
             while ((logLine = bufferedReader.readLine()) != null) {
@@ -358,7 +358,7 @@ public class CorrelationLoggingTest extends APIManagerLifecycleBaseTest {
             assertTrue(logHandlerStarted);
         });
 
-        with().pollInterval(1, TimeUnit.SECONDS).await().atMost(30, TimeUnit.SECONDS).untilAsserted(()-> {
+        with().pollInterval(5, TimeUnit.SECONDS).await().atMost(30, TimeUnit.SECONDS).untilAsserted(()-> {
             httpLog = false;
             methodCallsLog = false;
             InvokeTestAPI();
@@ -372,7 +372,7 @@ public class CorrelationLoggingTest extends APIManagerLifecycleBaseTest {
         });
 
         configureCorrelationLoggingComponent(new String[] { "http", "method-calls" }, false);
-        with().pollInterval(1, TimeUnit.SECONDS).await().atMost(30, TimeUnit.SECONDS).untilAsserted(()-> {
+        with().pollInterval(5, TimeUnit.SECONDS).await().atMost(30, TimeUnit.SECONDS).untilAsserted(()-> {
             httpLog = false;
             methodCallsLog = false;
             InvokeTestAPI();


### PR DESCRIPTION
Related to https://github.com/wso2/api-manager/issues/1204

Noticed test failures due to 429 HTTP response code in Jenkins build. Therefore, increasing the polling interval.