### PR TITLE
Fix: API creation scenario test

### DIFF
--- a/product-scenarios/1-manage-public-partner-private-apis/1.1-expose-service-as-rest-api/1.1.1-create-rest-api-from-scratch/src/test/java/org/wso2/am/scenario/tests/rest/api/creation/RESTApiCreationTestCase.java
+++ b/product-scenarios/1-manage-public-partner-private-apis/1.1-expose-service-as-rest-api/1.1.1-create-rest-api-from-scratch/src/test/java/org/wso2/am/scenario/tests/rest/api/creation/RESTApiCreationTestCase.java
@@ -20,6 +20,7 @@ import static org.testng.Assert.assertEquals;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import javax.ws.rs.core.Response;
 
 import org.apache.commons.logging.Log;
@@ -121,8 +122,9 @@ public class RESTApiCreationTestCase extends ScenarioTestBase {
         apiOperationsDTO.setTarget(apiResource);
 
         apiOperationsDTOs.add(apiOperationsDTO);
+        String context = "/" + UUID.randomUUID();
 
-        apiRequest = new APIRequest(apiName, "/" + apiName, new URL(backendEndPoint));
+        apiRequest = new APIRequest(apiName, context, new URL(backendEndPoint));
         apiRequest.setVersion(apiVersion);
         apiRequest.setVisibility(apiVisibility);
         apiRequest.setOperationsDTOS(apiOperationsDTOs);


### PR DESCRIPTION
### Purpose
Characters which give errors during the API deployment or API invocation were removed from the PR https://github.com/wso2-support/carbon-apimgt/pull/5749