### PR TITLE
Enable tokenRevocationJMSPublisher2 for event hub's event duplicate URL

### DIFF
--- a/modules/distribution/product/src/main/resources/conf/templates/repository/deployment/server/eventpublishers/tokenRevokeEventJMSPublisher_2.xml.j2
+++ b/modules/distribution/product/src/main/resources/conf/templates/repository/deployment/server/eventpublishers/tokenRevokeEventJMSPublisher_2.xml.j2
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-{% if apim.throttling.event_duplicate_url is defined %}
+{% if apim.event_hub.event_duplicate_url is defined || apim.throttling.event_duplicate_url is defined %}
         <eventPublisher name="tokenRevocationJMSPublisher2" statistics="disable"
 {% else %}
         <eventPublisher name="tokenRevocationJMSPublisher2" statistics="disable" processing="disable"


### PR DESCRIPTION
## Purpose
In the existing implementation, `tokenRevocationJMSPublisher2` event publisher is getting enabled only when the throttling event duplicate URL is defined. But this needs to be enabled once the event hub's event duplicate URL is defined as well.

This PR enables `tokenRevocationJMSPublisher2` event publisher when the event hub's event duplicate URL is defined.

Related to https://github.com/wso2/api-manager/issues/1935