### PR TITLE
Upgrade carbon-mediation version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1295,7 +1295,7 @@
         <carbon.kernel.imp.pkg.version>[4.5.0, 5.0.0)</carbon.kernel.imp.pkg.version>
 
         <!-- carbon mediation -->
-        <carbon.mediation.version>4.7.157</carbon.mediation.version>
+        <carbon.mediation.version>4.7.163</carbon.mediation.version>
 
         <!-- carbon identity -->
         <carbon.identity.version>5.24.4</carbon.identity.version>


### PR DESCRIPTION
Upgrades carbon mediation version to reflect netty version upgrade in [1].
Related git issue : https://github.com/wso2/api-manager/issues/1221
Related carbon PR : https://github.com/wso2/carbon-apimgt/pull/11819

[1]. https://github.com/wso2/carbon-mediation/pull/1667