### PR TITLE
Upgrade analytics-common and jsonpath versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1268,7 +1268,7 @@
     <properties>
 
         <project.scm.id>scm-server</project.scm.id>
-        <carbon.analytics.common.version>5.3.2</carbon.analytics.common.version>
+        <carbon.analytics.common.version>5.3.4</carbon.analytics.common.version>
         <!-- APIM Portals Component Version -->
         <carbon.apimgt.ui.version>9.0.411</carbon.apimgt.ui.version>
 
@@ -1438,7 +1438,7 @@
         <carbon.consent.mgt.version>2.4.1</carbon.consent.mgt.version>
         <carbon.database.utils.version>2.1.5</carbon.database.utils.version>
 
-        <com.jayway.jsonpath.version>2.4.0.wso2v2</com.jayway.jsonpath.version>
+        <com.jayway.jsonpath.version>2.6.0.wso2v1</com.jayway.jsonpath.version>
         <!-- xml testing library -->
         <xml.unit.verions>2.6.2</xml.unit.verions>
         <version.cava-toml>0.5.0</version.cava-toml>


### PR DESCRIPTION

Upgrades carbon-analytics-common version to reflect jsonpath upgrade in PR [1].
Related git issue : https://github.com/wso2/api-manager/issues/1297

[1]. https://github.com/wso2/carbon-analytics-common/pull/822