### PR TITLE
Add scripts to enable and disable FIPS compliance

### DIFF
--- a/modules/distribution/product/src/main/assembly/bin.xml
+++ b/modules/distribution/product/src/main/assembly/bin.xml
@@ -1250,6 +1250,20 @@
         </file>
 
         <file>
+            <source>src/main/startup-scripts/fips.sh</source>
+            <outputDirectory>wso2am-${pom.version}/bin/</outputDirectory>
+            <filtered>true</filtered>
+            <fileMode>755</fileMode>
+        </file>
+
+        <file>
+            <source>src/main/startup-scripts/fips.bat</source>
+            <outputDirectory>wso2am-${pom.version}/bin/</outputDirectory>
+            <filtered>true</filtered>
+            <fileMode>755</fileMode>
+        </file>
+
+        <file>
             <source>src/main/startup-scripts/profileSetup.sh</source>
             <outputDirectory>wso2am-${pom.version}/bin/</outputDirectory>
             <filtered>true</filtered>

--- a/modules/distribution/product/src/main/startup-scripts/fips.bat
+++ b/modules/distribution/product/src/main/startup-scripts/fips.bat
@@ -1,0 +1,515 @@
+@echo off
+rem ----------------------------------------------------------------------------
+rem Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+rem
+rem WSO2 LLC. licenses this file to you under the Apache License,
+rem Version 2.0 (the "License"); you may not use this file except
+rem in compliance with the License.
+rem You may obtain a copy of the License at
+rem
+rem http://www.apache.org/licenses/LICENSE-2.0
+rem
+rem Unless required by applicable law or agreed to in writing,
+rem software distributed under the License is distributed on an
+rem "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+rem KIND, either express or implied.  See the License for the
+rem specific language governing permissions and limitations
+rem under the License.
+
+set BC_FIPS_VERSION=1.0.2.3
+set BCPKIX_FIPS_VERSION=1.0.7
+set BCPROV_JDK15ON_VERSION=1.70.0.wso2v1
+set BCPKIX_JDK15ON_VERSION=1.70.0.wso2v1
+
+set EXPECTED_BCPROV_CHECKSUM=261f41c52b6a664a5e9011ba829e78eb314c0ed8
+set EXPECTED_BCPKIX_CHECKSUM=17db4aba24861e306427bdeff03b1c2fac57760f
+set EXPECTED_BC_FIPS_CHECKSUM=da62b32cb72591f5b4d322e6ab0ce7de3247b534
+set EXPECTED_BCPKIX_FIPS_CHECKSUM=fe07959721cfa2156be9722ba20fdfee2b5441b0
+
+
+rem ----- Only set CARBON_HOME if not already set ----------------------------
+:checkServer
+rem %~sdp0 is expanded pathname of the current script under NT with spaces in the path removed
+if "%CARBON_HOME%"=="" set CARBON_HOME=%~sdp0..
+SET curDrive=%cd:~0,1%
+SET wsasDrive=%CARBON_HOME:~0,1%
+if not "%curDrive%" == "%wsasDrive%" %wsasDrive%:
+
+rem find CARBON_HOME if it does not exist due to either an invalid value passed
+rem by the user or the %0 problem on Windows 9x
+if not exist "%CARBON_HOME%\bin\version.txt" goto noServerHome
+
+set ARGUEMENT=%1
+set api_publisher_bundles_info=%CARBON_HOME%\repository\components\api-publisher-deprecated\configuration\org.eclipse.equinox.simpleconfigurator\bundles.info
+set api_devportal_bundles_info=%CARBON_HOME%\repository\components\api-devportal-deprecated\configuration\org.eclipse.equinox.simpleconfigurator\bundles.info
+set api_key_manager_bundles_info=%CARBON_HOME%\repository\components\api-key-manager-deprecated\configuration\org.eclipse.equinox.simpleconfigurator\bundles.info
+set default_bundles_info=%CARBON_HOME%\repository\components\default\configuration\org.eclipse.equinox.simpleconfigurator\bundles.info
+set control_plane_bundles_info=%CARBON_HOME%\repository\components\control-plane\configuration\org.eclipse.equinox.simpleconfigurator\bundles.info
+set traffic_manager_bundles_info=%CARBON_HOME%\repository\components\traffic-manager\configuration\org.eclipse.equinox.simpleconfigurator\bundles.info
+set gateway_worker_bundles_info=%CARBON_HOME%\repository\components\gateway-worker\configuration\org.eclipse.equinox.simpleconfigurator\bundles.info
+
+set bcprov_text=bcprov-jdk15on,%BCPROV_JDK15ON_VERSION%,../plugins/bcprov-jdk15on_%BCPROV_JDK15ON_VERSION%.jar,4,true
+set bcpkix_text=bcpkix-jdk15on,%BCPKIX_JDK15ON_VERSION%,../plugins/bcpkix-jdk15on_%BCPKIX_JDK15ON_VERSION%.jar,4,true
+set "homeDir=%userprofile%"
+set server_restart_required=false
+
+rem commandline arguement 'DISABLE' or 'disable' is passed
+if "%ARGUEMENT%"=="DISABLE" goto disableFipsMode
+if "%ARGUEMENT%"=="disable" goto disableFipsMode
+if "%ARGUEMENT%"=="VERIFY" goto verifyFipsMode
+if "%ARGUEMENT%"=="verify" goto verifyFipsMode
+rem no commandline arguements are passed
+goto enableFipsMode
+
+:disableFipsMode
+if exist "%CARBON_HOME%\repository\components\lib\bc-fips*.jar" (
+    set server_restart_required=true
+    echo Remove existing bc-fips jar from lib folder.
+    DEL /F "%CARBON_HOME%\repository\components\lib\bc-fips*.jar"
+    echo Successfully removed bc-fips__%BC_FIPS_VERSION%.jar from components\lib.
+)
+if exist "%CARBON_HOME%\repository\components\lib\bcpkix-fips*.jar" (
+    set server_restart_required=true
+    echo Remove existing bcpkix-fips jar from lib folder.
+    DEL /F "%CARBON_HOME%\repository\components\lib\bcpkix-fips*.jar"
+    echo Successfully removed bcpkix-fips_%BC_FIPS_VERSION%.jar from components\lib.
+)
+if exist "%CARBON_HOME%\repository\components\dropins\bc_fips*.jar" (
+    set server_restart_required=true
+    echo Remove existing bc-fips jar from dropins folder.
+    DEL /F "%CARBON_HOME%\repository\components\dropins\bc_fips*.jar"
+    echo Successfully removed bc_fips_%BC_FIPS_VERSION%.jar from components\dropins.
+)
+if exist "%CARBON_HOME%\repository\components\dropins\bcpkix_fips*.jar" (
+    set server_restart_required=true
+    echo Remove existing bcpkix_fips jar from dropins folder.
+    DEL /F "%CARBON_HOME%\repository\components\dropins\bcpkix_fips*.jar"
+    echo Successfully removed bcpkix-fips_%BCPKIX_FIPS_VERSION%.jar from components\dropins.
+)
+if not exist "%CARBON_HOME%\repository\components\plugins\bcprov-jdk15on*.jar" (
+    set server_restart_required=true
+    if exist "%homeDir%\.wso2-bc\backup\bcprov-jdk15on_%BCPROV_JDK15ON_VERSION%.jar" (
+        move "%homeDir%\.wso2-bc\backup\bcprov-jdk15on_%BCPROV_JDK15ON_VERSION%.jar" "%CARBON_HOME%\repository\components\plugins"
+        echo Moved bcprov-jdk15on_%BCPROV_JDK15ON_VERSION%.jar from %homeDir%\.wso2-bc\backup to components/plugins.
+    ) else (
+        echo Downloading required bcprov-jdk15on jar : bcprov-jdk15on-%BCPROV_JDK15ON_VERSION%
+	    curl https://maven.wso2.org/nexus/content/repositories/releases/org/wso2/orbit/org/bouncycastle/bcprov-jdk15on/%BCPROV_JDK15ON_VERSION%/bcprov-jdk15on-%BCPROV_JDK15ON_VERSION%.jar -o %CARBON_HOME%/repository/components/plugins/bcprov-jdk15on_%BCPROV_JDK15ON_VERSION%.jar
+        FOR /F "tokens=*" %%G IN ('certutil -hashfile "%CARBON_HOME%/repository/components/plugins/bcprov-jdk15on_%BCPROV_JDK15ON_VERSION%.jar" SHA1 ^| FIND /V ":"') DO SET "ACTUAL_CHECKSUM_BCPROVE=%%G"
+        if "%ACTUAL_CHECKSUM_BCPROVE%"=="%EXPECTED_BCPROV_CHECKSUM%" (
+            echo Checksum verified: The downloaded bcprov-jdk15on-%BCPROV_JDK15ON_VERSION%.jar is valid.
+        ) else (
+            echo Checksum verification failed: The downloaded bcprov-jdk15on-%BCPROV_JDK15ON_VERSION%.jar may be corrupted.
+        )
+    )
+)
+if not exist "%CARBON_HOME%\repository\components\plugins\bcpkix-jdk15on*.jar" (
+    set server_restart_required=true
+    if exist "%homeDir%\.wso2-bc\backup\bcpkix-jdk15on_%BCPKIX_JDK15ON_VERSION%.jar" (
+        move "%homeDir%\.wso2-bc\backup\bcpkix-jdk15on_%BCPKIX_JDK15ON_VERSION%.jar" "%CARBON_HOME%\repository\components\plugins"
+        echo Moved bcpkix-jdk15on_%BCPKIX_JDK15ON_VERSION%.jar from %homeDir%\.wso2-bc\backup to components/plugins.
+    ) else (
+	    echo Downloading required bcpkix-jdk15on jar : bcpkix-jdk15on-%BCPKIX_JDK15ON_VERSION%
+	    curl https://maven.wso2.org/nexus/content/repositories/releases/org/wso2/orbit/org/bouncycastle/bcpkix-jdk15on/%BCPKIX_JDK15ON_VERSION%/bcpkix-jdk15on-%BCPKIX_JDK15ON_VERSION%.jar -o %CARBON_HOME%/repository/components/plugins/bcpkix-jdk15on_%BCPKIX_JDK15ON_VERSION%.jar
+        FOR /F "tokens=*" %%G IN ('certutil -hashfile "%CARBON_HOME%/repository/components/plugins/bcpkix-jdk15on_%BCPKIX_JDK15ON_VERSION%.jar" SHA1 ^| FIND /V ":"') DO SET "ACTUAL_CHECKSUM_BCPKIX=%%G"
+        if "%ACTUAL_CHECKSUM_BCPKIX%"=="%EXPECTED_BCPKIX_CHECKSUM%" (
+            echo Checksum verified: The downloaded bcpkix-jdk15on-%BCPKIX_JDK15ON_VERSION%.jar is valid.
+        ) else (
+            echo Checksum verification failed: The downloaded bcpkix-jdk15on-%BCPKIX_JDK15ON_VERSION%.jar may be corrupted.
+        )
+    )
+)
+findstr /c:%bcprov_text% %api_publisher_bundles_info% > nul
+if %errorlevel%==1 (
+    set server_restart_required=true
+    echo %bcprov_text% >>  %api_publisher_bundles_info%
+)
+findstr /c:%bcpkix_text% %api_publisher_bundles_info% > nul
+if %errorlevel%==1 (
+    set server_restart_required=true
+    echo %bcpkix_text% >>  %api_publisher_bundles_info%
+)
+findstr /c:%bcprov_text% %api_devportal_bundles_info% > nul
+if %errorlevel%==1 (
+    set server_restart_required=true
+    echo %bcprov_text% >>  %api_devportal_bundles_info%
+)
+findstr /c:%bcpkix_text% %api_devportal_bundles_info% > nul
+if %errorlevel%==1 (
+    set server_restart_required=true
+    echo %bcpkix_text% >>  %api_devportal_bundles_info%
+)
+findstr /c:%bcprov_text% %api_key_manager_bundles_info% > nul
+if %errorlevel%==1 (
+    set server_restart_required=true
+    echo %bcprov_text% >>  %api_key_manager_bundles_info%
+)
+findstr /c:%bcpkix_text% %api_key_manager_bundles_info% > nul
+if %errorlevel%==1 (
+    set server_restart_required=true
+    echo %bcpkix_text% >>  %api_key_manager_bundles_info%
+)
+findstr /c:%bcprov_text% %default_bundles_info% > nul
+if %errorlevel%==1 (
+    set server_restart_required=true
+    echo %bcprov_text% >>  %default_bundles_info%
+)
+findstr /c:%bcpkix_text% %default_bundles_info% > nul
+if %errorlevel%==1 (
+    set server_restart_required=true
+    echo %bcpkix_text% >>  %default_bundles_info%
+)
+findstr /c:%bcprov_text% %control_plane_bundles_info% > nul
+if %errorlevel%==1 (
+    set server_restart_required=true
+    echo %bcprov_text% >>  %control_plane_bundles_info%
+)
+findstr /c:%bcpkix_text% %control_plane_bundles_info% > nul
+if %errorlevel%==1 (
+    set server_restart_required=true
+    echo %bcpkix_text% >>  %control_plane_bundles_info%
+)
+findstr /c:%bcprov_text% %traffic_manager_bundles_info% > nul
+if %errorlevel%==1 (
+    set server_restart_required=true
+    echo %bcprov_text% >>  %traffic_manager_bundles_info%
+)
+findstr /c:%bcpkix_text% %traffic_manager_bundles_info% > nul
+if %errorlevel%==1 (
+    set server_restart_required=true
+    echo %bcpkix_text% >>  %traffic_manager_bundles_info%
+)
+findstr /c:%bcprov_text% %gateway_worker_bundles_info% > nul
+if %errorlevel%==1 (
+    set server_restart_required=true
+    echo %bcprov_text% >>  %gateway_worker_bundles_info%
+)
+findstr /c:%bcpkix_text% %gateway_worker_bundles_info% > nul
+if %errorlevel%==1 (
+    set server_restart_required=true
+    echo %bcpkix_text% >>  %gateway_worker_bundles_info%
+)
+
+goto printRestartMsg
+
+: enableFipsMode
+set arg1=
+set arg2=
+:parse_args
+if "%~1" == "" goto :done_args
+if /I "%~1" == "-f" set "arg1=%~2" & shift
+if /I "%~1" == "-m" set "arg2=%~2" & shift
+shift
+goto :parse_args
+:done_args
+
+if not exist "%homeDir%\.wso2-bc" (
+    mkdir "%homeDir%\.wso2-bc"
+)
+if not exist "%homeDir%\.wso2-bc\backup" (
+    mkdir "%homeDir%\.wso2-bc\backup"
+)
+if exist "%CARBON_HOME%\repository\components\plugins\bcprov-jdk15on*" (
+    set server_restart_required=true
+    echo Remove existing bcprov-jdk15on jar from plugins folder.
+    for /f "delims=" %%a in ('dir /b /s "%CARBON_HOME%\repository\components\plugins\bcprov-jdk15on_*.jar"') do (
+        set bcprov_location=%%a
+        goto check_bcprov_location
+    )
+   :check_bcprov_location
+    move "%bcprov_location%" "%homeDir%\.wso2-bc\backup"
+    echo Successfully removed bcprov-jdk15on_%BCPROV_JDK15ON_VERSION%.jar from components\plugins.
+)
+if exist "%CARBON_HOME%\repository\components\plugins\bcpkix-jdk15on*" (
+    set server_restart_required=true
+    echo Remove existing bcpkix-jdk15on jar from plugins folder.
+    for /f "delims=" %%a in ('dir /b /s "%CARBON_HOME%\repository\components\plugins\bcpkix-jdk15on_*.jar"') do (
+        set bcpkix_location=%%a
+        goto check_bcpkix_location
+
+    )
+   :check_bcpkix_location
+    move "%bcpkix_location%" "%homeDir%\.wso2-bc\backup"
+    echo Successfully removed bcpkix-jdk15on_%BCPKIX_JDK15ON_VERSION%.jar Removed from components\plugins.
+)
+if exist "%CARBON_HOME%\repository\components\lib\bc-fips*.jar" (
+    for /f "delims=" %%a in ('dir /b /s "%CARBON_HOME%\repository\components\lib\bc-fips*.jar"') do (
+        set bcfips_location=%%a
+        goto check_bcfips_location
+    )
+    :check_bcfips_location
+    for %%f in ("%bcfips_location%") do set "bcfips_location=%%~nxf"
+    if not "%bcfips_location%"=="bc-fips-%BC_FIPS_VERSION%.jar" (
+        set sever_restart_required=true
+        echo There is an update for bc-fips. Therefore Remove existing bc-fips jar from lib folder.
+        del /q "%CARBON_HOME%\repository\components\lib\bc-fips*.jar" 2> nul
+        echo Successfully removed bc-fips_%BC_FIPS_VERSION%.jar from components/lib.
+        if exist "%CARBON_HOME%\repository\components\dropins\bc_fips*.jar" (
+            set sever_restart_required=true
+            echo Remove existing bc-fips jar from dropins folder.
+            del /q "%CARBON_HOME%\repository\components\dropins\bc_fips*.jar" 2> nul
+            echo Successfully removed bc-fips_%BC_FIPS_VERSION%.jar from components/dropins.
+        )
+    )
+)
+
+if exist "%CARBON_HOME%\repository\components\lib\bcpkix-fips*.jar" (
+    for /f "delims=" %%a in ('dir /b /s "%CARBON_HOME%\repository\components\lib\bcpkix-fips*.jar"') do (
+        set bcpkixfips_location=%%a
+        goto check_bcpkixfips_location
+    )
+    :check_bcpkixfips_location
+    for %%f in ("%bcpkixfips_location%") do set "bcpkixfips_location=%%~nxf"
+    if not "%bcpkixfips_location%"=="bcpkix-fips-%BCPKIX_FIPS_VERSION%.jar" (
+        set sever_restart_required=true
+        echo There is an update for bcpkix-fips. Therefore Remove existing bcpkix-fips jar from lib folder.
+        del /q "%CARBON_HOME%\repository\components\lib\bcpkix-fips*.jar" 2> nul
+        echo Successfully removed bcpkix-fips_%BCPKIX_FIPS_VERSION%.jar from components/lib.
+        if exist "%CARBON_HOME%\repository\components\dropins\bcpkix_fips*.jar" (
+            set sever_restart_required=true
+            echo Remove existing bcpkix-fips jar from dropins folder.
+            del /q "%CARBON_HOME%\repository\components\dropins\bcpkix_fips*.jar" 2> nul
+            echo Successfully removed bcpkix-fips_%BCPKIX_FIPS_VERSION%.jar from components/dropins.
+        )
+    )
+)
+
+if not exist "%CARBON_HOME%\repository\components\lib\bc-fips*.jar" (
+    set server_restart_required=true
+	if not "%arg1%"=="" (
+	    if not exist "%arg1%\bc-fips-%BC_FIPS_VERSION%.jar" (
+	    	echo Can not be found requried bc-fips-%BC_FIPS_VERSION%.jar in given file path : "%arg1%".
+	    ) else (
+		    copy "%arg1%\bc-fips-%BC_FIPS_VERSION%.jar" "%CARBON_HOME%\repository\components\lib\"
+            if %errorlevel% equ 0 (
+                echo bc-fips JAR file copied successfully.
+            ) else (
+                echo Error copying bc-fips JAR file.
+            )
+    )
+	)
+	if not "%arg2%"=="" if "%arg1%"=="" (
+        echo Downloading required bc-fips jar : bc-fips-%BC_FIPS_VERSION%
+	    curl %arg2%/org/bouncycastle/bc-fips/%BC_FIPS_VERSION%/bc-fips-%BC_FIPS_VERSION%.jar -o %CARBON_HOME%/repository/components/lib/bc-fips-%BC_FIPS_VERSION%.jar
+        FOR /F "tokens=*" %%G IN ('certutil -hashfile "%CARBON_HOME%\repository\components\lib\bc-fips-%BC_FIPS_VERSION%.jar" SHA1 ^| FIND /V ":"') DO SET "ACTUAL_CHECKSUM_BC_FIPS=%%G"
+        if "%ACTUAL_CHECKSUM_BC_FIPS%"=="%EXPECTED_BC_FIPS_CHECKSUM%" (
+            echo Checksum verified: The downloaded bc-fips-%BC_FIPS_VERSION%.jar is valid.
+        ) else (
+            echo Checksum verification failed: The downloaded bc-fips-%BC_FIPS_VERSION%.jar may be corrupted.
+        )
+	)
+	if "%arg1%"=="" if "%arg2%"=="" (
+	    echo Downloading required bc-fips jar : bc-fips-%BC_FIPS_VERSION%
+	    curl https://repo1.maven.org/maven2/org/bouncycastle/bc-fips/%BC_FIPS_VERSION%/bc-fips-%BC_FIPS_VERSION%.jar -o %CARBON_HOME%/repository/components/lib/bc-fips-%BC_FIPS_VERSION%.jar
+        FOR /F "tokens=*" %%G IN ('certutil -hashfile "%CARBON_HOME%\repository\components\lib\bc-fips-%BC_FIPS_VERSION%.jar" SHA1 ^| FIND /V ":"') DO SET "ACTUAL_CHECKSUM_BC_FIPS=%%G"
+        if "%ACTUAL_CHECKSUM_BC_FIPS%"=="%EXPECTED_BC_FIPS_CHECKSUM%" (
+            echo Checksum verified: The downloaded bc-fips-%BC_FIPS_VERSION%.jar is valid.
+        ) else (
+            echo Checksum verification failed: The downloaded bc-fips-%BC_FIPS_VERSION%.jar may be corrupted.
+        )
+    )
+)
+
+if not exist "%CARBON_HOME%\repository\components\lib\bcpkix-fips*.jar" (
+    set server_restart_required=true
+	if not "%arg1%"=="" (
+	if not exist "%arg1%\bcpkix-fips-%BCPKIX_FIPS_VERSION%.jar" (
+		echo Can not be found requried bcpkix-fips-%BCPKIX_FIPS_VERSION%.jar in given file path : "%arg1%".
+	) else (
+        copy "%arg1%\bcpkix-fips-%BCPKIX_FIPS_VERSION%.jar" "%CARBON_HOME%\repository\components\lib\"
+        if %errorlevel% equ 0 (
+            echo bcpkix-fips JAR file copied successfully.
+        ) else (
+            echo Error copying bcpkix-fips JAR file.
+        )
+	)
+	)
+	if not "%arg2%"=="" if "%arg1%"=="" (
+        echo Downloading required bcpkix-fips jar : bcpkix-fips-%BCPKIX_FIPS_VERSION%
+	    curl %arg2%/org/bouncycastle/bcpkix-fips/%BCPKIX_FIPS_VERSION%/bcpkix-fips-%BCPKIX_FIPS_VERSION%.jar -o %CARBON_HOME%/repository/components/lib/bcpkix-fips-%BCPKIX_FIPS_VERSION%.jar
+        FOR /F "tokens=*" %%G IN ('certutil -hashfile "%CARBON_HOME%\repository\components\lib\bcpkix-fips-%BCPKIX_FIPS_VERSION%.jar" SHA1 ^| FIND /V ":"') DO SET "ACTUAL_CHECKSUM_BCPKIX_FIPS=%%G"
+        if "%ACTUAL_CHECKSUM_BCPKIX_FIPS%"=="%EXPECTED_BCPKIX_FIPS_CHECKSUM%" (
+            echo Checksum verified: The downloaded bcpkix-%BCPKIX_FIPS_VERSION%.jar is valid.
+        ) else (
+            echo Checksum verification failed: The downloaded bcpkix-%BCPKIX_FIPS_VERSION%.jar may be corrupted.
+        )
+	)
+	if "%arg1%"=="" if "%arg2%"=="" (
+	    echo Downloading required bcpkix-fips jar : bcpkix-fips-%BCPKIX_FIPS_VERSION%
+	    curl https://repo1.maven.org/maven2/org/bouncycastle/bcpkix-fips/%BCPKIX_FIPS_VERSION%/bcpkix-fips-%BCPKIX_FIPS_VERSION%.jar -o %CARBON_HOME%/repository/components/lib/bcpkix-fips-%BCPKIX_FIPS_VERSION%.jar
+        FOR /F "tokens=*" %%G IN ('certutil -hashfile "%CARBON_HOME%\repository\components\lib\bcpkix-fips-%BCPKIX_FIPS_VERSION%.jar" SHA1 ^| FIND /V ":"') DO SET "ACTUAL_CHECKSUM_BCPKIX_FIPS=%%G"
+        if "%ACTUAL_CHECKSUM_BCPKIX_FIPS%"=="%EXPECTED_BCPKIX_FIPS_CHECKSUM%" (
+            echo Checksum verified: The downloaded bcpkix-fips-%BCPKIX_FIPS_VERSION%.jar is valid.
+        ) else (
+            echo Checksum verification failed: The downloaded bcpkix-fips-%BCPKIX_FIPS_VERSION%.jar may be corrupted.
+        )
+    )
+)
+
+set api_publisher_temp_file=%CARBON_HOME%\repository\components\api-publisher-deprecated\configuration\org.eclipse.equinox.simpleconfigurator\api_publisher_temp.info
+findstr /v /c:%bcprov_text% /c:%bcpkix_text% %api_publisher_bundles_info% > !api_publisher_temp_file!
+move /y !api_publisher_temp_file! %api_publisher_bundles_info% > nul
+
+set api_devportal_temp_file=%CARBON_HOME%\repository\components\api-devportal-deprecated\configuration\org.eclipse.equinox.simpleconfigurator\api_devportal_temp.info
+findstr /v /c:%bcprov_text% /c:%bcpkix_text% %api_devportal_bundles_info% > !api_devportal_temp_file!
+move /y !api_devportal_temp_file! %api_devportal_bundles_info% > nul
+
+set api_key_manager_temp_file=%CARBON_HOME%\repository\components\api-key-manager-deprecated\configuration\org.eclipse.equinox.simpleconfigurator\api_key_manager_temp.info
+findstr /v /c:%bcprov_text% /c:%bcpkix_text% %api_key_manager_bundles_info% > !api_key_manager_temp_file!
+move /y !api_key_manager_temp_file! %api_key_manager_bundles_info% > nul
+
+set default_temp_file=%CARBON_HOME%\repository\components\default\configuration\org.eclipse.equinox.simpleconfigurator\default_temp.info
+findstr /v /c:%bcprov_text% /c:%bcpkix_text% %default_bundles_info% > !default_temp_file!
+move /y !default_temp_file! %default_bundles_info% > nul
+
+set control_plane_temp_file=%CARBON_HOME%\repository\components\control-plane\configuration\org.eclipse.equinox.simpleconfigurator\control_plane_temp.info
+findstr /v /c:%bcprov_text% /c:%bcpkix_text% %control_plane_bundles_info% > !control_plane_temp_file!
+move /y !control_plane_temp_file! %control_plane_bundles_info% > nul
+
+set traffic_manager_temp_file=%CARBON_HOME%\repository\components\traffic-manager\configuration\org.eclipse.equinox.simpleconfigurator\traffic_manager_temp.info
+findstr /v /c:%bcprov_text% /c:%bcpkix_text% %traffic_manager_bundles_info% > !traffic_manager_temp_file!
+move /y !traffic_manager_temp_file! %traffic_manager_bundles_info% > nul
+
+set gateway_worker_temp_file=%CARBON_HOME%\repository\components\gateway-worker\configuration\org.eclipse.equinox.simpleconfigurator\gateway_worker_temp.info
+findstr /v /c:%bcprov_text% /c:%bcpkix_text% %gateway_worker_bundles_info% > !gateway_worker_temp_file!
+move /y !gateway_worker_temp_file! %gateway_worker_bundles_info% > nul
+
+goto printRestartMsg
+
+:verifyFipsMode
+set verify=true
+if exist "%CARBON_HOME%\repository\components\plugins\bcprov-jdk15on*.jar" (
+	set location=
+	for /f "delims=" %%i in ('dir /b /s "%CARBON_HOME%\repository\components\plugins\bcprov-jdk15on*.jar" ^| findstr /i /c:".jar"') do (
+		set "location=%%i"
+		goto :verifyBcFipsLocation
+	)
+	:verifyBcFipsLocation
+	if not "%location%"=="" (
+		set verify=false
+		echo Found bcprov-jdk15on_%BCPROV_JDK15ON_VERSION%.jar in plugins folder. This jar should be removed.
+	)
+)
+if exist "%CARBON_HOME%\repository\components\plugins\bcpkix-jdk15on*.jar" (
+	set location=
+	for /f "delims=" %%i in ('dir /b /s "%CARBON_HOME%\repository\components\plugins\bcpkix-jdk15on*.jar" ^| findstr /i /c:".jar"') do (
+		set "location=%%i"
+		goto :verifyBcPkixFipsLocation
+	)
+	:verifyBcPkixFipsLocation
+	if not "%location%"=="" (
+		set verify=false
+		echo Found bcpkix-jdk15on_%BCPKIX_JDK15ON_VERSION%.jar in plugins folder. This jar should be removed.
+	)
+)
+if exist "%CARBON_HOME%\repository\components\lib\bc-fips*.jar" (
+	if not exist "%CARBON_HOME%\repository\components\lib\bc-fips-%BC_FIPS_VERSION%.jar" (
+		set verify=false
+		echo There is an update for bc-fips. Run the script again to get updates.
+    )
+)  else (
+    set verify=false
+    echo can not be found bc-fips_%BC_FIPS_VERSION%.jar in components/lib folder. This jar should be added.
+)
+
+if exist "%CARBON_HOME%\repository\components\lib\bcpkix-fips*.jar" (
+	if not exist "%CARBON_HOME%\repository\components\lib\bcpkix-fips-%BCPKIX_FIPS_VERSION%.jar" (
+		set verify=false
+		echo There is an update for bcpkix-fips. Run the script again to get updates.
+    )
+) else (
+    set verify=false
+    echo can not be found bc-fips_%BC_FIPS_VERSION%.jar in components/lib folder. This jar should be added.
+)
+
+findstr /i /c:"%bcprov_text%" "%api_publisher_bundles_info%" > nul
+if %errorlevel%==0 (
+    set verify=false
+    echo Found text "%bcprov_text%" in api-publisher bundles.info. This should be removed.
+)
+
+findstr /i /c:"%bcpkix_text%" "%api_publisher_bundles_info%" > nul
+if %errorlevel%==0 (
+    set verify=false
+    echo Found text "%bcpkix_text%" in api-publisher bundles.info. This should be removed.
+)
+
+findstr /i /c:"%bcprov_text%" "%api_devportal_bundles_info%" > nul
+if %errorlevel%==0 (
+    set verify=false
+    echo Found text "%bcprov_text%" in api-devportal bundles.info. This should be removed.
+)
+
+findstr /i /c:"%bcpkix_text%" "%api_devportal_bundles_info%" > nul
+if %errorlevel%==0 (
+    set verify=false
+    echo Found text "%bcpkix_text%" in api-devportal bundles.info. This should be removed.
+)
+
+findstr /i /c:"%bcprov_text%" "%api_key_manager_bundles_info%" > nul
+if %errorlevel%==0 (
+    set verify=false
+    echo Found text "%bcprov_text%" in api-key-manager bundles.info. This should be removed.
+)
+
+findstr /i /c:"%bcpkix_text%" "%api_key_manager_bundles_info%" > nul
+if %errorlevel%==0 (
+    set verify=false
+    echo Found text "%bcpkix_text%" in api-key-manager bundles.info. This should be removed.
+)
+
+findstr /i /c:"%bcprov_text%" "%default_bundles_info%" > nul
+if %errorlevel%==0 (
+    set verify=false
+    echo Found text "%bcprov_text%" in default bundles.info. This should be removed.
+)
+
+findstr /i /c:"%bcpkix_text%" "%default_bundles_info%" > nul
+if %errorlevel%==0 (
+    set verify=false
+    echo Found text "%bcpkix_text%" in default bundles.info. This should be removed.
+)
+
+findstr /i /c:"%bcprov_text%" "%traffic_manager_bundles_info%" > nul
+if %errorlevel%==0 (
+    set verify=false
+    echo Found text "%bcprov_text%" in traffic-manager bundles.info. This should be removed.
+)
+
+findstr /i /c:"%bcpkix_text%" "%traffic_manager_bundles_info%" > nul
+if %errorlevel%==0 (
+    set verify=false
+    echo Found text "%bcpkix_text%" in traffic-manager bundles.info. This should be removed.
+)
+
+findstr /i /c:"%bcprov_text%" "%gateway_worker_bundles_info%" > nul
+if %errorlevel%==0 (
+    set verify=false
+    echo Found text "%bcprov_text%" in gateway-worker bundles.info. This should be removed.
+)
+
+findstr /i /c:"%bcpkix_text%" "%gateway_worker_bundles_info%" > nul
+if %errorlevel%==0 (
+    set verify=false
+    echo Found text "%bcpkix_text%" in gateway-worker bundles.info. This should be removed.
+)
+
+if "%verify%"=="true" (
+	echo Verified : Product is FIPS compliant.
+) else (
+	echo Verification failed : Product is not FIPS compliant.
+)
+goto end
+
+:printRestartMsg
+if "%server_restart_required%"=="true" (
+    echo Please restart the server.
+)
+
+goto end
+
+:noServerHome
+echo CARBON_HOME is set incorrectly or CARBON could not be located. Please set CARBON_HOME.
+goto end
+
+:end
+endlocal

--- a/modules/distribution/product/src/main/startup-scripts/fips.sh
+++ b/modules/distribution/product/src/main/startup-scripts/fips.sh
@@ -16,11 +16,7 @@
 
 BC_FIPS_VERSION=1.0.2.3;
 BCPKIX_FIPS_VERSION=1.0.7;
-BCPROV_JDK15ON_VERSION=1.70.0.wso2v1;
-BCPKIX_JDK15ON_VERSION=1.70.0.wso2v1;
 
-EXPECTED_BCPROV_CHECKSUM="261f41c52b6a664a5e9011ba829e78eb314c0ed8"
-EXPECTED_BCPKIX_CHECKSUM="17db4aba24861e306427bdeff03b1c2fac57760f"
 EXPECTED_BC_FIPS_CHECKSUM="da62b32cb72591f5b4d322e6ab0ce7de3247b534"
 EXPECTED_BCPKIX_FIPS_CHECKSUM="fe07959721cfa2156be9722ba20fdfee2b5441b0"
 
@@ -39,80 +35,74 @@ control_plane_bundles_info="$CARBON_HOME/repository/components/control-plane/con
 traffic_manager_bundles_info="$CARBON_HOME/repository/components/traffic-manager/configuration/org.eclipse.equinox.simpleconfigurator/bundles.info";
 gateway_worker_bundles_info="$CARBON_HOME/repository/components/gateway-worker/configuration/org.eclipse.equinox.simpleconfigurator/bundles.info";
 
-bcprov_text="bcprov-jdk15on,$BCPROV_JDK15ON_VERSION,../plugins/bcprov-jdk15on_$BCPROV_JDK15ON_VERSION.jar,4,true";
-bcpkix_text="bcpkix-jdk15on,$BCPKIX_JDK15ON_VERSION,../plugins/bcpkix-jdk15on_$BCPKIX_JDK15ON_VERSION.jar,4,true";
 homeDir="$HOME"
 sever_restart_required=false
 
 if [ "$ARGUMENT" = "DISABLE" ] || [ "$ARGUMENT" = "disable" ]; then
-    if [ -f $CARBON_HOME/repository/components/lib/bc-fips*.jar ]; then
-	    sever_restart_required=true
-   		echo "Remove existing bc-fips jar from lib folder."
-   		rm rm $CARBON_HOME/repository/components/lib/bc-fips*.jar 2> /dev/null
-		  echo "Successfully removed bc-fips_$BC_FIPS_VERSION.jar Removed from component/lib."
-   	fi
-   	if [ -f $CARBON_HOME/repository/components/lib/bcpkix-fips*.jar ]; then
-   	    sever_restart_required=true
-   		echo "Remove existing bcpkix-fips jar from lib folder."
-   		rm rm $CARBON_HOME/repository/components/lib/bcpkix-fips*.jar 2> /dev/null
-   		echo "Successfully removed bcpkix-fips_$BCPKIX_JDK15ON_VERSION.jar  from component/lib."
-   	fi
-   	if [ -f $CARBON_HOME/repository/components/dropins/bc_fips*.jar ]; then
-   	    sever_restart_required=true
-   		echo "Remove existing bc-fips jar from dropins folder."
-   		rm rm $CARBON_HOME/repository/components/dropins/bc_fips*.jar 2> /dev/null
-   		echo "Successfully removed bc-fips_$BC_FIPS_VERSION.jar from component/dropins."
-   	fi
-   	if [ -f $CARBON_HOME/repository/components/dropins/bcpkix_fips*.jar ]; then
-   	    sever_restart_required=true
-   		echo "Remove existing bcpkix_fips jar from dropins folder."
-   		rm rm $CARBON_HOME/repository/components/dropins/bcpkix_fips*.jar 2> /dev/null
-		  echo "Successfully removed bcpkix_fips_$BCPKIX_JDK15ON_VERSION.jar from component/dropins."
-   	fi
-	if [ ! -e $CARBON_HOME/repository/components/plugins/bcprov-jdk15on*.jar ]; then
-	    sever_restart_required=true
-	    if [ -f "$homeDir/.wso2-bc/backup/bcprov-jdk15on_$BCPROV_JDK15ON_VERSION.jar" ]; then
-		    mv "$homeDir/.wso2-bc/backup/bcprov-jdk15on_$BCPROV_JDK15ON_VERSION.jar" "$CARBON_HOME/repository/components/plugins"
-		    echo "Moved bcprov-jdk15on_$BCPROV_JDK15ON_VERSION.jar from $homeDir/.wso2-bc/backup to components/plugins"
-	    else
-		    echo "Downloading required bcprov-jdk15on jar : bcprov-jdk15on-$BCPROV_JDK15ON_VERSION"
-		    curl https://maven.wso2.org/nexus/content/repositories/releases/org/wso2/orbit/org/bouncycastle/bcprov-jdk15on/$BCPROV_JDK15ON_VERSION/bcprov-jdk15on-$BCPROV_JDK15ON_VERSION.jar -o $CARBON_HOME/repository/components/plugins/bcprov-jdk15on_$BCPROV_JDK15ON_VERSION.jar
-	        ACTUAL_CHECKSUM=$(sha1sum $CARBON_HOME/repository/components/plugins/bcprov-jdk15on*.jar | cut -d' ' -f1)
-	        if [ "$EXPECTED_BCPROV_CHECKSUM" = "$ACTUAL_CHECKSUM" ]; then
-  		        echo "Checksum verified: The downloaded bcprov-jdk15on-$BCPROV_JDK15ON_VERSION.jar is valid."
-	        else
-  		        echo "Checksum verification failed: The downloaded bcprov-jdk15on-$BCPROV_JDK15ON_VERSION.jar may be corrupted."
-	        fi
-	    fi
-	fi
-	if [ ! -e $CARBON_HOME/repository/components/plugins/bcpkix-jdk15on*.jar ]; then
-	    sever_restart_required=true
-	    if [ -f "$homeDir/.wso2-bc/backup/bcpkix-jdk15on_$BCPKIX_JDK15ON_VERSION.jar" ]; then
-		    mv "$homeDir/.wso2-bc/backup/bcpkix-jdk15on_$BCPKIX_JDK15ON_VERSION.jar" "$CARBON_HOME/repository/components/plugins"
-		    echo "Moved bcpkix-jdk15on_$BCPKIX_JDK15ON_VERSION.jar from $homeDir/.wso2-bc/backup to components/plugins"
+  if [ -f $CARBON_HOME/repository/components/lib/bc-fips*.jar ]; then
+    sever_restart_required=true
+    echo "Removing existing bc-fips jar from lib folder."
+    rm rm $CARBON_HOME/repository/components/lib/bc-fips*.jar 2> /dev/null
+    echo "Successfully removed bc-fips_$BC_FIPS_VERSION.jar from component/lib."
+  fi
+  if [ -f $CARBON_HOME/repository/components/lib/bcpkix-fips*.jar ]; then
+    sever_restart_required=true
+    echo "Removing existing bcpkix-fips jar from lib folder."
+    rm rm $CARBON_HOME/repository/components/lib/bcpkix-fips*.jar 2> /dev/null
+    echo "Successfully removed bcpkix-fips_$BCPKIX_JDK15ON_VERSION.jar  from component/lib."
+  fi
+  if [ -f $CARBON_HOME/repository/components/dropins/bc_fips*.jar ]; then
+    sever_restart_required=true
+    echo "Removing existing bc-fips jar from dropins folder."
+    rm rm $CARBON_HOME/repository/components/dropins/bc_fips*.jar 2> /dev/null
+    echo "Successfully removed bc-fips_$BC_FIPS_VERSION.jar from component/dropins."
+  fi
+  if [ -f $CARBON_HOME/repository/components/dropins/bcpkix_fips*.jar ]; then
+      sever_restart_required=true
+    echo "Removing existing bcpkix_fips jar from dropins folder."
+    rm rm $CARBON_HOME/repository/components/dropins/bcpkix_fips*.jar 2> /dev/null
+    echo "Successfully removed bcpkix_fips_$BCPKIX_JDK15ON_VERSION.jar from component/dropins."
+  fi
+  if [ ! -e $CARBON_HOME/repository/components/plugins/bcprov-jdk15on*.jar ]; then
+      sever_restart_required=true
+      if [ -e $homeDir/.wso2-bc/backup/bcprov-jdk15on*.jar ]; then
+        location=$(find "$homeDir/.wso2-bc/backup/" -type f -name "bcprov-jdk15on*.jar" | head -1)
+        bcprov_file_name=$(basename "$location")
+        bcprov_version=${bcprov_file_name#*_}
+        bcprov_version=${bcprov_version%.jar}
+        mv "$location" "$CARBON_HOME/repository/components/plugins"
+        echo "Moved $bcprov_file_name from $homeDir/.wso2-bc/backup to components/plugins."
+      else
+        echo "Required bcprov-jdk15on jar is not available in $homeDir/.wso2-bc/backup. Download the jar from maven central repository."
+      fi
+  fi
+  if [ ! -e $CARBON_HOME/repository/components/plugins/bcpkix-jdk15on*.jar ]; then
+      sever_restart_required=true
+      if [ -e $homeDir/.wso2-bc/backup/bcpkix-jdk15on*.jar ]; then
+        location=$(find "$homeDir/.wso2-bc/backup/" -type f -name "bcpkix-jdk15on*.jar" | head -1)
+        bcpkix_file_name=$(basename "$location")
+        bcpkix_version=${bcpkix_file_name#*_}
+        bcpkix_version=${bcpkix_version%.jar}
+        mv "$location" "$CARBON_HOME/repository/components/plugins"
+        echo "Moved $bcpkix_file_name from $homeDir/.wso2-bc/backup to components/plugins."
+      else
+        echo "Required bcpkix-jdk15on jar is not available in $homeDir/.wso2-bc/backup. Download the jar from maven central repository."
+      fi
+  fi
 
-	    else
-		    echo "Downloading required bcpkix-jdk15on jar : bcpkix-jdk15on-$BCPKIX_JDK15ON_VERSION"
-		    curl https://maven.wso2.org/nexus/content/repositories/releases/org/wso2/orbit/org/bouncycastle/bcpkix-jdk15on/$BCPKIX_JDK15ON_VERSION/bcpkix-jdk15on-$BCPKIX_JDK15ON_VERSION.jar -o $CARBON_HOME/repository/components/plugins/bcpkix-jdk15on_$BCPKIX_JDK15ON_VERSION.jar
-	        ACTUAL_CHECKSUM=$(sha1sum $CARBON_HOME/repository/components/plugins/bcpkix-jdk15on*.jar | cut -d' ' -f1)
-	        if [ "$EXPECTED_BCPKIX_CHECKSUM" = "$ACTUAL_CHECKSUM" ]; then
-  		        echo "Checksum verified: The downloaded bcpkix-jdk15on-$BCPKIX_JDK15ON_VERSION.jar is valid."
-	        else
-  		        echo "Checksum verification failed: The downloaded bcpkix-jdk15on-$BCPKIX_JDK15ON_VERSION.jar may be corrupted."
-	        fi
-	    fi
-	fi
+  bcprov_text="bcprov-jdk15on,$bcprov_version,../plugins/$bcprov_file_name,4,true";
+  bcpkix_text="bcpkix-jdk15on,$bcpkix_version,../plugins/$bcpkix_file_name,4,true";
 
-	if ! grep -q "$bcprov_text" "$api_publisher_bundles_info" ; then
-		echo  $bcprov_text >> $api_publisher_bundles_info;
-		sever_restart_required=true
-	fi
-	if ! grep -q "$bcpkix_text" "$api_publisher_bundles_info" ; then
-		echo  $bcpkix_text >> $api_publisher_bundles_info;
-		sever_restart_required=true
-	fi
+  if ! grep -q "$bcprov_text" "$api_publisher_bundles_info" ; then
+    echo  $bcprov_text >> $api_publisher_bundles_info;
+    sever_restart_required=true
+  fi
+  if ! grep -q "$bcpkix_text" "$api_publisher_bundles_info" ; then
+    echo  $bcpkix_text >> $api_publisher_bundles_info;
+    sever_restart_required=true
+  fi
 
-	if ! grep -q "$bcprov_text" "$api_devportal_bundles_info" ; then
+  if ! grep -q "$bcprov_text" "$api_devportal_bundles_info" ; then
     echo  $bcprov_text >> $api_devportal_bundles_info;
     sever_restart_required=true
   fi
@@ -170,16 +160,18 @@ elif [ "$ARGUMENT" = "VERIFY" ] || [ "$ARGUMENT" = "verify" ]; then
 	verify=true;
 	if [ -f $CARBON_HOME/repository/components/plugins/bcprov-jdk15on*.jar ]; then
 		location=$(find "$CARBON_HOME/repository/components/plugins/" -type f -name "bcprov-jdk15on*.jar" | head -1)
+		file_name=$(basename "$location")
 		verify=false
-		echo "Found bcprov-jdk15on_$BCPROV_JDK15ON_VERSION.jar in plugins folder. This jar should be removed."
+		echo "Found $file_name in plugins folder. This jar should be removed."
 	fi
 	if [ -f $CARBON_HOME/repository/components/plugins/bcprov-jdk15on*.jar ]; then
 		location=$(find "$CARBON_HOME/repository/components/plugins/" -type f -name "bcpkix-jdk15on*.jar" | head -1)
+		file_name=$(basename "$location")
 		verify=false
-		echo "Found bcpkix-jdk15on_$BCPKIX_JDK15ON_VERSION.jar in plugins folder. This jar should be removed."
+		echo "Found $file_name in plugins folder. This jar should be removed."
 	fi
 	if [ -f $CARBON_HOME/repository/components/lib/bc-fips*.jar ]; then
-	    if [ ! -f $CARBON_HOME/repository/components/lib/bc-fips-$BC_FIPS_VERSION.jar ]; then
+    if [ ! -f $CARBON_HOME/repository/components/lib/bc-fips-$BC_FIPS_VERSION.jar ]; then
 			verify=false
 			echo "There is an update for bc-fips. Run the script again to get updates."
 		fi
@@ -188,72 +180,71 @@ elif [ "$ARGUMENT" = "VERIFY" ] || [ "$ARGUMENT" = "verify" ]; then
 		echo "bc-fips_$BC_FIPS_VERSION.jar can not be found  in components/lib folder. This jar should be added."
 	fi
 	if [ -f $CARBON_HOME/repository/components/lib/bcpkix-fips*.jar ]; then
-	    if [ ! -f $CARBON_HOME/repository/components/lib/bcpkix-fips-$BCPKIX_FIPS_VERSION.jar ]; then
-	    	verify=false
-	    	echo "There is an update for bcpkix-fips. Run the script again to get updates."
+    if [ ! -f $CARBON_HOME/repository/components/lib/bcpkix-fips-$BCPKIX_FIPS_VERSION.jar ]; then
+      verify=false
+      echo "There is an update for bcpkix-fips. Run the script again to get updates."
 
 		fi
 	else
 		verify=false
 		echo "bcpkix-fips_$BCPKIX_FIPS_VERSION.jar can not be found in components/lib folder. This jar should be added."
-
 	fi
 
-	if grep -q "$bcprov_text" "$api_publisher_bundles_info" ; then
+	if grep -q "bcprov-jdk15on" "$api_publisher_bundles_info" ; then
     verify=false
-    echo  "Found $bcprov_text in api-publisher bundles.info. This should be removed";
+    echo  "Found bcprov-jdk15on entry in api-publisher bundles.info. This should be removed.";
   fi
-  if grep -q "$bcpkix_text" "$api_publisher_bundles_info" ; then
+  if grep -q "bcpkix-jdk15on" "$api_publisher_bundles_info" ; then
     verify=false
-    echo  "Found $bcpkix_text in api-publisher bundles.info. This should be removed";
+    echo  "Found bcpkix-jdk15on entry in api-publisher bundles.info. This should be removed.";
   fi
-	if grep -q "$bcprov_text" "$api_devportal_bundles_info" ; then
+	if grep -q "bcprov-jdk15on" "$api_devportal_bundles_info" ; then
     verify=false
-    echo  "Found $bcprov_text in api-devportal bundles.info. This should be removed";
+    echo  "Found bcprov-jdk15on entry in api-devportal bundles.info. This should be removed.";
   fi
-  if grep -q "$bcpkix_text" "$api_devportal_bundles_info" ; then
+  if grep -q "bcpkix-jdk15on" "$api_devportal_bundles_info" ; then
     verify=false
-    echo  "Found $bcpkix_text in api-devportal bundles.info. This should be removed";
+    echo  "Found bcpkix-jdk15on entry in api-devportal bundles.info. This should be removed.";
   fi
-  if grep -q "$bcprov_text" "$api_key_manager_bundles_info" ; then
+  if grep -q "bcprov-jdk15on" "$api_key_manager_bundles_info" ; then
     verify=false
-    echo  "Found $bcprov_text in api-key-manager bundles.info. This should be removed";
+    echo  "Found bcprov-jdk15on entry in api-key-manager bundles.info. This should be removed.";
   fi
-  if grep -q "$bcpkix_text" "$api_key_manager_bundles_info" ; then
+  if grep -q "bcpkix-jdk15on" "$api_key_manager_bundles_info" ; then
     verify=false
-    echo  "Found $bcpkix_text in api-key-manager bundles.info. This should be removed";
+    echo  "Found bcpkix-jdk15on entry in api-key-manager bundles.info. This should be removed.";
   fi
-  if grep -q "$bcprov_text" "$default_bundles_info" ; then
+  if grep -q "bcprov-jdk15on" "$default_bundles_info" ; then
     verify=false
-    echo  "Found $bcprov_text in default bundles.info. This should be removed";
+    echo  "Found bcprov-jdk15on entry in default bundles.info. This should be removed.";
   fi
-  if grep -q "$bcpkix_text" "$default_bundles_info" ; then
+  if grep -q "bcpkix-jdk15on" "$default_bundles_info" ; then
     verify=false
-    echo  "Found $bcpkix_text in default bundles.info. This should be removed";
+    echo  "Found bcpkix-jdk15on entry in default bundles.info. This should be removed.";
   fi
-  if grep -q "$bcprov_text" "$control_plane_bundles_info" ; then
+  if grep -q "bcprov-jdk15on" "$control_plane_bundles_info" ; then
     verify=false
-    echo  "Found $bcprov_text in control-plane bundles.info. This should be removed";
+    echo  "Found bcprov-jdk15on entry in control-plane bundles.info. This should be removed.";
   fi
-  if grep -q "$bcpkix_text" "$control_plane_bundles_info" ; then
+  if grep -q "bcpkix-jdk15on" "$control_plane_bundles_info" ; then
     verify=false
-    echo  "Found $bcpkix_text in control-plane bundles.info. This should be removed";
+    echo  "Found bcpkix-jdk15on entry in control-plane bundles.info. This should be removed.";
   fi
-  if grep -q "$bcprov_text" "$traffic_manager_bundles_info" ; then
+  if grep -q "bcprov-jdk15on" "$traffic_manager_bundles_info" ; then
     verify=false
-    echo  "Found $bcprov_text in traffic-manager bundles.info. This should be removed";
+    echo  "Found bcprov-jdk15on entry in traffic-manager bundles.info. This should be removed.";
   fi
-  if grep -q "$bcpkix_text" "$traffic_manager_bundles_info" ; then
+  if grep -q "bcpkix-jdk15on" "$traffic_manager_bundles_info" ; then
     verify=false
-    echo  "Found $bcpkix_text in traffic-manager bundles.info. This should be removed";
+    echo  "Found bcpkix-jdk15on entry in traffic-manager bundles.info. This should be removed.";
   fi
-  if grep -q "$bcprov_text" "$gateway_worker_bundles_info" ; then
+  if grep -q "bcprov-jdk15on" "$gateway_worker_bundles_info" ; then
     verify=false
-    echo  "Found $bcprov_text in gateway-worker bundles.info. This should be removed";
+    echo  "Found bcprov-jdk15on entry in gateway-worker bundles.info. This should be removed.";
   fi
-  if grep -q "$bcpkix_text" "$gateway_worker_bundles_info" ; then
+  if grep -q "bcpkix-jdk15on" "$gateway_worker_bundles_info" ; then
     verify=false
-    echo  "Found $bcpkix_text in gateway-worker bundles.info. This should be removed";
+    echo  "Found bcpkix-jdk15on entry in gateway-worker bundles.info. This should be removed.";
   fi
 
 	if [ $verify = true ]; then
@@ -262,23 +253,20 @@ elif [ "$ARGUMENT" = "VERIFY" ] || [ "$ARGUMENT" = "verify" ]; then
 	fi
 
 else
-while getopts "f:m:" opt; do
-  	case $opt in
-    	f)
-    		arg1=$OPTARG
-      		;;
-    	m)
-      		arg2=$OPTARG
-      		;;
-    	\?)
-      	echo "Invalid option: -$OPTARG" >&2
-      	exit 1
-      	;;
-  	esac
-	done
-	echo "arg1: $arg1"
-	echo "arg2: $arg2"
-
+  while getopts "f:m:" opt; do
+    case $opt in
+      f)
+        arg1=$OPTARG
+          ;;
+      m)
+          arg2=$OPTARG
+          ;;
+      \?)
+        echo "Invalid option: -$OPTARG" >&2
+        exit 1
+        ;;
+    esac
+  done
 
 	if [ ! -d "$homeDir/.wso2-bc" ]; then
     		mkdir "$homeDir/.wso2-bc"
@@ -289,177 +277,180 @@ while getopts "f:m:" opt; do
 	if [ -f $CARBON_HOME/repository/components/plugins/bcprov-jdk15on*.jar ]; then
 	    sever_restart_required=true
 	    location=$(find "$CARBON_HOME/repository/components/plugins/" -type f -name "bcprov-jdk15on*.jar" | head -1)
-	    echo "Remove existing bcpkix-jdk15on jar from plugins folder."
+	    echo "Removing existing bcpkix-jdk15on jar from plugins folder."
+      if [ -f $homeDir/.wso2-bc/backup/bcprov-jdk15on*.jar ]; then
+        rm $homeDir/.wso2-bc/backup/bcprov-jdk15on*.jar
+      fi
 	    mv "$location" "$homeDir/.wso2-bc/backup"
-   	    echo "Successfully removed bcprov-jdk15on_$BCPROV_JDK15ON_VERSION.jar from component/plugins."
+	    bcprov_file_name=$(basename "$location")
+      echo "Successfully removed $bcprov_file_name from component/plugins."
 	fi
 	if [ -f $CARBON_HOME/repository/components/plugins/bcpkix-jdk15on*.jar ]; then
 	   	sever_restart_required=true
-   		echo "Remove existing bcpkix-jdk15on jar from plugins folder."
-   		location=$(find "$CARBON_HOME/repository/components/plugins/" -type f -name "bcpkix-jdk15on*.jar" | head -1)
-   		mv "$location" "$homeDir/.wso2-bc/backup"
-   		echo "Successfully removed bcpkix-jdk15on_$BCPKIX_JDK15ON_VERSION.jar from component/plugins."
+      echo "Removing existing bcpkix-jdk15on jar from plugins folder."
+      location=$(find "$CARBON_HOME/repository/components/plugins/" -type f -name "bcpkix-jdk15on*.jar" | head -1)
+      if [ -f $homeDir/.wso2-bc/backup/bcpkix-jdk15on*.jar ]; then
+        rm $homeDir/.wso2-bc/backup/bcpkix-jdk15on*.jar
+      fi
+      mv "$location" "$homeDir/.wso2-bc/backup"
+      bcpkix_file_name=$(basename "$location")
+      echo "Successfully removed $bcpkix_file_name from component/plugins."
 	fi
 
-  if grep -q "$bcprov_text" "$api_publisher_bundles_info" ; then
+  if grep -q "bcprov-jdk15on" "$api_publisher_bundles_info" ; then
     sever_restart_required=true
     sed -i '/bcprov-jdk15on/d' $api_publisher_bundles_info
   fi
-  if grep -q "$bcpkix_text" "$api_publisher_bundles_info" ; then
+  if grep -q "bcpkix-jdk15on" "$api_publisher_bundles_info" ; then
     sever_restart_required=true
     sed -i '/bcpkix-jdk15on/d' $api_publisher_bundles_info
   fi
-  if grep -q "$bcprov_text" "$api_devportal_bundles_info" ; then
+  if grep -q "bcprov-jdk15on" "$api_devportal_bundles_info" ; then
     sever_restart_required=true
     sed -i '/bcprov-jdk15on/d' $api_devportal_bundles_info
   fi
-  if grep -q "$bcpkix_text" "$api_devportal_bundles_info" ; then
+  if grep -q "bcpkix-jdk15on" "$api_devportal_bundles_info" ; then
     sever_restart_required=true
     sed -i '/bcpkix-jdk15on/d' $api_devportal_bundles_info
   fi
-  if grep -q "$bcprov_text" "$api_key_manager_bundles_info" ; then
+  if grep -q "bcprov-jdk15on" "$api_key_manager_bundles_info" ; then
     sever_restart_required=true
     sed -i '/bcprov-jdk15on/d' $api_key_manager_bundles_info
   fi
-  if grep -q "$bcpkix_text" "$api_key_manager_bundles_info" ; then
+  if grep -q "bcpkix-jdk15on" "$api_key_manager_bundles_info" ; then
     sever_restart_required=true
     sed -i '/bcpkix-jdk15on/d' $api_key_manager_bundles_info
   fi
-  if grep -q "$bcprov_text" "$default_bundles_info" ; then
+  if grep -q "bcprov-jdk15on" "$default_bundles_info" ; then
     sever_restart_required=true
     sed -i '/bcprov-jdk15on/d' $default_bundles_info
   fi
-  if grep -q "$bcpkix_text" "$default_bundles_info" ; then
+  if grep -q "bcpkix-jdk15on" "$default_bundles_info" ; then
     sever_restart_required=true
     sed -i '/bcpkix-jdk15on/d' $default_bundles_info
   fi
-  if grep -q "$bcprov_text" "$control_plane_bundles_info" ; then
+  if grep -q "bcprov-jdk15on" "$control_plane_bundles_info" ; then
     sever_restart_required=true
     sed -i '/bcprov-jdk15on/d' $control_plane_bundles_info
   fi
-  if grep -q "$bcpkix_text" "$control_plane_bundles_info" ; then
+  if grep -q "bcpkix-jdk15on" "$control_plane_bundles_info" ; then
     sever_restart_required=true
     sed -i '/bcpkix-jdk15on/d' $control_plane_bundles_info
   fi
-  if grep -q "$bcprov_text" "$traffic_manager_bundles_info" ; then
+  if grep -q "bcprov-jdk15on" "$traffic_manager_bundles_info" ; then
     sever_restart_required=true
     sed -i '/bcprov-jdk15on/d' $traffic_manager_bundles_info
   fi
-  if grep -q "$bcpkix_text" "$traffic_manager_bundles_info" ; then
+  if grep -q "bcpkix-jdk15on" "$traffic_manager_bundles_info" ; then
     sever_restart_required=true
     sed -i '/bcpkix-jdk15on/d' $traffic_manager_bundles_info
   fi
-  if grep -q "$bcprov_text" "$gateway_worker_bundles_info" ; then
+  if grep -q "bcprov-jdk15on" "$gateway_worker_bundles_info" ; then
     sever_restart_required=true
     sed -i '/bcprov-jdk15on/d' $gateway_worker_bundles_info
   fi
-  if grep -q "$bcpkix_text" "$gateway_worker_bundles_info" ; then
+  if grep -q "bcpkix-jdk15on" "$gateway_worker_bundles_info" ; then
     sever_restart_required=true
     sed -i '/bcpkix-jdk15on/d' $gateway_worker_bundles_info
   fi
 
 	if [ -e $CARBON_HOME/repository/components/lib/bc-fips*.jar ]; then
-	    location=$(find "$CARBON_HOME/repository/components/lib/" -type f -name "bc-fips*.jar" | head -1)
+    location=$(find "$CARBON_HOME/repository/components/lib/" -type f -name "bc-fips*.jar" | head -1)
 		if [ ! $location = "$CARBON_HOME/repository/components/lib/bc-fips-$BC_FIPS_VERSION.jar" ]; then
-		    sever_restart_required=true
-   	    	echo "There is an update for bc-fips. Therefore Remove existing bc-fips jar from lib folder."
-   		    rm rm $CARBON_HOME/repository/components/lib/bc-fips*.jar 2> /dev/null
-		    echo "Successfully removed bc-fips_$BC_FIPS_VERSION.jar from component/lib."
-		    if [ -f $CARBON_HOME/repository/components/dropins/bc_fips*.jar ]; then
-   	            	sever_restart_required=true
-   		        echo "Remove existing bc-fips jar from dropins folder."
-   		        rm rm $CARBON_HOME/repository/components/dropins/bc_fips*.jar 2> /dev/null
-   		        echo "Successfully removed bc-fips_$BC_FIPS_VERSION.jar from component/dropins."
-   	        fi
+      sever_restart_required=true
+        echo "There is an update for bc-fips. Therefore Remove existing bc-fips jar from lib folder."
+        rm rm $CARBON_HOME/repository/components/lib/bc-fips*.jar 2> /dev/null
+      echo "Successfully removed bc-fips_$BC_FIPS_VERSION.jar from component/lib."
+      if [ -f $CARBON_HOME/repository/components/dropins/bc_fips*.jar ]; then
+        sever_restart_required=true
+        echo "Removing existing bc-fips jar from dropins folder."
+        rm rm $CARBON_HOME/repository/components/dropins/bc_fips*.jar 2> /dev/null
+        echo "Successfully removed bc-fips_$BC_FIPS_VERSION.jar from component/dropins."
+      fi
 		fi
 	fi
 
 	if [ ! -e $CARBON_HOME/repository/components/lib/bc-fips*.jar ]; then
 		sever_restart_required=true
 		if [ -z "$arg1" ] && [ -z "$arg2" ]; then
-		    echo "both empty"
-		    echo "Downloading required bc-fips jar : bc-fips-$BC_FIPS_VERSION"
-		    curl https://repo1.maven.org/maven2/org/bouncycastle/bc-fips/$BC_FIPS_VERSION/bc-fips-$BC_FIPS_VERSION.jar -o $CARBON_HOME/repository/components/lib/bc-fips-$BC_FIPS_VERSION.jar
-		    ACTUAL_CHECKSUM=$(sha1sum $CARBON_HOME/repository/components/lib/bc-fips*.jar | cut -d' ' -f1)
-	    	if [ "$EXPECTED_BC_FIPS_CHECKSUM" = "$ACTUAL_CHECKSUM" ]; then
-  		        echo "Checksum verified: The downloaded bc-fips-$BC_FIPS_VERSION.jar is valid."
-	    	else
-  		        echo "Checksum verification failed: The downloaded bc-fips-$BC_FIPS_VERSION.jar may be corrupted."
-	   	    fi
-	   	elif [ ! -z "$arg1" ] && [ -z "$arg2" ]; then
-	        echo "2 empty"
-	    	if [ ! -e $arg1/bcpkix-fips-$BCPKIX_FIPS_VERSION.jar ]; then
-	    	    echo "Can not be found required bc-fips-$BC_FIPS_VERSION.jar in given file path : $arg1."
-	    	else
-			    cp "$arg1/bc-fips-$BC_FIPS_VERSION.jar" "$CARBON_HOME/repository/components/lib"
-			    if [ $? -eq 0 ]; then
-  				    echo "bc-fips JAR files copied successfully."
-			    else
-  				    echo "Error copying bc-fips JAR file."
-			    fi
-			fi
+      echo "Downloading required bc-fips jar : bc-fips-$BC_FIPS_VERSION"
+      curl https://repo1.maven.org/maven2/org/bouncycastle/bc-fips/$BC_FIPS_VERSION/bc-fips-$BC_FIPS_VERSION.jar -o $CARBON_HOME/repository/components/lib/bc-fips-$BC_FIPS_VERSION.jar
+      ACTUAL_CHECKSUM=$(sha1sum $CARBON_HOME/repository/components/lib/bc-fips*.jar | cut -d' ' -f1)
+      if [ "$EXPECTED_BC_FIPS_CHECKSUM" = "$ACTUAL_CHECKSUM" ]; then
+        echo "Checksum verified: The downloaded bc-fips-$BC_FIPS_VERSION.jar is valid."
+      else
+        echo "Checksum verification failed: The downloaded bc-fips-$BC_FIPS_VERSION.jar may be corrupted."
+      fi
+    elif [ ! -z "$arg1" ] && [ -z "$arg2" ]; then
+      if [ ! -e $arg1/bcpkix-fips-$BCPKIX_FIPS_VERSION.jar ]; then
+        echo "Can not be found required bc-fips-$BC_FIPS_VERSION.jar in given file path : $arg1."
+      else
+        cp "$arg1/bc-fips-$BC_FIPS_VERSION.jar" "$CARBON_HOME/repository/components/lib"
+        if [ $? -eq 0 ]; then
+            echo "bc-fips JAR files copied successfully."
+        else
+            echo "Error copying bc-fips JAR file."
+        fi
+      fi
 		else
-		    echo "1 empty"
-		    echo "Downloading required bc-fips jar : bc-fips-$BC_FIPS_VERSION"
-		    curl $arg2/org/bouncycastle/bc-fips/$BC_FIPS_VERSION/bc-fips-$BC_FIPS_VERSION.jar -o $CARBON_HOME/repository/components/lib/bc-fips-$BC_FIPS_VERSION.jar
-		    ACTUAL_CHECKSUM=$(sha1sum $CARBON_HOME/repository/components/lib/bc-fips*.jar | cut -d' ' -f1)
-	    	if [ "$EXPECTED_BC_FIPS_CHECKSUM" = "$ACTUAL_CHECKSUM" ]; then
-  		        echo "Checksum verified: The downloaded bc-fips-$BC_FIPS_VERSION.jar is valid."
-	    	else
-  		        echo "Checksum verification failed: The downloaded bc-fips-$BC_FIPS_VERSION.jar may be corrupted."
-	   	    fi
-	   	fi
+      echo "Downloading required bc-fips jar : bc-fips-$BC_FIPS_VERSION"
+      curl $arg2/org/bouncycastle/bc-fips/$BC_FIPS_VERSION/bc-fips-$BC_FIPS_VERSION.jar -o $CARBON_HOME/repository/components/lib/bc-fips-$BC_FIPS_VERSION.jar
+      ACTUAL_CHECKSUM=$(sha1sum $CARBON_HOME/repository/components/lib/bc-fips*.jar | cut -d' ' -f1)
+      if [ "$EXPECTED_BC_FIPS_CHECKSUM" = "$ACTUAL_CHECKSUM" ]; then
+        echo "Checksum verified: The downloaded bc-fips-$BC_FIPS_VERSION.jar is valid."
+      else
+        echo "Checksum verification failed: The downloaded bc-fips-$BC_FIPS_VERSION.jar may be corrupted."
+      fi
+    fi
 	fi
 
 	if [ -e $CARBON_HOME/repository/components/lib/bcpkix-fips*.jar ]; then
 	    location=$(find "$CARBON_HOME/repository/components/lib/" -type f -name "bcpkix-fips*.jar" | head -1)
 		if [ ! $location = "$CARBON_HOME/repository/components/lib/bcpkix-fips-$BCPKIX_FIPS_VERSION.jar" ]; then
-		    sever_restart_required=true
-   	    	echo "There is an update for bcpkix-fips. Therefore Remove existing bcpkix-fips jar from lib folder."
-   		    rm rm $CARBON_HOME/repository/components/lib/bcpkix-fips*.jar 2> /dev/null
-		    echo "Successfully removed bcpkix-fips_$BCPKIX_FIPS_VERSION.jar Removed from component/lib."
-		    if [ -f $CARBON_HOME/repository/components/dropins/bcpkix-fips*.jar ]; then
-   		        echo "Remove existing bcpkix-fips jar from dropins folder."
-   		        rm rm $CARBON_HOME/repository/components/dropins/bcpkix_fips*.jar 2> /dev/null
-   		        echo "Successfully removed bcpkix-fips_$BCPKIX_FIPS_VERSION.jar from component/dropins."
-   	        fi
+      sever_restart_required=true
+        echo "There is an update for bcpkix-fips. Therefore Remove existing bcpkix-fips jar from lib folder."
+        rm rm $CARBON_HOME/repository/components/lib/bcpkix-fips*.jar 2> /dev/null
+        echo "Successfully removed bcpkix-fips_$BCPKIX_FIPS_VERSION.jar from component/lib."
+      if [ -f $CARBON_HOME/repository/components/dropins/bcpkix-fips*.jar ]; then
+        echo "Removing existing bcpkix-fips jar from dropins folder."
+        rm rm $CARBON_HOME/repository/components/dropins/bcpkix_fips*.jar 2> /dev/null
+        echo "Successfully removed bcpkix-fips_$BCPKIX_FIPS_VERSION.jar from component/dropins."
+      fi
 		fi
 	fi
 
 	if [ ! -e $CARBON_HOME/repository/components/lib/bcpkix-fips*.jar ]; then
-	    sever_restart_required=true
-	    if [ -z "$arg1" ] && [ -z "$arg2" ]; then
-		    echo "Downloading required bcpkix-fips jar : bcpkix-fips-$BCPKIX_FIPS_VERSION"
-		    curl https://repo1.maven.org/maven2/org/bouncycastle/bcpkix-fips/$BCPKIX_FIPS_VERSION/bcpkix-fips-$BCPKIX_FIPS_VERSION.jar -o $CARBON_HOME/repository/components/lib/bcpkix-fips-$BCPKIX_FIPS_VERSION.jar
-		    ACTUAL_CHECKSUM=$(sha1sum $CARBON_HOME/repository/components/lib/bcpkix-fips*.jar | cut -d' ' -f1)
-	   	    if [ "$EXPECTED_BCPKIX_FIPS_CHECKSUM" = "$ACTUAL_CHECKSUM" ]; then
-  			    echo "Checksum verified: The downloaded bcpkix-fips-$BCPKIX_FIPS_VERSION.jar is valid."
-	    	else
-  			    echo "Checksum verification failed: The downloaded bcpkix-fips-$BCPKIX_FIPS_VERSION.jar may be corrupted."
-	    	fi
-	    elif [ ! -z "$arg1" ] && [ -z "$arg2" ]; then
-	   	    echo "2 empty"
-	   	    if [ ! -e $arg1/bcpkix-fips-$BCPKIX_FIPS_VERSION.jar ]; then
-	   	    	echo "Can not be found required bcpkix-fips-$BCPKIX_FIPS_VERSION.jar in given file path : $arg1."
-	   	    else
-			    cp "$arg1/bcpkix-fips-$BCPKIX_FIPS_VERSION.jar" "$CARBON_HOME/repository/components/lib"
-			    if [ $? -eq 0 ]; then
-  				    echo "bcpkix-fips JAR files copied successfully."
-			    else
-  				    echo "Error copying bcpkix-fips JAR file."
-			    fi
-		    fi
+    sever_restart_required=true
+    if [ -z "$arg1" ] && [ -z "$arg2" ]; then
+      echo "Downloading required bcpkix-fips jar : bcpkix-fips-$BCPKIX_FIPS_VERSION"
+      curl https://repo1.maven.org/maven2/org/bouncycastle/bcpkix-fips/$BCPKIX_FIPS_VERSION/bcpkix-fips-$BCPKIX_FIPS_VERSION.jar -o $CARBON_HOME/repository/components/lib/bcpkix-fips-$BCPKIX_FIPS_VERSION.jar
+      ACTUAL_CHECKSUM=$(sha1sum $CARBON_HOME/repository/components/lib/bcpkix-fips*.jar | cut -d' ' -f1)
+        if [ "$EXPECTED_BCPKIX_FIPS_CHECKSUM" = "$ACTUAL_CHECKSUM" ]; then
+          echo "Checksum verified: The downloaded bcpkix-fips-$BCPKIX_FIPS_VERSION.jar is valid."
+      else
+          echo "Checksum verification failed: The downloaded bcpkix-fips-$BCPKIX_FIPS_VERSION.jar may be corrupted."
+      fi
+    elif [ ! -z "$arg1" ] && [ -z "$arg2" ]; then
+      if [ ! -e $arg1/bcpkix-fips-$BCPKIX_FIPS_VERSION.jar ]; then
+        echo "Can not be found required bcpkix-fips-$BCPKIX_FIPS_VERSION.jar in given file path : $arg1."
+      else
+      cp "$arg1/bcpkix-fips-$BCPKIX_FIPS_VERSION.jar" "$CARBON_HOME/repository/components/lib"
+      if [ $? -eq 0 ]; then
+          echo "bcpkix-fips JAR files copied successfully."
+      else
+          echo "Error copying bcpkix-fips JAR file."
+      fi
+    fi
 		else
-			echo "1 empty"
 			echo "Downloading required bcpkix-fips jar : bcpkix-fips-$BCPKIX_FIPS_VERSION"
-		    curl $arg2/org/bouncycastle/bcpkix-fips/$BCPKIX_FIPS_VERSION/bcpkix-fips-$BCPKIX_FIPS_VERSION.jar -o $CARBON_HOME/repository/components/lib/bcpkix-fips-$BCPKIX_FIPS_VERSION.jar
+      curl $arg2/org/bouncycastle/bcpkix-fips/$BCPKIX_FIPS_VERSION/bcpkix-fips-$BCPKIX_FIPS_VERSION.jar -o $CARBON_HOME/repository/components/lib/bcpkix-fips-$BCPKIX_FIPS_VERSION.jar
 			ACTUAL_CHECKSUM=$(sha1sucam $CARBON_HOME/repository/components/lib/bc-fips*.jar | cut -d' ' -f1)
-	    	if [ "$EXPECTED_BC_FIPS_CHECKSUM" = "$ACTUAL_CHECKSUM" ]; then
-  		    	echo "Checksum verified: The downloaded bc-fips-$BC_FIPS_VERSION.jar is valid."
-	    	else
-  		    	echo "Checksum verification failed: The downloaded bc-fips-$BC_FIPS_VERSION.jar may be corrupted."
-	   		fi
-	   	fi
+      if [ "$EXPECTED_BC_FIPS_CHECKSUM" = "$ACTUAL_CHECKSUM" ]; then
+          echo "Checksum verified: The downloaded bc-fips-$BC_FIPS_VERSION.jar is valid."
+      else
+          echo "Checksum verification failed: The downloaded bc-fips-$BC_FIPS_VERSION.jar may be corrupted."
+      fi
+    fi
 	fi
 fi
 

--- a/modules/distribution/product/src/main/startup-scripts/fips.sh
+++ b/modules/distribution/product/src/main/startup-scripts/fips.sh
@@ -299,59 +299,59 @@ else
 
   if grep -q "bcprov-jdk15on" "$api_publisher_bundles_info" ; then
     sever_restart_required=true
-    sed -i '/bcprov-jdk15on/d' $api_publisher_bundles_info
+    sed -i'' -e '/bcprov-jdk15on/d' $api_publisher_bundles_info
   fi
   if grep -q "bcpkix-jdk15on" "$api_publisher_bundles_info" ; then
     sever_restart_required=true
-    sed -i '/bcpkix-jdk15on/d' $api_publisher_bundles_info
+    sed -i'' -e  '/bcpkix-jdk15on/d' $api_publisher_bundles_info
   fi
   if grep -q "bcprov-jdk15on" "$api_devportal_bundles_info" ; then
     sever_restart_required=true
-    sed -i '/bcprov-jdk15on/d' $api_devportal_bundles_info
+    sed -i'' -e  '/bcprov-jdk15on/d' $api_devportal_bundles_info
   fi
   if grep -q "bcpkix-jdk15on" "$api_devportal_bundles_info" ; then
     sever_restart_required=true
-    sed -i '/bcpkix-jdk15on/d' $api_devportal_bundles_info
+    sed -i'' -e  '/bcpkix-jdk15on/d' $api_devportal_bundles_info
   fi
   if grep -q "bcprov-jdk15on" "$api_key_manager_bundles_info" ; then
     sever_restart_required=true
-    sed -i '/bcprov-jdk15on/d' $api_key_manager_bundles_info
+    sed -i'' -e  '/bcprov-jdk15on/d' $api_key_manager_bundles_info
   fi
   if grep -q "bcpkix-jdk15on" "$api_key_manager_bundles_info" ; then
     sever_restart_required=true
-    sed -i '/bcpkix-jdk15on/d' $api_key_manager_bundles_info
+    sed -i'' -e  '/bcpkix-jdk15on/d' $api_key_manager_bundles_info
   fi
   if grep -q "bcprov-jdk15on" "$default_bundles_info" ; then
     sever_restart_required=true
-    sed -i '/bcprov-jdk15on/d' $default_bundles_info
+    sed -i'' -e  '/bcprov-jdk15on/d' $default_bundles_info
   fi
   if grep -q "bcpkix-jdk15on" "$default_bundles_info" ; then
     sever_restart_required=true
-    sed -i '/bcpkix-jdk15on/d' $default_bundles_info
+    sed -i'' -e  '/bcpkix-jdk15on/d' $default_bundles_info
   fi
   if grep -q "bcprov-jdk15on" "$control_plane_bundles_info" ; then
     sever_restart_required=true
-    sed -i '/bcprov-jdk15on/d' $control_plane_bundles_info
+    sed -i'' -e  '/bcprov-jdk15on/d' $control_plane_bundles_info
   fi
   if grep -q "bcpkix-jdk15on" "$control_plane_bundles_info" ; then
     sever_restart_required=true
-    sed -i '/bcpkix-jdk15on/d' $control_plane_bundles_info
+    sed -i'' -e  '/bcpkix-jdk15on/d' $control_plane_bundles_info
   fi
   if grep -q "bcprov-jdk15on" "$traffic_manager_bundles_info" ; then
     sever_restart_required=true
-    sed -i '/bcprov-jdk15on/d' $traffic_manager_bundles_info
+    sed -i'' -e  '/bcprov-jdk15on/d' $traffic_manager_bundles_info
   fi
   if grep -q "bcpkix-jdk15on" "$traffic_manager_bundles_info" ; then
     sever_restart_required=true
-    sed -i '/bcpkix-jdk15on/d' $traffic_manager_bundles_info
+    sed -i'' -e  '/bcpkix-jdk15on/d' $traffic_manager_bundles_info
   fi
   if grep -q "bcprov-jdk15on" "$gateway_worker_bundles_info" ; then
     sever_restart_required=true
-    sed -i '/bcprov-jdk15on/d' $gateway_worker_bundles_info
+    sed -i'' -e  '/bcprov-jdk15on/d' $gateway_worker_bundles_info
   fi
   if grep -q "bcpkix-jdk15on" "$gateway_worker_bundles_info" ; then
     sever_restart_required=true
-    sed -i '/bcpkix-jdk15on/d' $gateway_worker_bundles_info
+    sed -i'' -e  '/bcpkix-jdk15on/d' $gateway_worker_bundles_info
   fi
 
 	if [ -e $CARBON_HOME/repository/components/lib/bc-fips*.jar ]; then
@@ -375,7 +375,7 @@ else
 		if [ -z "$arg1" ] && [ -z "$arg2" ]; then
       echo "Downloading required bc-fips jar : bc-fips-$BC_FIPS_VERSION"
       curl https://repo1.maven.org/maven2/org/bouncycastle/bc-fips/$BC_FIPS_VERSION/bc-fips-$BC_FIPS_VERSION.jar -o $CARBON_HOME/repository/components/lib/bc-fips-$BC_FIPS_VERSION.jar
-      ACTUAL_CHECKSUM=$(sha1sum $CARBON_HOME/repository/components/lib/bc-fips*.jar | cut -d' ' -f1)
+      ACTUAL_CHECKSUM=$(shasum $CARBON_HOME/repository/components/lib/bc-fips*.jar | cut -d' ' -f1)
       if [ "$EXPECTED_BC_FIPS_CHECKSUM" = "$ACTUAL_CHECKSUM" ]; then
         echo "Checksum verified: The downloaded bc-fips-$BC_FIPS_VERSION.jar is valid."
       else
@@ -395,7 +395,7 @@ else
 		else
       echo "Downloading required bc-fips jar : bc-fips-$BC_FIPS_VERSION"
       curl $arg2/org/bouncycastle/bc-fips/$BC_FIPS_VERSION/bc-fips-$BC_FIPS_VERSION.jar -o $CARBON_HOME/repository/components/lib/bc-fips-$BC_FIPS_VERSION.jar
-      ACTUAL_CHECKSUM=$(sha1sum $CARBON_HOME/repository/components/lib/bc-fips*.jar | cut -d' ' -f1)
+      ACTUAL_CHECKSUM=$(shasum $CARBON_HOME/repository/components/lib/bc-fips*.jar | cut -d' ' -f1)
       if [ "$EXPECTED_BC_FIPS_CHECKSUM" = "$ACTUAL_CHECKSUM" ]; then
         echo "Checksum verified: The downloaded bc-fips-$BC_FIPS_VERSION.jar is valid."
       else
@@ -424,7 +424,7 @@ else
     if [ -z "$arg1" ] && [ -z "$arg2" ]; then
       echo "Downloading required bcpkix-fips jar : bcpkix-fips-$BCPKIX_FIPS_VERSION"
       curl https://repo1.maven.org/maven2/org/bouncycastle/bcpkix-fips/$BCPKIX_FIPS_VERSION/bcpkix-fips-$BCPKIX_FIPS_VERSION.jar -o $CARBON_HOME/repository/components/lib/bcpkix-fips-$BCPKIX_FIPS_VERSION.jar
-      ACTUAL_CHECKSUM=$(sha1sum $CARBON_HOME/repository/components/lib/bcpkix-fips*.jar | cut -d' ' -f1)
+      ACTUAL_CHECKSUM=$(shasum $CARBON_HOME/repository/components/lib/bcpkix-fips*.jar | cut -d' ' -f1)
         if [ "$EXPECTED_BCPKIX_FIPS_CHECKSUM" = "$ACTUAL_CHECKSUM" ]; then
           echo "Checksum verified: The downloaded bcpkix-fips-$BCPKIX_FIPS_VERSION.jar is valid."
       else

--- a/modules/distribution/product/src/main/startup-scripts/fips.sh
+++ b/modules/distribution/product/src/main/startup-scripts/fips.sh
@@ -1,0 +1,468 @@
+#! /bin/bash
+# ----------------------------------------------------------------------------
+#  Copyright 2023 WSO2, LLC. http://www.wso2.org
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+BC_FIPS_VERSION=1.0.2.3;
+BCPKIX_FIPS_VERSION=1.0.7;
+BCPROV_JDK15ON_VERSION=1.70.0.wso2v1;
+BCPKIX_JDK15ON_VERSION=1.70.0.wso2v1;
+
+EXPECTED_BCPROV_CHECKSUM="261f41c52b6a664a5e9011ba829e78eb314c0ed8"
+EXPECTED_BCPKIX_CHECKSUM="17db4aba24861e306427bdeff03b1c2fac57760f"
+EXPECTED_BC_FIPS_CHECKSUM="da62b32cb72591f5b4d322e6ab0ce7de3247b534"
+EXPECTED_BCPKIX_FIPS_CHECKSUM="fe07959721cfa2156be9722ba20fdfee2b5441b0"
+
+# Get standard environment variables
+PRGDIR=`dirname "$PRG"`
+
+# Only set CARBON_HOME if not already set
+[ -z "$CARBON_HOME" ] && CARBON_HOME=`cd "$PRGDIR/.." ; pwd`
+
+ARGUMENT=$1;
+api_publisher_bundles_info="$CARBON_HOME/repository/components/api-publisher-deprecated/configuration/org.eclipse.equinox.simpleconfigurator/bundles.info";
+api_devportal_bundles_info="$CARBON_HOME/repository/components/api-devportal-deprecated/configuration/org.eclipse.equinox.simpleconfigurator/bundles.info";
+api_key_manager_bundles_info="$CARBON_HOME/repository/components/api-key-manager-deprecated/configuration/org.eclipse.equinox.simpleconfigurator/bundles.info";
+default_bundles_info="$CARBON_HOME/repository/components/default/configuration/org.eclipse.equinox.simpleconfigurator/bundles.info";
+control_plane_bundles_info="$CARBON_HOME/repository/components/control-plane/configuration/org.eclipse.equinox.simpleconfigurator/bundles.info";
+traffic_manager_bundles_info="$CARBON_HOME/repository/components/traffic-manager/configuration/org.eclipse.equinox.simpleconfigurator/bundles.info";
+gateway_worker_bundles_info="$CARBON_HOME/repository/components/gateway-worker/configuration/org.eclipse.equinox.simpleconfigurator/bundles.info";
+
+bcprov_text="bcprov-jdk15on,$BCPROV_JDK15ON_VERSION,../plugins/bcprov-jdk15on_$BCPROV_JDK15ON_VERSION.jar,4,true";
+bcpkix_text="bcpkix-jdk15on,$BCPKIX_JDK15ON_VERSION,../plugins/bcpkix-jdk15on_$BCPKIX_JDK15ON_VERSION.jar,4,true";
+homeDir="$HOME"
+sever_restart_required=false
+
+if [ "$ARGUMENT" = "DISABLE" ] || [ "$ARGUMENT" = "disable" ]; then
+    if [ -f $CARBON_HOME/repository/components/lib/bc-fips*.jar ]; then
+	    sever_restart_required=true
+   		echo "Remove existing bc-fips jar from lib folder."
+   		rm rm $CARBON_HOME/repository/components/lib/bc-fips*.jar 2> /dev/null
+		  echo "Successfully removed bc-fips_$BC_FIPS_VERSION.jar Removed from component/lib."
+   	fi
+   	if [ -f $CARBON_HOME/repository/components/lib/bcpkix-fips*.jar ]; then
+   	    sever_restart_required=true
+   		echo "Remove existing bcpkix-fips jar from lib folder."
+   		rm rm $CARBON_HOME/repository/components/lib/bcpkix-fips*.jar 2> /dev/null
+   		echo "Successfully removed bcpkix-fips_$BCPKIX_JDK15ON_VERSION.jar  from component/lib."
+   	fi
+   	if [ -f $CARBON_HOME/repository/components/dropins/bc_fips*.jar ]; then
+   	    sever_restart_required=true
+   		echo "Remove existing bc-fips jar from dropins folder."
+   		rm rm $CARBON_HOME/repository/components/dropins/bc_fips*.jar 2> /dev/null
+   		echo "Successfully removed bc-fips_$BC_FIPS_VERSION.jar from component/dropins."
+   	fi
+   	if [ -f $CARBON_HOME/repository/components/dropins/bcpkix_fips*.jar ]; then
+   	    sever_restart_required=true
+   		echo "Remove existing bcpkix_fips jar from dropins folder."
+   		rm rm $CARBON_HOME/repository/components/dropins/bcpkix_fips*.jar 2> /dev/null
+		  echo "Successfully removed bcpkix_fips_$BCPKIX_JDK15ON_VERSION.jar from component/dropins."
+   	fi
+	if [ ! -e $CARBON_HOME/repository/components/plugins/bcprov-jdk15on*.jar ]; then
+	    sever_restart_required=true
+	    if [ -f "$homeDir/.wso2-bc/backup/bcprov-jdk15on_$BCPROV_JDK15ON_VERSION.jar" ]; then
+		    mv "$homeDir/.wso2-bc/backup/bcprov-jdk15on_$BCPROV_JDK15ON_VERSION.jar" "$CARBON_HOME/repository/components/plugins"
+		    echo "Moved bcprov-jdk15on_$BCPROV_JDK15ON_VERSION.jar from $homeDir/.wso2-bc/backup to components/plugins"
+	    else
+		    echo "Downloading required bcprov-jdk15on jar : bcprov-jdk15on-$BCPROV_JDK15ON_VERSION"
+		    curl https://maven.wso2.org/nexus/content/repositories/releases/org/wso2/orbit/org/bouncycastle/bcprov-jdk15on/$BCPROV_JDK15ON_VERSION/bcprov-jdk15on-$BCPROV_JDK15ON_VERSION.jar -o $CARBON_HOME/repository/components/plugins/bcprov-jdk15on_$BCPROV_JDK15ON_VERSION.jar
+	        ACTUAL_CHECKSUM=$(sha1sum $CARBON_HOME/repository/components/plugins/bcprov-jdk15on*.jar | cut -d' ' -f1)
+	        if [ "$EXPECTED_BCPROV_CHECKSUM" = "$ACTUAL_CHECKSUM" ]; then
+  		        echo "Checksum verified: The downloaded bcprov-jdk15on-$BCPROV_JDK15ON_VERSION.jar is valid."
+	        else
+  		        echo "Checksum verification failed: The downloaded bcprov-jdk15on-$BCPROV_JDK15ON_VERSION.jar may be corrupted."
+	        fi
+	    fi
+	fi
+	if [ ! -e $CARBON_HOME/repository/components/plugins/bcpkix-jdk15on*.jar ]; then
+	    sever_restart_required=true
+	    if [ -f "$homeDir/.wso2-bc/backup/bcpkix-jdk15on_$BCPKIX_JDK15ON_VERSION.jar" ]; then
+		    mv "$homeDir/.wso2-bc/backup/bcpkix-jdk15on_$BCPKIX_JDK15ON_VERSION.jar" "$CARBON_HOME/repository/components/plugins"
+		    echo "Moved bcpkix-jdk15on_$BCPKIX_JDK15ON_VERSION.jar from $homeDir/.wso2-bc/backup to components/plugins"
+
+	    else
+		    echo "Downloading required bcpkix-jdk15on jar : bcpkix-jdk15on-$BCPKIX_JDK15ON_VERSION"
+		    curl https://maven.wso2.org/nexus/content/repositories/releases/org/wso2/orbit/org/bouncycastle/bcpkix-jdk15on/$BCPKIX_JDK15ON_VERSION/bcpkix-jdk15on-$BCPKIX_JDK15ON_VERSION.jar -o $CARBON_HOME/repository/components/plugins/bcpkix-jdk15on_$BCPKIX_JDK15ON_VERSION.jar
+	        ACTUAL_CHECKSUM=$(sha1sum $CARBON_HOME/repository/components/plugins/bcpkix-jdk15on*.jar | cut -d' ' -f1)
+	        if [ "$EXPECTED_BCPKIX_CHECKSUM" = "$ACTUAL_CHECKSUM" ]; then
+  		        echo "Checksum verified: The downloaded bcpkix-jdk15on-$BCPKIX_JDK15ON_VERSION.jar is valid."
+	        else
+  		        echo "Checksum verification failed: The downloaded bcpkix-jdk15on-$BCPKIX_JDK15ON_VERSION.jar may be corrupted."
+	        fi
+	    fi
+	fi
+
+	if ! grep -q "$bcprov_text" "$api_publisher_bundles_info" ; then
+		echo  $bcprov_text >> $api_publisher_bundles_info;
+		sever_restart_required=true
+	fi
+	if ! grep -q "$bcpkix_text" "$api_publisher_bundles_info" ; then
+		echo  $bcpkix_text >> $api_publisher_bundles_info;
+		sever_restart_required=true
+	fi
+
+	if ! grep -q "$bcprov_text" "$api_devportal_bundles_info" ; then
+    echo  $bcprov_text >> $api_devportal_bundles_info;
+    sever_restart_required=true
+  fi
+  if ! grep -q "$bcpkix_text" "$api_devportal_bundles_info" ; then
+    echo  $bcpkix_text >> $api_devportal_bundles_info;
+    sever_restart_required=true
+  fi
+
+  if ! grep -q "$bcprov_text" "$api_key_manager_bundles_info" ; then
+    echo  $bcprov_text >> $api_key_manager_bundles_info;
+    sever_restart_required=true
+  fi
+  if ! grep -q "$bcpkix_text" "$api_key_manager_bundles_info" ; then
+    echo  $bcpkix_text >> $api_key_manager_bundles_info;
+    sever_restart_required=true
+  fi
+
+  if ! grep -q "$bcprov_text" "$default_bundles_info" ; then
+    echo  $bcprov_text >> $default_bundles_info;
+    sever_restart_required=true
+  fi
+  if ! grep -q "$bcpkix_text" "$default_bundles_info" ; then
+    echo  $bcpkix_text >> $default_bundles_info;
+    sever_restart_required=true
+  fi
+
+  if ! grep -q "$bcprov_text" "$control_plane_bundles_info" ; then
+    echo  $bcprov_text >> $control_plane_bundles_info;
+    sever_restart_required=true
+  fi
+  if ! grep -q "$bcpkix_text" "$control_plane_bundles_info" ; then
+    echo  $bcpkix_text >> $control_plane_bundles_info;
+    sever_restart_required=true
+  fi
+
+  if ! grep -q "$bcprov_text" "$traffic_manager_bundles_info" ; then
+    echo  $bcprov_text >> $traffic_manager_bundles_info;
+    sever_restart_required=true
+  fi
+  if ! grep -q "$bcpkix_text" "$traffic_manager_bundles_info" ; then
+    echo  $bcpkix_text >> $traffic_manager_bundles_info;
+    sever_restart_required=true
+  fi
+
+  if ! grep -q "$bcprov_text" "$gateway_worker_bundles_info" ; then
+    echo  $bcprov_text >> $gateway_worker_bundles_info;
+    sever_restart_required=true
+  fi
+  if ! grep -q "$bcpkix_text" "$gateway_worker_bundles_info" ; then
+    echo  $bcpkix_text >> $gateway_worker_bundles_info;
+    sever_restart_required=true
+  fi
+
+elif [ "$ARGUMENT" = "VERIFY" ] || [ "$ARGUMENT" = "verify" ]; then
+	verify=true;
+	if [ -f $CARBON_HOME/repository/components/plugins/bcprov-jdk15on*.jar ]; then
+		location=$(find "$CARBON_HOME/repository/components/plugins/" -type f -name "bcprov-jdk15on*.jar" | head -1)
+		verify=false
+		echo "Found bcprov-jdk15on_$BCPROV_JDK15ON_VERSION.jar in plugins folder. This jar should be removed."
+	fi
+	if [ -f $CARBON_HOME/repository/components/plugins/bcprov-jdk15on*.jar ]; then
+		location=$(find "$CARBON_HOME/repository/components/plugins/" -type f -name "bcpkix-jdk15on*.jar" | head -1)
+		verify=false
+		echo "Found bcpkix-jdk15on_$BCPKIX_JDK15ON_VERSION.jar in plugins folder. This jar should be removed."
+	fi
+	if [ -f $CARBON_HOME/repository/components/lib/bc-fips*.jar ]; then
+	    if [ ! -f $CARBON_HOME/repository/components/lib/bc-fips-$BC_FIPS_VERSION.jar ]; then
+			verify=false
+			echo "There is an update for bc-fips. Run the script again to get updates."
+		fi
+	else
+		verify=false
+		echo "bc-fips_$BC_FIPS_VERSION.jar can not be found  in components/lib folder. This jar should be added."
+	fi
+	if [ -f $CARBON_HOME/repository/components/lib/bcpkix-fips*.jar ]; then
+	    if [ ! -f $CARBON_HOME/repository/components/lib/bcpkix-fips-$BCPKIX_FIPS_VERSION.jar ]; then
+	    	verify=false
+	    	echo "There is an update for bcpkix-fips. Run the script again to get updates."
+
+		fi
+	else
+		verify=false
+		echo "bcpkix-fips_$BCPKIX_FIPS_VERSION.jar can not be found in components/lib folder. This jar should be added."
+
+	fi
+
+	if grep -q "$bcprov_text" "$api_publisher_bundles_info" ; then
+    verify=false
+    echo  "Found $bcprov_text in api-publisher bundles.info. This should be removed";
+  fi
+  if grep -q "$bcpkix_text" "$api_publisher_bundles_info" ; then
+    verify=false
+    echo  "Found $bcpkix_text in api-publisher bundles.info. This should be removed";
+  fi
+	if grep -q "$bcprov_text" "$api_devportal_bundles_info" ; then
+    verify=false
+    echo  "Found $bcprov_text in api-devportal bundles.info. This should be removed";
+  fi
+  if grep -q "$bcpkix_text" "$api_devportal_bundles_info" ; then
+    verify=false
+    echo  "Found $bcpkix_text in api-devportal bundles.info. This should be removed";
+  fi
+  if grep -q "$bcprov_text" "$api_key_manager_bundles_info" ; then
+    verify=false
+    echo  "Found $bcprov_text in api-key-manager bundles.info. This should be removed";
+  fi
+  if grep -q "$bcpkix_text" "$api_key_manager_bundles_info" ; then
+    verify=false
+    echo  "Found $bcpkix_text in api-key-manager bundles.info. This should be removed";
+  fi
+  if grep -q "$bcprov_text" "$default_bundles_info" ; then
+    verify=false
+    echo  "Found $bcprov_text in default bundles.info. This should be removed";
+  fi
+  if grep -q "$bcpkix_text" "$default_bundles_info" ; then
+    verify=false
+    echo  "Found $bcpkix_text in default bundles.info. This should be removed";
+  fi
+  if grep -q "$bcprov_text" "$control_plane_bundles_info" ; then
+    verify=false
+    echo  "Found $bcprov_text in control-plane bundles.info. This should be removed";
+  fi
+  if grep -q "$bcpkix_text" "$control_plane_bundles_info" ; then
+    verify=false
+    echo  "Found $bcpkix_text in control-plane bundles.info. This should be removed";
+  fi
+  if grep -q "$bcprov_text" "$traffic_manager_bundles_info" ; then
+    verify=false
+    echo  "Found $bcprov_text in traffic-manager bundles.info. This should be removed";
+  fi
+  if grep -q "$bcpkix_text" "$traffic_manager_bundles_info" ; then
+    verify=false
+    echo  "Found $bcpkix_text in traffic-manager bundles.info. This should be removed";
+  fi
+  if grep -q "$bcprov_text" "$gateway_worker_bundles_info" ; then
+    verify=false
+    echo  "Found $bcprov_text in gateway-worker bundles.info. This should be removed";
+  fi
+  if grep -q "$bcpkix_text" "$gateway_worker_bundles_info" ; then
+    verify=false
+    echo  "Found $bcpkix_text in gateway-worker bundles.info. This should be removed";
+  fi
+
+	if [ $verify = true ]; then
+		echo "Verified : Product is FIPS compliant."
+	else 	echo "Verification failed : Product is not FIPS compliant."
+	fi
+
+else
+while getopts "f:m:" opt; do
+  	case $opt in
+    	f)
+    		arg1=$OPTARG
+      		;;
+    	m)
+      		arg2=$OPTARG
+      		;;
+    	\?)
+      	echo "Invalid option: -$OPTARG" >&2
+      	exit 1
+      	;;
+  	esac
+	done
+	echo "arg1: $arg1"
+	echo "arg2: $arg2"
+
+
+	if [ ! -d "$homeDir/.wso2-bc" ]; then
+    		mkdir "$homeDir/.wso2-bc"
+	fi
+	if [ ! -d "$homeDir/.wso2-bc/backup" ]; then
+    		mkdir "$homeDir/.wso2-bc/backup"
+	fi
+	if [ -f $CARBON_HOME/repository/components/plugins/bcprov-jdk15on*.jar ]; then
+	    sever_restart_required=true
+	    location=$(find "$CARBON_HOME/repository/components/plugins/" -type f -name "bcprov-jdk15on*.jar" | head -1)
+	    echo "Remove existing bcpkix-jdk15on jar from plugins folder."
+	    mv "$location" "$homeDir/.wso2-bc/backup"
+   	    echo "Successfully removed bcprov-jdk15on_$BCPROV_JDK15ON_VERSION.jar from component/plugins."
+	fi
+	if [ -f $CARBON_HOME/repository/components/plugins/bcpkix-jdk15on*.jar ]; then
+	   	sever_restart_required=true
+   		echo "Remove existing bcpkix-jdk15on jar from plugins folder."
+   		location=$(find "$CARBON_HOME/repository/components/plugins/" -type f -name "bcpkix-jdk15on*.jar" | head -1)
+   		mv "$location" "$homeDir/.wso2-bc/backup"
+   		echo "Successfully removed bcpkix-jdk15on_$BCPKIX_JDK15ON_VERSION.jar from component/plugins."
+	fi
+
+  if grep -q "$bcprov_text" "$api_publisher_bundles_info" ; then
+    sever_restart_required=true
+    sed -i '/bcprov-jdk15on/d' $api_publisher_bundles_info
+  fi
+  if grep -q "$bcpkix_text" "$api_publisher_bundles_info" ; then
+    sever_restart_required=true
+    sed -i '/bcpkix-jdk15on/d' $api_publisher_bundles_info
+  fi
+  if grep -q "$bcprov_text" "$api_devportal_bundles_info" ; then
+    sever_restart_required=true
+    sed -i '/bcprov-jdk15on/d' $api_devportal_bundles_info
+  fi
+  if grep -q "$bcpkix_text" "$api_devportal_bundles_info" ; then
+    sever_restart_required=true
+    sed -i '/bcpkix-jdk15on/d' $api_devportal_bundles_info
+  fi
+  if grep -q "$bcprov_text" "$api_key_manager_bundles_info" ; then
+    sever_restart_required=true
+    sed -i '/bcprov-jdk15on/d' $api_key_manager_bundles_info
+  fi
+  if grep -q "$bcpkix_text" "$api_key_manager_bundles_info" ; then
+    sever_restart_required=true
+    sed -i '/bcpkix-jdk15on/d' $api_key_manager_bundles_info
+  fi
+  if grep -q "$bcprov_text" "$default_bundles_info" ; then
+    sever_restart_required=true
+    sed -i '/bcprov-jdk15on/d' $default_bundles_info
+  fi
+  if grep -q "$bcpkix_text" "$default_bundles_info" ; then
+    sever_restart_required=true
+    sed -i '/bcpkix-jdk15on/d' $default_bundles_info
+  fi
+  if grep -q "$bcprov_text" "$control_plane_bundles_info" ; then
+    sever_restart_required=true
+    sed -i '/bcprov-jdk15on/d' $control_plane_bundles_info
+  fi
+  if grep -q "$bcpkix_text" "$control_plane_bundles_info" ; then
+    sever_restart_required=true
+    sed -i '/bcpkix-jdk15on/d' $control_plane_bundles_info
+  fi
+  if grep -q "$bcprov_text" "$traffic_manager_bundles_info" ; then
+    sever_restart_required=true
+    sed -i '/bcprov-jdk15on/d' $traffic_manager_bundles_info
+  fi
+  if grep -q "$bcpkix_text" "$traffic_manager_bundles_info" ; then
+    sever_restart_required=true
+    sed -i '/bcpkix-jdk15on/d' $traffic_manager_bundles_info
+  fi
+  if grep -q "$bcprov_text" "$gateway_worker_bundles_info" ; then
+    sever_restart_required=true
+    sed -i '/bcprov-jdk15on/d' $gateway_worker_bundles_info
+  fi
+  if grep -q "$bcpkix_text" "$gateway_worker_bundles_info" ; then
+    sever_restart_required=true
+    sed -i '/bcpkix-jdk15on/d' $gateway_worker_bundles_info
+  fi
+
+	if [ -e $CARBON_HOME/repository/components/lib/bc-fips*.jar ]; then
+	    location=$(find "$CARBON_HOME/repository/components/lib/" -type f -name "bc-fips*.jar" | head -1)
+		if [ ! $location = "$CARBON_HOME/repository/components/lib/bc-fips-$BC_FIPS_VERSION.jar" ]; then
+		    sever_restart_required=true
+   	    	echo "There is an update for bc-fips. Therefore Remove existing bc-fips jar from lib folder."
+   		    rm rm $CARBON_HOME/repository/components/lib/bc-fips*.jar 2> /dev/null
+		    echo "Successfully removed bc-fips_$BC_FIPS_VERSION.jar from component/lib."
+		    if [ -f $CARBON_HOME/repository/components/dropins/bc_fips*.jar ]; then
+   	            	sever_restart_required=true
+   		        echo "Remove existing bc-fips jar from dropins folder."
+   		        rm rm $CARBON_HOME/repository/components/dropins/bc_fips*.jar 2> /dev/null
+   		        echo "Successfully removed bc-fips_$BC_FIPS_VERSION.jar from component/dropins."
+   	        fi
+		fi
+	fi
+
+	if [ ! -e $CARBON_HOME/repository/components/lib/bc-fips*.jar ]; then
+		sever_restart_required=true
+		if [ -z "$arg1" ] && [ -z "$arg2" ]; then
+		    echo "both empty"
+		    echo "Downloading required bc-fips jar : bc-fips-$BC_FIPS_VERSION"
+		    curl https://repo1.maven.org/maven2/org/bouncycastle/bc-fips/$BC_FIPS_VERSION/bc-fips-$BC_FIPS_VERSION.jar -o $CARBON_HOME/repository/components/lib/bc-fips-$BC_FIPS_VERSION.jar
+		    ACTUAL_CHECKSUM=$(sha1sum $CARBON_HOME/repository/components/lib/bc-fips*.jar | cut -d' ' -f1)
+	    	if [ "$EXPECTED_BC_FIPS_CHECKSUM" = "$ACTUAL_CHECKSUM" ]; then
+  		        echo "Checksum verified: The downloaded bc-fips-$BC_FIPS_VERSION.jar is valid."
+	    	else
+  		        echo "Checksum verification failed: The downloaded bc-fips-$BC_FIPS_VERSION.jar may be corrupted."
+	   	    fi
+	   	elif [ ! -z "$arg1" ] && [ -z "$arg2" ]; then
+	        echo "2 empty"
+	    	if [ ! -e $arg1/bcpkix-fips-$BCPKIX_FIPS_VERSION.jar ]; then
+	    	    echo "Can not be found required bc-fips-$BC_FIPS_VERSION.jar in given file path : $arg1."
+	    	else
+			    cp "$arg1/bc-fips-$BC_FIPS_VERSION.jar" "$CARBON_HOME/repository/components/lib"
+			    if [ $? -eq 0 ]; then
+  				    echo "bc-fips JAR files copied successfully."
+			    else
+  				    echo "Error copying bc-fips JAR file."
+			    fi
+			fi
+		else
+		    echo "1 empty"
+		    echo "Downloading required bc-fips jar : bc-fips-$BC_FIPS_VERSION"
+		    curl $arg2/org/bouncycastle/bc-fips/$BC_FIPS_VERSION/bc-fips-$BC_FIPS_VERSION.jar -o $CARBON_HOME/repository/components/lib/bc-fips-$BC_FIPS_VERSION.jar
+		    ACTUAL_CHECKSUM=$(sha1sum $CARBON_HOME/repository/components/lib/bc-fips*.jar | cut -d' ' -f1)
+	    	if [ "$EXPECTED_BC_FIPS_CHECKSUM" = "$ACTUAL_CHECKSUM" ]; then
+  		        echo "Checksum verified: The downloaded bc-fips-$BC_FIPS_VERSION.jar is valid."
+	    	else
+  		        echo "Checksum verification failed: The downloaded bc-fips-$BC_FIPS_VERSION.jar may be corrupted."
+	   	    fi
+	   	fi
+	fi
+
+	if [ -e $CARBON_HOME/repository/components/lib/bcpkix-fips*.jar ]; then
+	    location=$(find "$CARBON_HOME/repository/components/lib/" -type f -name "bcpkix-fips*.jar" | head -1)
+		if [ ! $location = "$CARBON_HOME/repository/components/lib/bcpkix-fips-$BCPKIX_FIPS_VERSION.jar" ]; then
+		    sever_restart_required=true
+   	    	echo "There is an update for bcpkix-fips. Therefore Remove existing bcpkix-fips jar from lib folder."
+   		    rm rm $CARBON_HOME/repository/components/lib/bcpkix-fips*.jar 2> /dev/null
+		    echo "Successfully removed bcpkix-fips_$BCPKIX_FIPS_VERSION.jar Removed from component/lib."
+		    if [ -f $CARBON_HOME/repository/components/dropins/bcpkix-fips*.jar ]; then
+   		        echo "Remove existing bcpkix-fips jar from dropins folder."
+   		        rm rm $CARBON_HOME/repository/components/dropins/bcpkix_fips*.jar 2> /dev/null
+   		        echo "Successfully removed bcpkix-fips_$BCPKIX_FIPS_VERSION.jar from component/dropins."
+   	        fi
+		fi
+	fi
+
+	if [ ! -e $CARBON_HOME/repository/components/lib/bcpkix-fips*.jar ]; then
+	    sever_restart_required=true
+	    if [ -z "$arg1" ] && [ -z "$arg2" ]; then
+		    echo "Downloading required bcpkix-fips jar : bcpkix-fips-$BCPKIX_FIPS_VERSION"
+		    curl https://repo1.maven.org/maven2/org/bouncycastle/bcpkix-fips/$BCPKIX_FIPS_VERSION/bcpkix-fips-$BCPKIX_FIPS_VERSION.jar -o $CARBON_HOME/repository/components/lib/bcpkix-fips-$BCPKIX_FIPS_VERSION.jar
+		    ACTUAL_CHECKSUM=$(sha1sum $CARBON_HOME/repository/components/lib/bcpkix-fips*.jar | cut -d' ' -f1)
+	   	    if [ "$EXPECTED_BCPKIX_FIPS_CHECKSUM" = "$ACTUAL_CHECKSUM" ]; then
+  			    echo "Checksum verified: The downloaded bcpkix-fips-$BCPKIX_FIPS_VERSION.jar is valid."
+	    	else
+  			    echo "Checksum verification failed: The downloaded bcpkix-fips-$BCPKIX_FIPS_VERSION.jar may be corrupted."
+	    	fi
+	    elif [ ! -z "$arg1" ] && [ -z "$arg2" ]; then
+	   	    echo "2 empty"
+	   	    if [ ! -e $arg1/bcpkix-fips-$BCPKIX_FIPS_VERSION.jar ]; then
+	   	    	echo "Can not be found required bcpkix-fips-$BCPKIX_FIPS_VERSION.jar in given file path : $arg1."
+	   	    else
+			    cp "$arg1/bcpkix-fips-$BCPKIX_FIPS_VERSION.jar" "$CARBON_HOME/repository/components/lib"
+			    if [ $? -eq 0 ]; then
+  				    echo "bcpkix-fips JAR files copied successfully."
+			    else
+  				    echo "Error copying bcpkix-fips JAR file."
+			    fi
+		    fi
+		else
+			echo "1 empty"
+			echo "Downloading required bcpkix-fips jar : bcpkix-fips-$BCPKIX_FIPS_VERSION"
+		    curl $arg2/org/bouncycastle/bcpkix-fips/$BCPKIX_FIPS_VERSION/bcpkix-fips-$BCPKIX_FIPS_VERSION.jar -o $CARBON_HOME/repository/components/lib/bcpkix-fips-$BCPKIX_FIPS_VERSION.jar
+			ACTUAL_CHECKSUM=$(sha1sucam $CARBON_HOME/repository/components/lib/bc-fips*.jar | cut -d' ' -f1)
+	    	if [ "$EXPECTED_BC_FIPS_CHECKSUM" = "$ACTUAL_CHECKSUM" ]; then
+  		    	echo "Checksum verified: The downloaded bc-fips-$BC_FIPS_VERSION.jar is valid."
+	    	else
+  		    	echo "Checksum verification failed: The downloaded bc-fips-$BC_FIPS_VERSION.jar may be corrupted."
+	   		fi
+	   	fi
+	fi
+fi
+
+if [ "$sever_restart_required" = true ] ; then
+    echo "Please restart the server."
+fi


### PR DESCRIPTION
This PR adds the scripts (fips.sh and fips.bat) to enable and disable FIPS compliance.

Related issue: https://github.com/wso2/api-manager/issues/1616