### PR TITLE
Bump carbon.apimgt.version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1280,7 +1280,7 @@
         <carbon.apimgt.ui.version>9.0.453</carbon.apimgt.ui.version>
 
         <!-- APIM Component Version -->
-        <carbon.apimgt.version>9.28.155</carbon.apimgt.version>
+        <carbon.apimgt.version>9.28.160</carbon.apimgt.version>
 
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 


### PR DESCRIPTION
## Purpose

- Bump `carbon.apimgt.version` to reflect the fix added via https://github.com/wso2/carbon-apimgt/pull/12094
