### PR TITLE
Modify JWT test case to also validate the `kid` claim using JWKS endpoint 

### DIFF
--- a/modules/distribution/product/src/main/resources/conf/default.json
+++ b/modules/distribution/product/src/main/resources/conf/default.json
@@ -459,5 +459,5 @@
   "apim.analytics.properties.truststore_location": "${carbon.home}/repository/resources/security/$ref{truststore.file_name}",
   "apim.analytics.properties.truststore_password": "$ref{truststore.password}",
   "tenant_mgt.disable_email_domain_validation": true,
-  "apim.jwt.use_kid_property": false
+  "apim.jwt.use_kid_property": true
 }

--- a/modules/distribution/product/src/main/resources/conf/default.json
+++ b/modules/distribution/product/src/main/resources/conf/default.json
@@ -458,5 +458,6 @@
   "apim.analytics.properties.keystore_password": "$ref{keystore.primary.password}",
   "apim.analytics.properties.truststore_location": "${carbon.home}/repository/resources/security/$ref{truststore.file_name}",
   "apim.analytics.properties.truststore_password": "$ref{truststore.password}",
-  "tenant_mgt.disable_email_domain_validation": true
+  "tenant_mgt.disable_email_domain_validation": true,
+  "apim.jwt.use_kid_property": false
 }

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/jwt/BackendJWTUtil.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/jwt/BackendJWTUtil.java
@@ -55,7 +55,7 @@ public class BackendJWTUtil {
         JSONObject jsonHeaderObject = new JSONObject(decodedJWTHeaderString);
         Assert.assertEquals(jsonHeaderObject.getString("typ"), "JWT");
         Assert.assertEquals(jsonHeaderObject.getString("alg"), "RS256");
-        Assert.assertFalse(jsonHeaderObject.has("kid"));
+        Assert.assertTrue(jsonHeaderObject.has("kid"));
     }
 
     /**

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/jwt/BackendJWTUtil.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/jwt/BackendJWTUtil.java
@@ -49,13 +49,20 @@ public class BackendJWTUtil {
      * verify JWT Header
      *
      * @param decodedJWTHeaderString decoded JWT Header value
+     * @param jwksKidClaim           kid claim in JWKS endpoint
      * @throws JSONException if JSON payload is malformed
      */
-    public static void verifyJWTHeader(String decodedJWTHeaderString) throws JSONException {
+    public static void verifyJWTHeader(String decodedJWTHeaderString, String jwksKidClaim) throws JSONException {
         JSONObject jsonHeaderObject = new JSONObject(decodedJWTHeaderString);
         Assert.assertEquals(jsonHeaderObject.getString("typ"), "JWT");
         Assert.assertEquals(jsonHeaderObject.getString("alg"), "RS256");
+
+        // Verify kid claim: check if kid claim in JWT header match with that of JWKS endpoint
         Assert.assertTrue(jsonHeaderObject.has("kid"));
+        if (jwksKidClaim != null) {
+            Assert.assertEquals(jsonHeaderObject.getString("kid"), jwksKidClaim, "kid claim in JWT header " +
+                    "does not match with that of JWKS endpoint");
+        }
     }
 
     /**

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/jwt/JWTTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/jwt/JWTTestCase.java
@@ -28,6 +28,7 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.util.EntityUtils;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.testng.Assert;
@@ -76,6 +77,7 @@ import java.util.regex.PatternSyntaxException;
 
 import javax.ws.rs.core.Response;
 
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.AssertJUnit.assertTrue;
 
@@ -107,6 +109,7 @@ public class JWTTestCase extends APIManagerLifecycleBaseTest {
     URL tokenEndpointURL;
     private String tokenURL;
     private String identityLoginURL;
+    private String jwksKidClaim;
     private final String CALLBACK_URL = "https://localhost:9443/store/";
 
     @BeforeClass(alwaysRun = true)
@@ -191,6 +194,16 @@ public class JWTTestCase extends APIManagerLifecycleBaseTest {
                 APIMIntegrationConstants.IS_API_EXISTS);
         waitForAPIDeploymentSync(user.getUserName(), api2Request.getName(), api2Request.getVersion(),
                 APIMIntegrationConstants.IS_API_EXISTS);
+
+        // Invoke JWKS endpoint and retrieve kid claim to validate backend JWT
+        HttpClient httpclient = HttpClientBuilder.create().build();
+        HttpGet jwksGet = new HttpGet(getAPIInvocationURLHttp("jwks"));
+        HttpResponse jwksResponse = httpclient.execute(jwksGet);
+        assertEquals(jwksResponse.getStatusLine().getStatusCode(), HTTP_RESPONSE_CODE_OK,
+                "Invocation fails for JWKS GET request");
+        String jwksResponseString = EntityUtils.toString(jwksResponse.getEntity(), "UTF-8");
+        JSONObject jwksResponseObject = new JSONObject(jwksResponseString);
+        jwksKidClaim = jwksResponseObject.getJSONArray("keys").getJSONObject(0).getString("kid");
     }
 
     @Test(groups = {"wso2.am"}, description = "Backend JWT Token Generation for Oauth Based App")
@@ -225,7 +238,7 @@ public class JWTTestCase extends APIManagerLifecycleBaseTest {
             //Do the signature verification for super tenant as tenant key store not there accessible
             BackendJWTUtil.verifySignature(jwtheader);
             log.debug("Decoded JWT header String = " + decodedJWTHeaderString);
-            BackendJWTUtil.verifyJWTHeader(decodedJWTHeaderString);
+            BackendJWTUtil.verifyJWTHeader(decodedJWTHeaderString, jwksKidClaim);
             JSONObject jsonObject = new JSONObject(decodedJWTString);
             log.info("JWT Received ==" + jsonObject.toString());
             //Validate expiry time
@@ -273,7 +286,7 @@ public class JWTTestCase extends APIManagerLifecycleBaseTest {
             //Do the signature verification
             BackendJWTUtil.verifySignature(jwtheader);
             log.debug("Decoded JWT header String = " + decodedJWTHeaderString);
-            BackendJWTUtil.verifyJWTHeader(decodedJWTHeaderString);
+            BackendJWTUtil.verifyJWTHeader(decodedJWTHeaderString, jwksKidClaim);
             JSONObject jsonObject = new JSONObject(decodedJWTString);
 
             // check default claims
@@ -341,7 +354,7 @@ public class JWTTestCase extends APIManagerLifecycleBaseTest {
         //Do the signature verification
         BackendJWTUtil.verifySignature(jwtheader);
         log.debug("Decoded JWT header String = " + decodedJWTHeaderString);
-        BackendJWTUtil.verifyJWTHeader(decodedJWTHeaderString);
+        BackendJWTUtil.verifyJWTHeader(decodedJWTHeaderString, jwksKidClaim);
         JSONObject jsonObject = new JSONObject(decodedJWTString);
 
         // check default claims
@@ -386,7 +399,7 @@ public class JWTTestCase extends APIManagerLifecycleBaseTest {
         //Do the signature verification
         BackendJWTUtil.verifySignature(jwtheader);
         log.debug("Decoded JWT header String = " + decodedJWTHeaderString);
-        BackendJWTUtil.verifyJWTHeader(decodedJWTHeaderString);
+        BackendJWTUtil.verifyJWTHeader(decodedJWTHeaderString, jwksKidClaim);
         JSONObject jsonObject = new JSONObject(decodedJWTString);
 
         // check default claims
@@ -434,7 +447,7 @@ public class JWTTestCase extends APIManagerLifecycleBaseTest {
             //Do the signature verification
             BackendJWTUtil.verifySignature(jwtheader);
             log.debug("Decoded JWT header String = " + decodedJWTHeaderString);
-            BackendJWTUtil.verifyJWTHeader(decodedJWTHeaderString);
+            BackendJWTUtil.verifyJWTHeader(decodedJWTHeaderString, jwksKidClaim);
             JSONObject jsonObject = new JSONObject(decodedJWTString);
 
             // check default claims

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/jwt/urlsafe/URLSafeJWTTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/jwt/urlsafe/URLSafeJWTTestCase.java
@@ -156,7 +156,7 @@ public class URLSafeJWTTestCase extends APIManagerLifecycleBaseTest {
         JSONObject jsonHeaderObject = new JSONObject(decodedJWTHeaderString);
         Assert.assertEquals(jsonHeaderObject.getString("typ"), "JWT");
         Assert.assertEquals(jsonHeaderObject.getString("alg"), "RS256");
-        Assert.assertFalse(jsonHeaderObject.has("kid"));
+        Assert.assertTrue(jsonHeaderObject.has("kid"));
         JSONObject jsonObject = new JSONObject(decodedJWTString);
         log.info("JWT Received ==" + jsonObject.toString());
         // check default claims

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/jwt/urlsafe/URLSafeJWTTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/jwt/urlsafe/URLSafeJWTTestCase.java
@@ -212,7 +212,7 @@ public class URLSafeJWTTestCase extends APIManagerLifecycleBaseTest {
         JSONObject jsonHeaderObject = new JSONObject(decodedJWTHeaderString);
         Assert.assertEquals(jsonHeaderObject.getString("typ"), "JWT");
         Assert.assertEquals(jsonHeaderObject.getString("alg"), "RS256");
-        Assert.assertFalse(jsonHeaderObject.has("kid"));
+        Assert.assertTrue(jsonHeaderObject.has("kid"));
         JSONObject jsonObject = new JSONObject(decodedJWTString);
 
         // check default claims

--- a/pom.xml
+++ b/pom.xml
@@ -1277,10 +1277,10 @@
         <carbon.analytics.common.version>5.3.5</carbon.analytics.common.version>
 
         <!-- APIM Portals Component Version -->
-        <carbon.apimgt.ui.version>9.0.468</carbon.apimgt.ui.version>
+        <carbon.apimgt.ui.version>9.0.453</carbon.apimgt.ui.version>
 
         <!-- APIM Component Version -->
-        <carbon.apimgt.version>9.28.175</carbon.apimgt.version>
+        <carbon.apimgt.version>9.28.161</carbon.apimgt.version>
 
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1277,10 +1277,10 @@
         <carbon.analytics.common.version>5.3.5</carbon.analytics.common.version>
 
         <!-- APIM Portals Component Version -->
-        <carbon.apimgt.ui.version>9.0.453</carbon.apimgt.ui.version>
+        <carbon.apimgt.ui.version>9.0.468</carbon.apimgt.ui.version>
 
         <!-- APIM Component Version -->
-        <carbon.apimgt.version>9.28.161</carbon.apimgt.version>
+        <carbon.apimgt.version>9.28.175</carbon.apimgt.version>
 
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1280,7 +1280,7 @@
         <carbon.apimgt.ui.version>9.0.453</carbon.apimgt.ui.version>
 
         <!-- APIM Component Version -->
-        <carbon.apimgt.version>9.28.160</carbon.apimgt.version>
+        <carbon.apimgt.version>9.28.161</carbon.apimgt.version>
 
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 


### PR DESCRIPTION
### Purpose

Integration test PR to cover Gateway JWKS support feature added via [1]. The JWKS endpoint is invoked and the extracted kid claim is validated against the kid claim embedded within the backend JWT header.

1. https://github.com/wso2/api-manager/issues/1839