### PR TITLE
Update resource files to test base64Binary data type

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/soap/phoneverify.wsdl
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/soap/phoneverify.wsdl
@@ -7,6 +7,7 @@
                     <s:sequence>
                         <s:element minOccurs="0" maxOccurs="1" name="PhoneNumber" type="s:string" />
                         <s:element minOccurs="0" maxOccurs="1" name="LicenseKey" type="s:string" />
+                        <s:element minOccurs="0" maxOccurs="1" name="PhoneData" type="s:base64Binary" />
                     </s:sequence>
                 </s:complexType>
             </s:element>

--- a/pom.xml
+++ b/pom.xml
@@ -1275,7 +1275,7 @@
         <carbon.apimgt.ui.version>9.0.432</carbon.apimgt.ui.version>
 
         <!-- APIM Component Version -->
-        <carbon.apimgt.version>9.28.141</carbon.apimgt.version>
+        <carbon.apimgt.version>9.28.146</carbon.apimgt.version>
 
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 


### PR DESCRIPTION
Update test resources on wso2/api-manager#1840
Update carbon.apimgt released version with https://github.com/wso2/carbon-apimgt/pull/12021