### PR TITLE
Fixed invalid error codes when sending request to a unavailable API endpoint with a binary file with .yaml extension

### DIFF
--- a/modules/distribution/product/src/main/conf/synapse-configs/default/sequences/main.xml
+++ b/modules/distribution/product/src/main/conf/synapse-configs/default/sequences/main.xml
@@ -26,6 +26,7 @@
             <property name="RESOURCE" expression="fn:concat('/', $axis2:REST_URL_POSTFIX)"/>
             <property name="HEALTH CHECK URL" expression="$axis2:TransportInURL"/>
         </log>
+        <property name="message.builder.invoked" value="true" scope="axis2" type="BOOLEAN"/>
         <property name="url_axis2" expression="$axis2:TransportInURL"/>
         <filter source="$axis2:TransportInURL" regex="/">
             <payloadFactory media-type="xml">


### PR DESCRIPTION
Fix https://github.com/wso2/api-manager/issues/2267