### PR TITLE
Add integration tests to save advance configs under x-wso2 production and sandbox endpoints.

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/oas/OASTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/oas/OASTestCase.java
@@ -19,6 +19,9 @@
 
 package org.wso2.am.integration.tests.oas;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.internal.LinkedTreeMap;
 import org.apache.commons.io.IOUtils;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.json.JSONObject;
@@ -135,7 +138,40 @@ public class OASTestCase extends APIMIntegrationBaseTest {
         }
     }
 
-    @Test(groups = { "wso2.am" }, description = "API definition import", dependsOnMethods = "testAPIDefinitionUpdate")
+    @Test(groups = { "wso2.am" }, description = "API definition update with advance configs",
+            dependsOnMethods = "testAPIDefinitionUpdate")
+    public void testAddAdvanceConfigsToAPIDefinition() throws Exception {
+        String apiDefinitionInPublisher = IOUtils.toString(
+                getClass().getClassLoader().getResourceAsStream(resourcePath + "oas_with_advance_configs.json"),
+                "UTF-8");
+        String addedAdvanceEndpointConfigsSandbox = "{\"circuitBreakers\":{\"maxRetries\":4.0,\"maxConnectionPools\"" +
+                ":2048.0,\"maxRequests\":100.0,\"maxPendingRequests\":25.0,\"maxConnections\":2048.0}}" ;
+        String addedAdvanceEndpointConfigsProduction = "{\"circuitBreakers\":{\"maxRetries\":3.0,\"maxConnectionPools" +
+                "\":1024.0,\"maxRequests\":75.0,\"maxPendingRequests\":35.0,\"maxConnections\":1024.0}}";
+        restAPIPublisher.updateSwagger(apiId, apiDefinitionInPublisher);
+
+        APIDTO apidto = restAPIPublisher.getAPIByID(apiId, user.getUserDomain());
+        Assert.assertNotNull(apidto);
+
+        LinkedTreeMap endpointConfiglinkedTreeMap = (LinkedTreeMap) apidto.getEndpointConfig();
+        Gson gson = new Gson();
+
+        JsonObject advanceConfigsObject = gson.toJsonTree(((LinkedTreeMap)endpointConfiglinkedTreeMap
+                .get("sandbox_endpoints")).get("advanceEndpointConfig")).getAsJsonObject();
+
+        //added advance configs should be there in the updated endpointConfigs string
+        Assert.assertEquals(advanceConfigsObject.toString(), addedAdvanceEndpointConfigsSandbox);
+
+        advanceConfigsObject = gson.toJsonTree(((LinkedTreeMap)endpointConfiglinkedTreeMap
+                .get("production_endpoints")).get("advanceEndpointConfig")).getAsJsonObject();
+
+        //added advance configs should be there in the updated endpointConfigs string
+        Assert.assertEquals(advanceConfigsObject.toString(), addedAdvanceEndpointConfigsProduction);
+
+    }
+
+    @Test(groups = { "wso2.am" }, description = "API definition import", dependsOnMethods =
+            "testAddAdvanceConfigsToAPIDefinition")
     public void testAPIDefinitionImport() throws Exception {
         String originalDefinition = IOUtils.toString(
                 getClass().getClassLoader().getResourceAsStream(resourcePath + "oas_import.json"),

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/oas/v2/oas_with_advance_configs.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/oas/v2/oas_with_advance_configs.json
@@ -1,0 +1,127 @@
+{
+  "swagger" : "2.0",
+  "info" : {
+    "version" : "1.0.0",
+    "title" : "SwaggerPetstore_v2"
+  },
+  "security" : [ {
+    "default" : [ ]
+  } ],
+  "paths" : {
+    "/pets" : {
+      "get" : {
+        "parameters" : [ ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        },
+        "security" : [ {
+          "default" : [ "SwaggerPetstore_v2" ]
+        } ],
+        "x-auth-type" : "Application & Application User",
+        "x-throttling-tier" : "Unlimited",
+        "x-wso2-application-security": {
+          "security-types": ["oauth2"],
+          "optional": false
+        }
+      }
+    },
+    "/pets/{petId}" : {
+      "get" : {
+        "parameters" : [ {
+          "name" : "petId",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        },
+        "security" : [ {
+          "default" : [ ]
+        } ],
+        "x-auth-type" : "Application & Application User",
+        "x-throttling-tier" : "Unlimited",
+        "x-wso2-application-security": {
+          "security-types": ["oauth2"],
+          "optional": false
+        }
+      }
+    },
+    "/oldpets" : {
+      "delete" : {
+        "parameters" : [ ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        },
+        "security" : [ {
+          "default" : [ "SwaggerPetstore_v2" ]
+        } ],
+        "x-auth-type" : "Application & Application User",
+        "x-throttling-tier" : "Unlimited",
+        "x-wso2-application-security": {
+          "security-types": ["oauth2"],
+          "optional": false
+        }
+      }
+    }
+  },
+  "x-wso2-api-key-header": "ApiKey",
+  "securityDefinitions" : {
+    "default" : {
+      "type" : "oauth2",
+      "authorizationUrl" : "https://test.com",
+      "flow" : "implicit",
+      "scopes" : {
+        "SwaggerPetstore_v2" : "SwaggerPetstore_v2"
+      },
+      "x-scopes-bindings" : {
+        "SwaggerPetstore_v2" : "admin"
+      }
+    }
+  },
+  "x-throttling-tier" : "Unlimited",
+  "x-wso2-cors" : {
+    "corsConfigurationEnabled" : true,
+    "accessControlAllowOrigins" : [ "*" ],
+    "accessControlAllowCredentials" : false,
+    "accessControlAllowHeaders" : [ "authorization", "Access-Control-Allow-Origin", "Content-Type", "SOAPAction" ],
+    "accessControlAllowMethods" : [ "GET", "PUT", "POST", "DELETE", "PATCH", "OPTIONS" ]
+  },
+  "x-wso2-production-endpoints": {
+    "urls": [
+      "https://localhost:9443/publisher-new/apis/create/openapi"
+    ],
+    "type": "http",
+    "advanceEndpointConfig": {
+      "circuitBreakers": {
+        "maxRetries": 3,
+        "maxConnectionPools": 1024,
+        "maxRequests": 75,
+        "maxPendingRequests": 35,
+        "maxConnections": 1024
+      }
+    }
+  },
+  "x-wso2-sandbox-endpoints" : {
+    "urls": [
+      "https://localhost:9443/publisher-new/apis/create/openapi"
+    ],
+    "type": "http",
+    "advanceEndpointConfig": {
+      "circuitBreakers": {
+        "maxRetries": 4,
+        "maxConnectionPools": 2048,
+        "maxRequests": 100,
+        "maxPendingRequests": 25,
+        "maxConnections": 2048
+      }
+    }
+  },
+  "x-wso2-basePath" : "/SwaggerPetstorev2/1.0.0"
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/oas/v3/oas_with_advance_configs.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/oas/v3/oas_with_advance_configs.json
@@ -1,0 +1,137 @@
+{
+  "openapi" : "3.0.1",
+  "info" : {
+    "title" : "SwaggerPetstore_v3",
+    "version" : "1.0.0"
+  },
+  "servers" : [ {
+    "url" : "/"
+  } ],
+  "security" : [ {
+    "default" : [ ]
+  } ],
+  "paths" : {
+    "/pets" : {
+      "get" : {
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        },
+        "security" : [ {
+          "default" : [ "SwaggerPetstore_v3" ]
+        } ],
+        "x-auth-type" : "Application & Application User",
+        "x-throttling-tier" : "Unlimited",
+        "x-wso2-application-security": {
+          "security-types": ["oauth2"],
+          "optional": false
+        }
+      }
+    },
+    "/pets/{petId}" : {
+      "get" : {
+        "parameters" : [ {
+          "name" : "petId",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        },
+        "security" : [ {
+          "default" : [ ]
+        } ],
+        "x-auth-type" : "Application & Application User",
+        "x-throttling-tier" : "Unlimited",
+        "x-wso2-application-security": {
+          "security-types": ["oauth2"],
+          "optional": false
+        }
+      }
+    },
+    "/oldpets" : {
+      "delete" : {
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        },
+        "security" : [ {
+          "default" : [ "SwaggerPetstore_v3" ]
+        } ],
+        "x-auth-type" : "Application & Application User",
+        "x-throttling-tier" : "Unlimited",
+        "x-wso2-application-security": {
+          "security-types": ["oauth2"],
+          "optional": false
+        }
+      }
+    }
+  },
+  "components" : {
+    "securitySchemes" : {
+      "default" : {
+        "type" : "oauth2",
+        "flows" : {
+          "implicit" : {
+            "authorizationUrl" : "https://test.com",
+            "scopes" : {
+              "SwaggerPetstore_v3" : "SwaggerPetstore_v3"
+            },
+            "x-scopes-bindings" : {
+              "SwaggerPetstore_v3" : "admin"
+            }
+          }
+        }
+      }
+    }
+  },
+  "x-wso2-api-key-header": "ApiKey",
+  "x-throttling-tier" : "Unlimited",
+  "x-wso2-cors" : {
+    "corsConfigurationEnabled" : true,
+    "accessControlAllowOrigins" : [ "*" ],
+    "accessControlAllowCredentials" : false,
+    "accessControlAllowHeaders" : [ "authorization", "Access-Control-Allow-Origin", "Content-Type", "SOAPAction" ],
+    "accessControlAllowMethods" : [ "GET", "PUT", "POST", "DELETE", "PATCH", "OPTIONS" ]
+  },
+  "x-wso2-production-endpoints": {
+    "urls": [
+      "https://localhost:9443/publisher-new/apis/create/openapi"
+    ],
+    "type": "http",
+    "advanceEndpointConfig": {
+      "circuitBreakers": {
+        "maxRetries": 3,
+        "maxConnectionPools": 1024,
+        "maxRequests": 75,
+        "maxPendingRequests": 35,
+        "maxConnections": 1024
+      }
+    }
+  },
+  "x-wso2-sandbox-endpoints" : {
+    "urls": [
+      "https://localhost:9443/publisher-new/apis/create/openapi"
+    ],
+    "type": "http",
+    "advanceEndpointConfig": {
+      "circuitBreakers": {
+        "maxRetries": 4,
+        "maxConnectionPools": 2048,
+        "maxRequests": 100,
+        "maxPendingRequests": 25,
+        "maxConnections": 2048
+      }
+    }
+  },
+  "x-wso2-basePath" : "/SwaggerPetstorev3/1.0.0"
+}


### PR DESCRIPTION
Public fix : https://github.com/wso2/carbon-apimgt/pull/12196