### PR TITLE
Change JMS event publisher data type to JSON

### DIFF
--- a/modules/distribution/product/src/main/resources/conf/templates/repository/deployment/server/eventpublishers/jmsEventPublisher2.xml.j2
+++ b/modules/distribution/product/src/main/resources/conf/templates/repository/deployment/server/eventpublishers/jmsEventPublisher2.xml.j2
@@ -7,7 +7,7 @@
 
   trace="disable" xmlns="http://wso2.org/carbon/eventpublisher">
   <from streamName="org.wso2.throttle.globalThrottle.stream" version="1.0.0"/>
-  <mapping customMapping="disable" type="map"/>
+  <mapping customMapping="disable" type="json"/>
   <to eventAdapterType="jms">
     <property name="java.naming.factory.initial">org.wso2.andes.jndi.PropertiesFileInitialContextFactory</property>
     <property name="java.naming.provider.url">repository/conf/jndi2.properties</property>

--- a/modules/distribution/product/src/main/resources/conf/templates/repository/deployment/server/eventpublishers/jmsEventPublisher_1.10.0_2.xml.j2
+++ b/modules/distribution/product/src/main/resources/conf/templates/repository/deployment/server/eventpublishers/jmsEventPublisher_1.10.0_2.xml.j2
@@ -6,7 +6,7 @@
 {% endif %}
   trace="disable" xmlns="http://wso2.org/carbon/eventpublisher">
   <from streamName="org.wso2.throttle.globalThrottle.stream" version="1.1.0"/>
-  <mapping customMapping="disable" type="map"/>
+  <mapping customMapping="disable" type="json"/>
   <to eventAdapterType="jms">
     <property name="java.naming.factory.initial">org.wso2.andes.jndi.PropertiesFileInitialContextFactory</property>
     <property name="java.naming.provider.url">repository/conf/jndi2.properties</property>


### PR DESCRIPTION
This PR adds the change to the JMS event publisher data type from Map to JSON.

Fixes https://github.com/wso2/api-manager/issues/1884