### PR TITLE
Add a test scenario to test API creation with only sandpoint endpoint

### DIFF
--- a/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/utils/bean/APIRequest.java
+++ b/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/utils/bean/APIRequest.java
@@ -394,6 +394,53 @@ public class APIRequest extends AbstractRequest {
 
     }
 
+    /**
+     * This method will create API request.
+     *
+     * @param apiName                  - Name of the API
+     * @param context                  - API context
+     * @param prodEndpointAvailability - True = Only Product, False = Only Sandbox
+     * @param endpointUrl              - API endpoint URL
+     * @throws APIManagerIntegrationTestException - Throws if API request cannot be generated.
+     */
+    public APIRequest(String apiName, String context, boolean prodEndpointAvailability, URL endpointUrl) throws APIManagerIntegrationTestException {
+        this.name = apiName;
+        this.context = context;
+        try {
+            String endPointString = "{\n" +
+                    "  \"sandbox_endpoints\": {\n" +
+                    "    \"url\": \"" + endpointUrl + "\",\n" +
+                    "    \"config\": null,\n" +
+                    "    \"template_not_supported\": false\n" +
+                    "  },\n" +
+                    "  \"endpoint_type\": \"http\"\n" +
+                    "}";
+            if (prodEndpointAvailability) {
+                endPointString = "{\n" +
+                        "  \"production_endpoints\": {\n" +
+                        "    \"template_not_supported\": false,\n" +
+                        "    \"config\": null,\n" +
+                        "    \"url\": \"" + endpointUrl + "\"\n" +
+                        "  },\n" +
+                        "  \"endpoint_type\": \"http\"\n" +
+                        "}";
+            }
+
+            JSONParser parser = new JSONParser();
+            this.endpoint = (org.json.simple.JSONObject) parser.parse(endPointString);
+            this.corsConfiguration = new JSONObject("{\"corsConfigurationEnabled\" : false, " +
+                    "\"accessControlAllowOrigins\" : [\"*\"], " +
+                    "\"accessControlAllowCredentials\" : true, " +
+                    "\"accessControlAllowHeaders\" : " +
+                    "[\"Access-Control-Allow-Origin\", \"authorization\", " +
+                    "\"Content-Type\"], \"accessControlAllowMethods\" : [\"POST\", " +
+                    "\"PATCH\", \"GET\", \"DELETE\", \"OPTIONS\", \"PUT\"]}");
+        } catch (JSONException | ParseException e) {
+            log.error("JSON construct error", e);
+            throw new APIManagerIntegrationTestException("JSON construct error", e);
+        }
+    }
+
     @Override
     public void setAction() {
         setAction("addAPI");

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/publisher/APIM18CreateAnAPIThroughThePublisherRestAPITestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/publisher/APIM18CreateAnAPIThroughThePublisherRestAPITestCase.java
@@ -24,6 +24,7 @@ import io.swagger.parser.OpenAPIParser;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.parser.core.models.SwaggerParseResult;
+import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.httpclient.HttpStatus;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -36,6 +37,7 @@ import org.testng.annotations.Test;
 import org.wso2.am.integration.clients.publisher.api.ApiException;
 import org.wso2.am.integration.clients.publisher.api.ApiResponse;
 import org.wso2.am.integration.clients.publisher.api.v1.dto.APIDTO;
+import org.wso2.am.integration.clients.publisher.api.v1.dto.APIKeyDTO;
 import org.wso2.am.integration.clients.publisher.api.v1.dto.APIOperationsDTO;
 import org.wso2.am.integration.test.utils.base.APIMIntegrationBaseTest;
 import org.wso2.am.integration.test.utils.base.APIMIntegrationConstants;
@@ -55,6 +57,7 @@ import java.util.Map;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.assertNotNull;
 
 /**
  * Create an API through the Publisher Rest API and validate the API
@@ -222,6 +225,66 @@ public class APIM18CreateAnAPIThroughThePublisherRestAPITestCase extends APIMInt
         String retrievedSwagger = restAPIPublisher.getSwaggerByID(apiId2);
 
         validateRemoteReference(retrievedSwagger);
+    }
+
+    @Test(groups = {"wso2.am"}, description = "Create APIs with only Sandbox Endpoints")
+    public void testCreateApiWithOnlySandboxEndpoints() throws Exception {
+        String apiContextTest = "publisherTestAPIWithNoProductEndpoint";
+        String apiNameNoProdEndpointTest = "APIM18PublisherTestNoProduction";
+        String apiDescription = "This is Test API Created by API Manager Integration Test. This has no production endpoints";
+        String apiTag = "tag18-1, tag18-2, tag18-3";
+
+        APIRequest apiCreationRequestBean;
+        apiCreationRequestBean = new APIRequest(apiNameNoProdEndpointTest, apiContextTest, false, new URL(apiProductionEndPointUrl));
+
+        apiCreationRequestBean.setVersion(apiVersion);
+        apiCreationRequestBean.setDescription(apiDescription);
+        apiCreationRequestBean.setTags(apiTag);
+        apiCreationRequestBean.setTiersCollection("Gold,Bronze");
+        apiCreationRequestBean.setTier("Gold");
+
+        APIOperationsDTO apiOperationsDTO = new APIOperationsDTO();
+        apiOperationsDTO.setVerb("GET");
+        apiOperationsDTO.setTarget("/customers/{id}");
+
+        List<APIOperationsDTO> operationsDTOS = new ArrayList<>();
+        operationsDTOS.add(apiOperationsDTO);
+
+        apiCreationRequestBean.setOperationsDTOS(operationsDTOS);
+        apiCreationRequestBean.setOperationsDTOS(operationsDTOS);
+        apiCreationRequestBean.setDefault_version_checked("true");;
+        apiCreationRequestBean.setBusinessOwner("api18b");
+        apiCreationRequestBean.setBusinessOwnerEmail("api18b@ee.com");
+        apiCreationRequestBean.setTechnicalOwner("api18t");
+        apiCreationRequestBean.setTechnicalOwnerEmail("api18t@ww.com");
+        apiCreationRequestBean.setOperationsDTOS(operationsDTOS);
+
+        HttpResponse apiCreationResponse = restAPIPublisher.addAPI(apiCreationRequestBean);
+        apiId = apiCreationResponse.getData();
+
+        assertEquals(apiCreationResponse.getResponseCode(), Response.Status.CREATED.getStatusCode(),
+                "Response Code miss matched when creating the API");
+
+        //Check the availability of an API in Publisher
+        HttpResponse response = restAPIPublisher.getAPI(apiId);
+        assertEquals(response.getResponseCode(), Response.Status.OK.getStatusCode(),
+                "Response Code miss matched when creating the API");
+        assertTrue(response.getData().contains(apiNameNoProdEndpointTest), "Invalid API Name");
+        assertTrue(response.getData().contains(apiVersion), "Invalid API Version");
+        assertTrue(response.getData().contains(apiContextTest), "Invalid API Context");
+
+        ApiResponse<APIKeyDTO> apiKeyDTO = restAPIPublisher.generateInternalApiKey(apiId);
+        assertEquals(200, apiKeyDTO.getStatusCode(),
+                "Key generation is failed for APIs which don't have product endpoints");
+        String apiKey = apiKeyDTO.getData().getApikey();
+        assertNotNull(apiKey, "API Key is null");
+        String[] split_string = apiKey.split("\\.");
+        String base64EncodedBody = split_string[1];
+        Base64 base64Url = new Base64(true);
+        String body = new String(base64Url.decode(base64EncodedBody));
+        JSONObject keyBody = new JSONObject(body);
+        String keyType = keyBody.getString("keytype");
+        assertEquals("SANDBOX", keyType, "API Key is not type SANDBOX");
     }
 
     @Test(groups = {"wso2.am"}, description = "Create APIs with archives with a random master swagger file name")


### PR DESCRIPTION
This PR is to add a new test scenario to test API creation where it doesn’t have a product endpoint. In addition to that, another test was added to test the key generation in that scenario. Test scenario was added to APIM18CreateAnAPIThroughThePublisherRestAPITestCase.

This test will cover https://github.com/wso2/api-manager/issues/1190 fix.