### PR TITLE
Fix the tests for parameter ordering

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/soap/in-sequence-check-phone-numbers.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/soap/in-sequence-check-phone-numbers.xml
@@ -21,17 +21,17 @@
   <soapenv:Envelope xmlns:soapenv="http://www.w3.org/2003/05/soap-envelope" xmlns:web="http://ws.cdyne.com/PhoneVerify/query">
   <soapenv:Header/>
   <soapenv:Body>
-  	<web:CheckPhoneNumbers xmlns:web="http://ws.cdyne.com/PhoneVerify/query">
-   <web:LicenseKey>$1</web:LicenseKey>
-   <web:PhoneNumbers>$2</web:PhoneNumbers>
+    <web:CheckPhoneNumbers xmlns:web="http://ws.cdyne.com/PhoneVerify/query">
+  <web:PhoneNumbers>$1</web:PhoneNumbers>
+  <web:LicenseKey>$2</web:LicenseKey>
 </web:CheckPhoneNumbers>
 
   </soapenv:Body>
   </soapenv:Envelope>
   </format>
   <args>
- 	<arg evaluator="xml" expression="get-property('req.var.CheckPhoneNumbers.LicenseKey')"/>
-<arg evaluator="xml" expression="get-property('req.var.CheckPhoneNumbers.PhoneNumbers.string')"/>
+  <arg evaluator="xml" expression="get-property('req.var.CheckPhoneNumbers.PhoneNumbers.string')"/>
+<arg evaluator="xml" expression="get-property('req.var.CheckPhoneNumbers.LicenseKey')"/>
 
   </args>
 </payloadFactory>

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/soap/in-sequence-check-phone-numbers.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/soap/in-sequence-check-phone-numbers.xml
@@ -22,8 +22,8 @@
   <soapenv:Header/>
   <soapenv:Body>
   	<web:CheckPhoneNumbers xmlns:web="http://ws.cdyne.com/PhoneVerify/query">
-  <web:PhoneNumbers>$1</web:PhoneNumbers>
-  <web:LicenseKey>$2</web:LicenseKey>
+   <web:PhoneNumbers>$1</web:PhoneNumbers>
+   <web:LicenseKey>$2</web:LicenseKey>
 </web:CheckPhoneNumbers>
 
   </soapenv:Body>

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/soap/in-sequence-check-phone-numbers.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/soap/in-sequence-check-phone-numbers.xml
@@ -21,7 +21,7 @@
   <soapenv:Envelope xmlns:soapenv="http://www.w3.org/2003/05/soap-envelope" xmlns:web="http://ws.cdyne.com/PhoneVerify/query">
   <soapenv:Header/>
   <soapenv:Body>
-    <web:CheckPhoneNumbers xmlns:web="http://ws.cdyne.com/PhoneVerify/query">
+  	<web:CheckPhoneNumbers xmlns:web="http://ws.cdyne.com/PhoneVerify/query">
   <web:PhoneNumbers>$1</web:PhoneNumbers>
   <web:LicenseKey>$2</web:LicenseKey>
 </web:CheckPhoneNumbers>
@@ -30,7 +30,7 @@
   </soapenv:Envelope>
   </format>
   <args>
-  <arg evaluator="xml" expression="get-property('req.var.CheckPhoneNumbers.PhoneNumbers.string')"/>
+ 	<arg evaluator="xml" expression="get-property('req.var.CheckPhoneNumbers.PhoneNumbers.string')"/>
 <arg evaluator="xml" expression="get-property('req.var.CheckPhoneNumbers.LicenseKey')"/>
 
   </args>

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/soap/updated-in-sequence-check-phone-numbers.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/soap/updated-in-sequence-check-phone-numbers.xml
@@ -22,17 +22,17 @@
   <soapenv:Envelope xmlns:soapenv="http://www.w3.org/2003/05/soap-envelope" xmlns:web="http://ws.cdyne.com/PhoneVerify/query">
   <soapenv:Header/>
   <soapenv:Body>
-  	<web:CheckPhoneNumbers xmlns:web="http://ws.cdyne.com/PhoneVerify/query">
-  <web:LicenseKey>$1</web:LicenseKey>
-  <web:PhoneNumbers>$2</web:PhoneNumbers>
+    <web:CheckPhoneNumbers xmlns:web="http://ws.cdyne.com/PhoneVerify/query">
+  <web:PhoneNumbers>$1</web:PhoneNumbers>
+  <web:LicenseKey>$2</web:LicenseKey>
 </web:CheckPhoneNumbers>
 
   </soapenv:Body>
   </soapenv:Envelope>
   </format>
   <args>
- 	<arg evaluator="xml" expression="get-property('req.var.CheckPhoneNumbers.LicenseKey')"/>
-<arg evaluator="xml" expression="get-property('req.var.CheckPhoneNumbers.PhoneNumbers.string')"/>
+  <arg evaluator="xml" expression="get-property('req.var.CheckPhoneNumbers.PhoneNumbers.string')"/>
+<arg evaluator="xml" expression="get-property('req.var.CheckPhoneNumbers.LicenseKey')"/>
 
   </args>
 </payloadFactory>

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/soap/updated-in-sequence-check-phone-numbers.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/soap/updated-in-sequence-check-phone-numbers.xml
@@ -22,7 +22,7 @@
   <soapenv:Envelope xmlns:soapenv="http://www.w3.org/2003/05/soap-envelope" xmlns:web="http://ws.cdyne.com/PhoneVerify/query">
   <soapenv:Header/>
   <soapenv:Body>
-    <web:CheckPhoneNumbers xmlns:web="http://ws.cdyne.com/PhoneVerify/query">
+  	<web:CheckPhoneNumbers xmlns:web="http://ws.cdyne.com/PhoneVerify/query">
   <web:PhoneNumbers>$1</web:PhoneNumbers>
   <web:LicenseKey>$2</web:LicenseKey>
 </web:CheckPhoneNumbers>
@@ -31,7 +31,7 @@
   </soapenv:Envelope>
   </format>
   <args>
-  <arg evaluator="xml" expression="get-property('req.var.CheckPhoneNumbers.PhoneNumbers.string')"/>
+ 	<arg evaluator="xml" expression="get-property('req.var.CheckPhoneNumbers.PhoneNumbers.string')"/>
 <arg evaluator="xml" expression="get-property('req.var.CheckPhoneNumbers.LicenseKey')"/>
 
   </args>

--- a/pom.xml
+++ b/pom.xml
@@ -1275,7 +1275,7 @@
         <carbon.apimgt.ui.version>9.0.426</carbon.apimgt.ui.version>
 
         <!-- APIM Component Version -->
-        <carbon.apimgt.version>9.28.97</carbon.apimgt.version>
+        <carbon.apimgt.version>9.28.99</carbon.apimgt.version>
 
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 


### PR DESCRIPTION
With the fix https://github.com/wso2/carbon-apimgt/pull/11871 parameter order of soap to rest conversion will be preserved with the wsdl definition. Fixing the test case that has a mismatching order with the original definition.

Fixes: wso2/api-manager#1441