### PR TITLE
Upgrade Azure AD KeyManager connector to version 1.0.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1466,7 +1466,7 @@
         <wsdl4j.version>1.6.3.wso2v3</wsdl4j.version>
         <wso2is.km.version>1.6.8</wso2is.km.version>
         <okta.keymanager.feature.version>3.2.0</okta.keymanager.feature.version>
-        <azure.keymanager.feature.version>1.0.1</azure.keymanager.feature.version>
+        <azure.keymanager.feature.version>1.0.5</azure.keymanager.feature.version>
         <keycloak.keymanager.feature.version>2.1.0</keycloak.keymanager.feature.version>
         <auth0.keymanager.feature.version>1.0.4</auth0.keymanager.feature.version>
         <pingfederate.keymanager.feature.version>1.0.6</pingfederate.keymanager.feature.version>


### PR DESCRIPTION
This PR upgrades the Azure AD KeyManager connector to version 1.0.5.

Fixes https://github.com/wso2/api-manager/issues/1900