### PR TITLE
Upgrade carbon-messaging version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1409,7 +1409,7 @@
         <carbon.metrics.version>1.3.12</carbon.metrics.version>
         <!-- MB Features -->
         <carbon.messaging.version>3.3.27</carbon.messaging.version>
-        <carbon.event-processing.version>2.3.5</carbon.event-processing.version>
+        <carbon.event-processing.version>2.3.6</carbon.event-processing.version>
         <andes.version>3.3.24</andes.version>
         <orbit.version.geronimo-jms_1.1_spec>1.1.1.wso2v1</orbit.version.geronimo-jms_1.1_spec>
         <commons-digester.version>1.8.1</commons-digester.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1408,7 +1408,7 @@
 
         <carbon.metrics.version>1.3.12</carbon.metrics.version>
         <!-- MB Features -->
-        <carbon.messaging.version>3.3.26</carbon.messaging.version>
+        <carbon.messaging.version>3.3.27</carbon.messaging.version>
         <carbon.event-processing.version>2.3.5</carbon.event-processing.version>
         <andes.version>3.3.24</andes.version>
         <orbit.version.geronimo-jms_1.1_spec>1.1.1.wso2v1</orbit.version.geronimo-jms_1.1_spec>


### PR DESCRIPTION
Upgrades carbon-messaging version to latest to reflect the protobuf-java version upgrade in PR [1].
Related carbon-apimgt PR : https://github.com/wso2/carbon-apimgt/pull/11816

[1]. https://github.com/wso2/carbon-business-messaging/pull/718