### PR TITLE
Fix: Recover with Security Questions Option is not Working on Forgot Password

### DIFF
--- a/modules/distribution/product/src/main/extensions/basicauth.jsp
+++ b/modules/distribution/product/src/main/extensions/basicauth.jsp
@@ -138,8 +138,6 @@
     Boolean isEmailUsernameEnabled = false;
     String usernameLabel = "username";
     Boolean isSelfSignUpEnabledInTenant;
-    Boolean isUsernameRecoveryEnabledInTenant;
-    Boolean isPasswordRecoveryEnabledInTenant;
     Boolean isMultiAttributeLoginEnabledInTenant;
     if (StringUtils.isNotBlank(emailUsernameEnable)) {
         isEmailUsernameEnabled = Boolean.valueOf(emailUsernameEnable);
@@ -149,8 +147,6 @@
     try {
         PreferenceRetrievalClient preferenceRetrievalClient = new PreferenceRetrievalClient();
         isSelfSignUpEnabledInTenant = preferenceRetrievalClient.checkSelfRegistration(tenantDomain);
-        isUsernameRecoveryEnabledInTenant = preferenceRetrievalClient.checkUsernameRecovery(tenantDomain);
-        isPasswordRecoveryEnabledInTenant = preferenceRetrievalClient.checkPasswordRecovery(tenantDomain);
         isMultiAttributeLoginEnabledInTenant = preferenceRetrievalClient.checkMultiAttributeLogin(tenantDomain);
     } catch (PreferenceRetrievalClientException e) {
         request.setAttribute("error", true);
@@ -370,7 +366,7 @@
     %>
 
     <div class="buttons">
-        <% if (isRecoveryEPAvailable && (isUsernameRecoveryEnabledInTenant || isPasswordRecoveryEnabledInTenant)) { %>
+        <% if (isRecoveryEPAvailable) { %>
         <div class="field">
             <%=AuthenticationEndpointUtil.i18n(resourceBundle, "forgot.username.password")%>
             <a

--- a/modules/distribution/product/src/main/extensions/password-recovery.jsp
+++ b/modules/distribution/product/src/main/extensions/password-recovery.jsp
@@ -86,13 +86,9 @@
         reCaptchaEnabled = true;
     }
 
-    Boolean isQuestionBasedPasswordRecoveryEnabledByTenant;
-    Boolean isNotificationBasedPasswordRecoveryEnabledByTenant;
     Boolean isMultiAttributeLoginEnabledInTenant;
     try {
         PreferenceRetrievalClient preferenceRetrievalClient = new PreferenceRetrievalClient();
-        isQuestionBasedPasswordRecoveryEnabledByTenant = preferenceRetrievalClient.checkQuestionBasedPasswordRecovery(tenantDomain);
-        isNotificationBasedPasswordRecoveryEnabledByTenant = preferenceRetrievalClient.checkNotificationBasedPasswordRecovery(tenantDomain);
         isMultiAttributeLoginEnabledInTenant = preferenceRetrievalClient.checkMultiAttributeLogin(tenantDomain);
     } catch (PreferenceRetrievalClientException e) {
         request.setAttribute("error", true);
@@ -205,13 +201,6 @@
                                 <div class="ui radio checkbox">
                                     <input type="radio" name="recoveryOption" value="EMAIL" checked/>
                                     <label><%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "Recover.with.mail")%>
-                                    </label>
-                                </div>
-                            </div>
-                            <div class="field">
-                                <div class="ui radio checkbox">
-                                    <input type="radio" name="recoveryOption" value="SECURITY_QUESTIONS"/>
-                                    <label><%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "Recover.with.question")%>
                                     </label>
                                 </div>
                             </div>


### PR DESCRIPTION
After removing unwanted elements, the recovery page looks as follows.
![Screenshot 2023-02-16 at 21 02 26](https://user-images.githubusercontent.com/43112139/219412392-81d73cec-aec8-47fe-a631-b72df7503aba.png)
