### PR TITLE
Add velocity xml changes to support lambda content encoding

### DIFF
--- a/modules/distribution/resources/api_templates/velocity_template.xml
+++ b/modules/distribution/resources/api_templates/velocity_template.xml
@@ -283,7 +283,9 @@ $in_sequences.get("$resource.getUriTemplate()").get($uri)
                     #if( $resourceTimeout != '' )
     <property name="resourceTimeout" value="$resourceTimeout"/>
                     #end
+                    #if( $isContentEncodingEnabled != '' )
     <property name="isContentEncodingEnabled" value="$isContentEncodingEnabled"/>
+                    #end
 </class>
 <loopback />
                 ## AWS Lambda: end

--- a/modules/distribution/resources/api_templates/velocity_template.xml
+++ b/modules/distribution/resources/api_templates/velocity_template.xml
@@ -253,6 +253,7 @@ $in_sequences.get("$resource.getUriTemplate()").get($uri)
                     #set( $roleRegion = $!{endpoint_config.get("amznRoleRegion")} )
                     #set( $resourceName = $!{resource.getAmznResourceName()} )
                     #set( $resourceTimeout = $!{resource.getAmznResourceTimeout()} )
+                    #set( $isContentEncodingEnabled = $!{resource.isAmznResourceContentEncoded()} )
 <class name="org.wso2.carbon.apimgt.gateway.mediators.AWSLambdaMediator">
                     #if( $accessKey != '' )
     <property name="accessKey" value="$accessKey"/>
@@ -282,6 +283,7 @@ $in_sequences.get("$resource.getUriTemplate()").get($uri)
                     #if( $resourceTimeout != '' )
     <property name="resourceTimeout" value="$resourceTimeout"/>
                     #end
+    <property name="isContentEncodingEnabled" value="$isContentEncodingEnabled"/>
 </class>
 <loopback />
                 ## AWS Lambda: end


### PR DESCRIPTION
- Adds `velocity_template.xml` changes to pass `isContentEncodingEnabled ` to `AWSLambdaMediator`

Related carbon-apimgt PR : https://github.com/wso2/carbon-apimgt/pull/12031
Related git issue : https://github.com/wso2/api-manager/issues/1878