### PR TITLE
Comment out CorrelationLoggingTest from testng

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -431,7 +431,7 @@
         <parameter name="group" value="group1"/>
         <classes>
             <class name="org.wso2.am.integration.tests.logging.APILoggingTest"/>
-            <class name="org.wso2.am.integration.tests.logging.CorrelationLoggingTest"/>
+<!--            <class name="org.wso2.am.integration.tests.logging.CorrelationLoggingTest"/>-->
         </classes>
     </test>
     <test name="apim-revoke-one-time-token-flow-tests" preserve-order="true" parallel="false" group-by-instances="true">


### PR DESCRIPTION
Related to https://github.com/wso2/api-manager/issues/1204

Any type of correlation logs doesn't get logged in Jenkins build within 60 seconds after enabling all of them. This is intermittent. hence, disabling the tests temporarily.