### PR TITLE
Upgrade gson to 2.9.1

### DIFF
--- a/modules/distribution/product/src/main/assembly/bin.xml
+++ b/modules/distribution/product/src/main/assembly/bin.xml
@@ -84,6 +84,7 @@
                 <exclude>**/repository/components/plugins/com.google.gson_2.2.4.jar</exclude>
                 <exclude>**/repository/components/plugins/com.google.gson_2.5.0.jar</exclude>
                 <exclude>**/repository/components/plugins/com.google.gson_2.3.1.jar</exclude>
+                <exclude>**/repository/components/plugins/com.google.gson_2.9.0.jar</exclude>
                 <!--<exclude>**/repository/components/plugins/org.wso2.carbon.captcha.mgt_4.2.0.jar</exclude>-->
                 <exclude>**/repository/components/plugins/guava_12.0.0.wso2v1.jar</exclude>
                 <exclude>**/repository/components/plugins/wadl-core_1.1.3.wso2v2.jar</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -1342,7 +1342,7 @@
         <opencsv.version>1.8</opencsv.version>
         <poi.version>3.0-FINAL</poi.version>
         <woden.version>1.0.0.M8-wso2v1</woden.version>
-        <synapse.version>4.0.0-wso2v9</synapse.version>
+        <synapse.version>4.0.0-wso2v13</synapse.version>
         <passthru.transport.patch.version>1.0.2</passthru.transport.patch.version>
         <axis2.wso2.version>1.6.1-wso2v85</axis2.wso2.version>
         <axiom.wso2.version>1.2.11-wso2v25</axiom.wso2.version>
@@ -1471,7 +1471,7 @@
         <auth0.keymanager.feature.version>1.0.4</auth0.keymanager.feature.version>
         <pingfederate.keymanager.feature.version>1.0.6</pingfederate.keymanager.feature.version>
         <forgerock.keymanager.feature.version>1.1.0</forgerock.keymanager.feature.version>
-        <apim.analytics.publisher.version>1.1.2</apim.analytics.publisher.version>
+        <apim.analytics.publisher.version>1.1.3</apim.analytics.publisher.version>
         <disruptor.orbit.version>3.4.2.wso2v1</disruptor.orbit.version>
         <opensaml2.version>2.6.6.wso2v4</opensaml2.version>
         <rampart.wso2.version>1.7.0-wso2v3</rampart.wso2.version>


### PR DESCRIPTION
This PR upgrades gson to 2.9.1 and removes multiple versions of the jar available in the pack.

Related issue: https://github.com/wso2/api-manager/issues/1310