### PR TITLE
upgrade analytics-common and identity-framework versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1268,7 +1268,7 @@
     <properties>
 
         <project.scm.id>scm-server</project.scm.id>
-        <carbon.analytics.common.version>5.3.2</carbon.analytics.common.version>
+        <carbon.analytics.common.version>5.3.3</carbon.analytics.common.version>
         <!-- APIM Portals Component Version -->
         <carbon.apimgt.ui.version>9.0.411</carbon.apimgt.ui.version>
 
@@ -1298,7 +1298,7 @@
         <carbon.mediation.version>4.7.157</carbon.mediation.version>
 
         <!-- carbon identity -->
-        <carbon.identity.version>5.24.4</carbon.identity.version>
+        <carbon.identity.version>5.24.5</carbon.identity.version>
         <carbon.identity.governance.version>1.7.2</carbon.identity.governance.version>
         <carbon.identity.event.handler.account.lock.version>1.7.1</carbon.identity.event.handler.account.lock.version>
         <carbon.identity.event.handler.notification.version>1.6.0</carbon.identity.event.handler.notification.version>


### PR DESCRIPTION
Upgrades carbon-analytics-common and identity framework versions.
Related carbon-apimgt PR : https://github.com/wso2/carbon-apimgt/pull/11817

Related git issue : https://github.com/wso2/api-manager/issues/1267