### PR TITLE
Add portals to the control plane profile for windows

### DIFF
--- a/modules/distribution/product/src/main/startup-scripts/profileSetup.bat
+++ b/modules/distribution/product/src/main/startup-scripts/profileSetup.bat
@@ -98,7 +98,7 @@ call :replaceDeploymentConfiguration
 call :replaceAxis2TemplateFile %pathToAxis2ControlPlaneXmlTemplate%
 call :replaceTenantAxis2TemplateFile %pathToTenantAxis2ControlPlaneXmlTemplate%
 rem ---removing webbapps which are not required for this profile--------
-for /f %%i in ('dir %pathToWebapps% /b ^| findstr /v "api#am#publisher#v.*war api#am#publisher.war api#am#devportal#v.*war api#am#devportal.war client-registration#v.*war authenticationendpoint accountrecoveryendpoint oauth2.war api#am#admin#v.*war api#am#admin.war internal#data#v.*war"') do (
+for /f %%i in ('dir %pathToWebapps% /b ^| findstr /v "api#am#publisher#v.*war api#am#publisher.war api#am#devportal#v.*war api#am#devportal.war client-registration#v.*war authenticationendpoint accountrecoveryendpoint oauth2.war api#am#admin#v.*war api#am#admin.war internal#data#v.*war admin devportal publisher"') do (
 	del /f %pathToWebapps%\%%i
 	call :Timestamp value
 	echo %value% INFO - Removed the %%i file from %pathToWebapps%


### PR DESCRIPTION
This PR adds the portals to the filtered files/directories in webapps directory when optimizing for the control plane profile in Windows.

Fixes https://github.com/wso2/api-manager/issues/1535