### PR TITLE
Upgrade synapse and mediation versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1297,7 +1297,7 @@
         <carbon.kernel.imp.pkg.version>[4.5.0, 5.0.0)</carbon.kernel.imp.pkg.version>
 
         <!-- carbon mediation -->
-        <carbon.mediation.version>4.7.170</carbon.mediation.version>
+        <carbon.mediation.version>4.7.175</carbon.mediation.version>
 
         <!-- carbon identity -->
         <carbon.identity.version>5.24.8</carbon.identity.version>
@@ -1342,7 +1342,7 @@
         <opencsv.version>1.8</opencsv.version>
         <poi.version>3.0-FINAL</poi.version>
         <woden.version>1.0.0.M8-wso2v1</woden.version>
-        <synapse.version>4.0.0-wso2v13</synapse.version>
+        <synapse.version>4.0.0-wso2v20</synapse.version>
         <passthru.transport.patch.version>1.0.2</passthru.transport.patch.version>
         <axis2.wso2.version>1.6.1-wso2v85</axis2.wso2.version>
         <axiom.wso2.version>1.2.11-wso2v25</axiom.wso2.version>
@@ -1376,7 +1376,7 @@
         <waffle-jna.version>1.6.wso2v6</waffle-jna.version>
         <version.org.wso2.orbit.javax.xml.bind>2.3.1.wso2v1</version.org.wso2.orbit.javax.xml.bind>
         <opensaml2.wso2.version>3.3.1.wso2v4</opensaml2.wso2.version>
-        <transport.http.netty.version>6.3.42</transport.http.netty.version>
+        <transport.http.netty.version>6.3.44</transport.http.netty.version>
 
         <imp.pkg.version.javax.servlet>[2.6.0, 3.0.0)</imp.pkg.version.javax.servlet>
 
@@ -1475,7 +1475,7 @@
         <disruptor.orbit.version>3.4.2.wso2v1</disruptor.orbit.version>
         <opensaml2.version>2.6.6.wso2v4</opensaml2.version>
         <rampart.wso2.version>1.7.0-wso2v3</rampart.wso2.version>
-        <wss4j.version>1.6.0-wso2v5</wss4j.version>
+        <wss4j.version>1.6.0-wso2v7</wss4j.version>
 
         <!-- Service Catalog Client Dependencies -->
         <com.squareup.okhttp3.version>4.9.0</com.squareup.okhttp3.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1275,7 +1275,7 @@
         <carbon.apimgt.ui.version>9.0.431</carbon.apimgt.ui.version>
 
         <!-- APIM Component Version -->
-        <carbon.apimgt.version>9.28.109</carbon.apimgt.version>
+        <carbon.apimgt.version>9.28.112</carbon.apimgt.version>
 
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 


### PR DESCRIPTION
This PR upgrades the following versions in product-apim.

- carbon-apimgt
- synapse
- mediation
- wss4j
- transport.http.netty

**Note**: Also includes fixes from https://github.com/wso2/product-apim/pull/13159