### PR TITLE
Remove snakeyaml 1.28 from cxf3 folder

### DIFF
--- a/modules/distribution/product/src/main/assembly/bin.xml
+++ b/modules/distribution/product/src/main/assembly/bin.xml
@@ -765,6 +765,7 @@
             </includes>
             <excludes>
                 <exclude>**/cxf3/spring-asm-3.1.4.RELEASE.jar</exclude>
+                <exclude>**/cxf3/snakeyaml-1.28.jar</exclude>
             </excludes>
         </fileSet>
 


### PR DESCRIPTION
Removes snakeyaml 1.28 from lib/runtimes/cxf3 folder.

Related git issue : https://github.com/wso2/api-manager/issues/1222