### PR TITLE
Add integrations tests to check malformed API contexts

### DIFF
--- a/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/impl/RestAPIPublisherImpl.java
+++ b/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/impl/RestAPIPublisherImpl.java
@@ -275,7 +275,6 @@ public class RestAPIPublisherImpl {
             return response;
         }
         return null;
-
     }
 
     /**
@@ -1262,7 +1261,6 @@ public class RestAPIPublisherImpl {
         }
         return response;
     }
-
 
     public WSDLValidationResponseDTO validateWsdlDefinition(String url, File wsdlDefinition) throws ApiException {
         ApiResponse<WSDLValidationResponseDTO> response = validationApi

--- a/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/utils/base/APIMIntegrationConstants.java
+++ b/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/utils/base/APIMIntegrationConstants.java
@@ -42,6 +42,15 @@ public class APIMIntegrationConstants {
     public static final String API_RESPONSE_ELEMENT_NAME_APIS = "apis";
     public static final String API_RESPONSE_ELEMENT_NAME_ID = "id";
 
+    public static final String API_NAME = "name";
+    public static final String API_CONTEXT = "context";
+    public static final String API_VERSION = "version";
+    public static final String ENDPOINT_TYPE = "endpoint_type";
+    public static final String SANDBOX_ENDPOINTS = "sandbox_endpoints";
+    public static final String PRODUCTION_ENDPOINTS = "production_endpoints";
+    public static final String ENDPOINT_CONFIG = "endpointConfig";
+    public static final String POLICIES = "policies";
+    public static final String OPERATIONS = "operations";
     public static final String API_CONTEXT_MALFORMED_ERROR = "The API context is malformed";
     public static final String API_PRODUCT_CONTEXT_MALFORMED_ERROR = "The API Product context is malformed";
 

--- a/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/utils/base/APIMIntegrationConstants.java
+++ b/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/utils/base/APIMIntegrationConstants.java
@@ -42,6 +42,9 @@ public class APIMIntegrationConstants {
     public static final String API_RESPONSE_ELEMENT_NAME_APIS = "apis";
     public static final String API_RESPONSE_ELEMENT_NAME_ID = "id";
 
+    public static final String API_CONTEXT_MALFORMED_ERROR = "The API context is malformed";
+    public static final String API_PRODUCT_CONTEXT_MALFORMED_ERROR = "The API Product context is malformed";
+
     public static final String OAUTH_DEFAULT_APPLICATION_NAME = "DefaultApplication";
 
     public static final String IS_API_EXISTS = "\"isApiExists\":true";

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/apiproduct/APIProductCreationTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/apiproduct/APIProductCreationTestCase.java
@@ -57,6 +57,7 @@ import org.wso2.carbon.automation.test.utils.common.TestConfigurationProvider;
 import org.wso2.carbon.automation.test.utils.http.client.HttpResponse;
 import org.wso2.carbon.integration.common.admin.client.UserManagementClient;
 
+import javax.ws.rs.core.Response;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
@@ -89,6 +90,8 @@ public class APIProductCreationTestCase extends APIManagerLifecycleBaseTest {
     private ApiProductTestHelper apiProductTestHelper;
     private String apiProductId2;
     private String resourcePath;
+    private String apiID1;
+    private String apiID2;
 
     @Factory(dataProvider = "userModeDataProvider")
     public APIProductCreationTestCase(TestUserMode userMode) {
@@ -297,6 +300,37 @@ public class APIProductCreationTestCase extends APIManagerLifecycleBaseTest {
         boolean isDefaultVersion = Boolean.TRUE.equals(newApiProductDTO.isIsDefaultVersion());
         Assert.assertEquals(isDefaultVersion, true, "Copied API Product is not the default version");
     }
+
+    @Test(groups = {"wso2.am"}, description = "Test creation of API Product with malformed context")
+    public void testCreateApiProductWithMalformedContext() throws Exception {
+        // Pre-Conditions : Create APIs
+        List<APIDTO> apisToBeUsed = new ArrayList<>();
+        APIDTO apiOne = apiTestHelper.createApiOne(getBackendEndServiceEndPointHttp("wildcard/resources"));
+        APIDTO apiTwo = apiTestHelper.createApiTwo(getBackendEndServiceEndPointHttp("wildcard/resources"));
+        apisToBeUsed.add(apiOne);
+        apisToBeUsed.add(apiTwo);
+        apiID1 = apiOne.getId();
+        apiID2 = apiTwo.getId();
+
+        // Step 1 : Create APIProduct
+        final String provider = user.getUserName();
+        final String name = UUID.randomUUID().toString();
+        final String context = "/" + UUID.randomUUID().toString() + "{version}" ;
+        final String version = "1.0.0";
+
+        List<String> policies = Arrays.asList(TIER_UNLIMITED, TIER_GOLD);
+
+        try{
+            apiProductTestHelper.createAPIProductInPublisher(provider, name, context, version,
+                    apisToBeUsed, policies);
+        } catch (ApiException e) {
+            Assert.assertEquals(e.getCode(), Response.Status.BAD_REQUEST.getStatusCode());
+            Assert.assertTrue(e.getResponseBody().contains(
+                    APIMIntegrationConstants.API_PRODUCT_CONTEXT_MALFORMED_ERROR));
+
+        }
+    }
+
 
     @Test(groups = {"wso2.am"}, description = "Test creation and invocation of API Product which depends " +
             "on a visibility restricted API")
@@ -780,6 +814,9 @@ public class APIProductCreationTestCase extends APIManagerLifecycleBaseTest {
 
     @AfterClass(alwaysRun = true)
     public void cleanUpArtifacts() throws Exception {
+
+        restAPIPublisher.deleteAPI(apiID1);
+        restAPIPublisher.deleteAPI(apiID2);
 
         super.cleanUp();
         userManagementClient.deleteUser(RESTRICTED_SUBSCRIBER);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/apiproduct/APIProductCreationTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/apiproduct/APIProductCreationTestCase.java
@@ -327,10 +327,8 @@ public class APIProductCreationTestCase extends APIManagerLifecycleBaseTest {
             Assert.assertEquals(e.getCode(), Response.Status.BAD_REQUEST.getStatusCode());
             Assert.assertTrue(e.getResponseBody().contains(
                     APIMIntegrationConstants.API_PRODUCT_CONTEXT_MALFORMED_ERROR));
-
         }
     }
-
 
     @Test(groups = {"wso2.am"}, description = "Test creation and invocation of API Product which depends " +
             "on a visibility restricted API")
@@ -817,7 +815,6 @@ public class APIProductCreationTestCase extends APIManagerLifecycleBaseTest {
 
         restAPIPublisher.deleteAPI(apiID1);
         restAPIPublisher.deleteAPI(apiID2);
-
         super.cleanUp();
         userManagementClient.deleteUser(RESTRICTED_SUBSCRIBER);
         userManagementClient.deleteUser(STANDARD_SUBSCRIBER);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/graphql/GraphqlTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/graphql/GraphqlTestCase.java
@@ -225,7 +225,6 @@ public class GraphqlTestCase extends APIMIntegrationBaseTest {
         response = restAPIPublisher.importGraphqlSchemaDefinitionWithInvalidContext(file, additionalPropertiesObj.toString());
         Assert.assertNotNull(response, "Response cannot be null");
         Assert.assertEquals(response.getResponseCode(), 400, "Response Code miss matched when creating the API");
-
     }
 
     @Test(groups = {"wso2.am"}, description = "test retrieve schemaDefinition at publisher")

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/graphql/GraphqlTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/graphql/GraphqlTestCase.java
@@ -204,22 +204,22 @@ public class GraphqlTestCase extends APIMIntegrationBaseTest {
         HttpResponse response = null;
 
         ArrayList<String> policies = new ArrayList<String>();
-        policies.add("Unlimited");
+        policies.add(APIMIntegrationConstants.API_TIER.UNLIMITED);
 
         JSONObject additionalPropertiesObj = new JSONObject();
-        additionalPropertiesObj.put("name", "GraphQLAPIWithInvalidContext");
-        additionalPropertiesObj.put("context", "invalidContext{version}");
-        additionalPropertiesObj.put("version", API_VERSION_1_0_0);
+        additionalPropertiesObj.put(APIMIntegrationConstants.API_NAME, "GraphQLAPIWithInvalidContext");
+        additionalPropertiesObj.put(APIMIntegrationConstants.API_CONTEXT, "invalidContext{version}");
+        additionalPropertiesObj.put(APIMIntegrationConstants.API_VERSION, API_VERSION_1_0_0);
 
         JSONObject url = new JSONObject();
         url.put("url", END_POINT_URL);
         JSONObject endpointConfig = new JSONObject();
-        endpointConfig.put("endpoint_type", "http");
-        endpointConfig.put("sandbox_endpoints", url);
-        endpointConfig.put("production_endpoints", url);
-        additionalPropertiesObj.put("endpointConfig", endpointConfig);
-        additionalPropertiesObj.put("policies", policies);
-        additionalPropertiesObj.put("operations", operations);
+        endpointConfig.put(APIMIntegrationConstants.ENDPOINT_TYPE, "http");
+        endpointConfig.put(APIMIntegrationConstants.SANDBOX_ENDPOINTS, url);
+        endpointConfig.put(APIMIntegrationConstants.PRODUCTION_ENDPOINTS, url);
+        additionalPropertiesObj.put(APIMIntegrationConstants.ENDPOINT_CONFIG, endpointConfig);
+        additionalPropertiesObj.put(APIMIntegrationConstants.POLICIES, policies);
+        additionalPropertiesObj.put(APIMIntegrationConstants.OPERATIONS, operations);
 
         // create Graphql API
         response = restAPIPublisher.importGraphqlSchemaDefinitionWithInvalidContext(file, additionalPropertiesObj.toString());

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/WSDLImportTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/WSDLImportTestCase.java
@@ -289,7 +289,6 @@ public class WSDLImportTestCase extends APIManagerLifecycleBaseTest {
         } catch (ApiException e) {
             Assert.assertEquals(e.getCode(), Response.Status.BAD_REQUEST.getStatusCode());
             Assert.assertTrue(e.getResponseBody().contains(APIMIntegrationConstants.API_CONTEXT_MALFORMED_ERROR));
-
         }
     }
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/publisher/APIM18CreateAnAPIThroughThePublisherRestAPITestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/publisher/APIM18CreateAnAPIThroughThePublisherRestAPITestCase.java
@@ -149,6 +149,31 @@ public class APIM18CreateAnAPIThroughThePublisherRestAPITestCase extends APIMInt
         assertTrue(response.getData().contains("lastUpdatedTimestamp"), "Last Updated Timestamp is not available");
     }
 
+    @Test(groups = {
+            "wso2.am" }, description = "Create an API Through the Publisher Rest API with malformed context")
+    public void testCreateAnAPIWithMalformedContextThroughThePublisherRest()
+            throws Exception {
+
+        // Now APIs with malformed context should not be allowed to create
+        String apiContextTest = "apim18PublisherTestAPIMalformed`";
+        String apiDescription = "This is Test API Created by API Manager Integration Test";
+        String apiTag = "tag18-4, tag18-5, tag18-6";
+        String apiName = "APIM18PublisherTestMalformed";
+
+        APIRequest apiCreationRequestBean;
+        apiCreationRequestBean = new APIRequest(apiName, apiContextTest, new URL(apiProductionEndPointUrl));
+
+        apiCreationRequestBean.setVersion(apiVersion);
+        apiCreationRequestBean.setDescription(apiDescription);
+        apiCreationRequestBean.setTags(apiTag);
+        apiCreationRequestBean.setTier("Gold");
+
+        HttpResponse response = restAPIPublisher.addAPIWithMalformedContext(apiCreationRequestBean);
+        Assert.assertNotNull(response, "Response cannot be null");
+        Assert.assertEquals(response.getResponseCode(), 400, "Response Code miss matched when creating the API");
+
+    }
+
     @Test(groups = {"wso2.am"}, description = "Remove an API Through the Publisher Rest API",
             dependsOnMethods = "testCreateAnAPIThroughThePublisherRest")
     public void testRemoveAnAPIThroughThePublisherRest() throws Exception {

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/publisher/APIM18CreateAnAPIThroughThePublisherRestAPITestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/publisher/APIM18CreateAnAPIThroughThePublisherRestAPITestCase.java
@@ -166,11 +166,11 @@ public class APIM18CreateAnAPIThroughThePublisherRestAPITestCase extends APIMInt
         apiCreationRequestBean.setVersion(apiVersion);
         apiCreationRequestBean.setDescription(apiDescription);
         apiCreationRequestBean.setTags(apiTag);
-        apiCreationRequestBean.setTier("Gold");
+        apiCreationRequestBean.setTier(APIMIntegrationConstants.API_TIER.GOLD);
 
         HttpResponse response = restAPIPublisher.addAPIWithMalformedContext(apiCreationRequestBean);
         Assert.assertNotNull(response, "Response cannot be null");
-        Assert.assertEquals(response.getResponseCode(), 400, "Response Code miss matched when creating the API");
+        Assert.assertEquals(response.getResponseCode(), Response.Status.BAD_REQUEST.getStatusCode(), "Response Code miss matched when creating the API");
     }
 
     @Test(groups = {"wso2.am"}, description = "Remove an API Through the Publisher Rest API",

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/publisher/APIM18CreateAnAPIThroughThePublisherRestAPITestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/publisher/APIM18CreateAnAPIThroughThePublisherRestAPITestCase.java
@@ -171,7 +171,6 @@ public class APIM18CreateAnAPIThroughThePublisherRestAPITestCase extends APIMInt
         HttpResponse response = restAPIPublisher.addAPIWithMalformedContext(apiCreationRequestBean);
         Assert.assertNotNull(response, "Response cannot be null");
         Assert.assertEquals(response.getResponseCode(), 400, "Response Code miss matched when creating the API");
-
     }
 
     @Test(groups = {"wso2.am"}, description = "Remove an API Through the Publisher Rest API",

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/websocket/WebSocketAPITestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/websocket/WebSocketAPITestCase.java
@@ -72,6 +72,7 @@ import org.wso2.carbon.automation.test.utils.http.client.HttpResponse;
 import org.wso2.carbon.integration.common.utils.mgt.ServerConfigurationManager;
 import org.wso2.carbon.utils.xml.StringUtils;
 
+import javax.ws.rs.core.Response;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -487,7 +488,7 @@ public class WebSocketAPITestCase extends APIMIntegrationBaseTest {
         apiRequest.setApiTier(APIMIntegrationConstants.API_TIER.UNLIMITED);
 
         HttpResponse response = restAPIPublisher.addAPIWithMalformedContext(apiRequest);
-        Assert.assertEquals(response.getResponseCode(), 400, "Response Code miss matched when creating the API");
+        Assert.assertEquals(response.getResponseCode(), Response.Status.BAD_REQUEST.getStatusCode(), "Response Code miss matched when creating the API");
     }
 
     /**

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/websocket/WebSocketAPITestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/websocket/WebSocketAPITestCase.java
@@ -488,8 +488,6 @@ public class WebSocketAPITestCase extends APIMIntegrationBaseTest {
 
         HttpResponse response = restAPIPublisher.addAPIWithMalformedContext(apiRequest);
         Assert.assertEquals(response.getResponseCode(), 400, "Response Code miss matched when creating the API");
-
-
     }
 
     /**

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/websocket/WebSocketAPITestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/websocket/WebSocketAPITestCase.java
@@ -101,6 +101,7 @@ public class WebSocketAPITestCase extends APIMIntegrationBaseTest {
         QUERY
     }
     private final String apiName = "WebSocketAPI";
+    private final String apiNameWithMalformedContext = "WebSocketAPIWithMalformedContext";
     private final String applicationName = "WebSocketApplication";
     private final String applicationJWTName = "WebSocketJWTTypeApplication";
     private final String testMessage = "Web Socket Test Message";
@@ -465,6 +466,30 @@ public class WebSocketAPITestCase extends APIMIntegrationBaseTest {
             }
             client.stop();
         }
+    }
+
+    @Test(description = "Create WebSocket API with malformed context",
+            dependsOnMethods = "testWebSocketAPIRemoveEndpoint")
+    public void testCreateWebSocketAPIWithMalformedContext() throws Exception {
+
+        provider = user.getUserName();
+        String apiContext = "echo{version}";
+        String apiVersion = "1.0.0";
+
+        URI endpointUri = new URI("ws://" + webSocketServerHost + ":" + webSocketServerPort);
+
+        //Create the api creation request object
+        apiRequest = new APIRequest(apiNameWithMalformedContext, apiContext, endpointUri, endpointUri);
+        apiRequest.setVersion(apiVersion);
+        apiRequest.setTiersCollection(APIMIntegrationConstants.API_TIER.ASYNC_UNLIMITED);
+        apiRequest.setProvider(provider);
+        apiRequest.setType("WS");
+        apiRequest.setApiTier(APIMIntegrationConstants.API_TIER.UNLIMITED);
+
+        HttpResponse response = restAPIPublisher.addAPIWithMalformedContext(apiRequest);
+        Assert.assertEquals(response.getResponseCode(), 400, "Response Code miss matched when creating the API");
+
+
     }
 
     /**


### PR DESCRIPTION
This PR adds integration tests to cover the following scenarios.

- Create publisher rest API with malformed context.
- Create graphql API using schema with malformed context.
- Create API product with malformed context.
- Create websocket API with malformed context.
- WSDL import with malformed context.