### PR TITLE
Disable all types of correlation logs at the end

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/logging/CorrelationLoggingTest.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/logging/CorrelationLoggingTest.java
@@ -506,6 +506,8 @@ public class CorrelationLoggingTest extends APIManagerLifecycleBaseTest {
 
     @AfterClass(alwaysRun = true)
     void destroy() throws Exception {
+        // Disabling all correlation log components for next tests
+        configureCorrelationLoggingComponent(new String[] {"http", "jdbc", "synapse", "ldap", "method-calls"}, false);
         restAPIStore.deleteApplication(applicationId);
         restAPIPublisher.deleteAPI(apiId);
     }


### PR DESCRIPTION
Related to https://github.com/wso2/api-manager/issues/1204

Prevent failing Run 2 if Run 1 failed in the middle