### PR TITLE
Add integration tests for ELK Analytics enabled with an operation policy

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/analytics/ELKAnalyticsWithRespondMediatorTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/analytics/ELKAnalyticsWithRespondMediatorTestCase.java
@@ -1,0 +1,174 @@
+package org.wso2.am.integration.tests.analytics;
+
+import com.google.gson.Gson;
+import org.json.JSONException;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.am.integration.clients.publisher.api.ApiException;
+import org.wso2.am.integration.clients.publisher.api.v1.dto.APIDTO;
+import org.wso2.am.integration.clients.publisher.api.v1.dto.APIOperationPoliciesDTO;
+import org.wso2.am.integration.clients.publisher.api.v1.dto.OperationPolicyDTO;
+import org.wso2.am.integration.clients.publisher.api.v1.dto.OperationPolicyDataDTO;
+import org.wso2.am.integration.clients.store.api.v1.dto.ApplicationDTO;
+import org.wso2.am.integration.clients.store.api.v1.dto.ApplicationKeyDTO;
+import org.wso2.am.integration.clients.store.api.v1.dto.ApplicationKeyGenerateRequestDTO;
+import org.wso2.am.integration.test.utils.APIManagerIntegrationTestException;
+import org.wso2.am.integration.test.utils.base.APIMIntegrationConstants;
+import org.wso2.am.integration.test.utils.bean.APIRequest;
+import org.wso2.am.integration.tests.api.lifecycle.APIManagerLifecycleBaseTest;
+import org.wso2.carbon.automation.test.utils.http.client.HttpRequestUtil;
+import org.wso2.carbon.automation.test.utils.http.client.HttpResponse;
+import org.wso2.carbon.integration.common.utils.FileManager;
+import org.wso2.carbon.integration.common.utils.exceptions.AutomationUtilException;
+import org.wso2.carbon.integration.common.utils.mgt.ServerConfigurationManager;
+import org.wso2.carbon.utils.ServerConstants;
+
+import javax.xml.xpath.XPathExpressionException;
+import java.io.*;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.testng.Assert.assertTrue;
+
+public class ELKAnalyticsWithRespondMediatorTestCase extends APIManagerLifecycleBaseTest {
+    private final String ELK_API_NAME = "ElkAnalyticsAPI";
+    private final String API_VERSION_1_0_0 = "1.0.0";
+    private final String INVOKABLE_API_CONTEXT = "elkapi";
+    private ServerConfigurationManager serverConfigurationManager;
+    private String applicationId;
+    private String apiId;
+    private String policyId;
+    private String accessToken;
+
+    @BeforeClass(alwaysRun = true)
+    public void initialize() throws JSONException, APIManagerIntegrationTestException, ApiException,
+            IOException, AutomationUtilException, XPathExpressionException,
+            org.wso2.am.integration.clients.store.api.ApiException {
+        super.init();
+
+        serverConfigurationManager = new ServerConfigurationManager(superTenantKeyManagerContext);
+
+        serverConfigurationManager.applyConfiguration(new File(getAMResourceLocation()
+                + File.separator + "configFiles" + File.separator + "ElkAnalytics" +
+                File.separator + "deployment.toml"));
+
+        String ELK_APPLICATION_NAME = "ElkAnalyticsApplication";
+        HttpResponse applicationResponse = restAPIStore.createApplication(ELK_APPLICATION_NAME,
+                "Test Application for ELK", APIMIntegrationConstants.APPLICATION_TIER.UNLIMITED,
+                ApplicationDTO.TokenTypeEnum.JWT);
+        applicationId = applicationResponse.getData();
+
+        String API_END_POINT_POSTFIX_URL = "jaxrs_basic/services/customers/customerservice/";
+        String apiEndPointUrl = backEndServerUrl.getWebAppURLHttp() + API_END_POINT_POSTFIX_URL;
+        APIRequest apiRequest = new APIRequest(ELK_API_NAME, INVOKABLE_API_CONTEXT, new URL(apiEndPointUrl));
+        apiRequest.setVersion(API_VERSION_1_0_0);
+        apiRequest.setTiersCollection(APIMIntegrationConstants.API_TIER.UNLIMITED);
+        apiRequest.setTier(APIMIntegrationConstants.API_TIER.UNLIMITED);
+        apiRequest.setTags(API_TAGS);
+        apiId = createPublishAndSubscribeToAPIUsingRest(apiRequest, restAPIPublisher, restAPIStore, applicationId,
+                APIMIntegrationConstants.API_TIER.UNLIMITED);
+
+        ArrayList<String> grantTypes = new ArrayList<>();
+        grantTypes.add("client_credentials");
+
+        ApplicationKeyDTO applicationKeyDTO = restAPIStore.generateKeys(applicationId, "3600", null,
+                ApplicationKeyGenerateRequestDTO.KeyTypeEnum.PRODUCTION, null, grantTypes);
+        accessToken = applicationKeyDTO.getToken().getAccessToken();
+    }
+
+    @Test(groups = {"wso2.am"}, description = "Test ELK Analytics with Respond Mediator")
+    public void testELKAnalyticsWithRespondMediator() throws Exception {
+        // Add metrics logger to log4j2.properties
+        String log4jPropertiesFile = getAMResourceLocation() + File.separator + "configFiles"
+                + File.separator + "ElkAnalytics" + File.separator + "log4j2.properties";
+        String log4jPropertiesTargetLocation = System.getProperty(ServerConstants.CARBON_HOME) + File.separator
+                + "repository" + File.separator + "conf" + File.separator + "log4j2.properties";
+        FileManager.copyFile(new File(log4jPropertiesFile), log4jPropertiesTargetLocation);
+
+        // Add common operation policy with respond mediator
+        addNewOperationPolicy();
+        Map<String, String> updatedCommonPolicyMap = restAPIPublisher.getAllCommonOperationPolicies();
+        Assert.assertNotNull(updatedCommonPolicyMap.get("respondMediatorPolicy"),
+                "Unable to find the newly added common policy");
+
+        // Add policy to API
+        HttpResponse getAPIResponse = restAPIPublisher.getAPI(apiId);
+        APIDTO apidto = new Gson().fromJson(getAPIResponse.getData(), APIDTO.class);
+        APIOperationPoliciesDTO apiOperationPoliciesDTO = new APIOperationPoliciesDTO();
+        List<OperationPolicyDTO> policyList = new ArrayList<>();
+        OperationPolicyDTO policyDTO = new OperationPolicyDTO();
+        String POLICY_NAME = "respondMediatorPolicy";
+        policyDTO.setPolicyName(POLICY_NAME);
+        policyDTO.setPolicyId(updatedCommonPolicyMap.get(POLICY_NAME));
+        policyList.add(policyDTO);
+        apiOperationPoliciesDTO.setRequest(policyList);
+
+        apidto.getOperations().get(0).setOperationPolicies(apiOperationPoliciesDTO);
+        restAPIPublisher.updateAPI(apidto);
+        // Create Revision and Deploy to Gateway
+        createAPIRevisionAndDeployUsingRest(apiId, restAPIPublisher);
+        waitForAPIDeployment();
+
+
+        Map<String, String> requestHeaders = new HashMap<String, String>();
+        requestHeaders.put("Authorization", "Bearer " + accessToken);
+
+        String API_GET_ENDPOINT_METHOD = "/customers/123";
+        HttpResponse response = HttpRequestUtil
+                .doGet(getAPIInvocationURLHttp(INVOKABLE_API_CONTEXT, API_VERSION_1_0_0) +
+                        API_GET_ENDPOINT_METHOD, requestHeaders);
+
+        String metricsFile = System.getProperty(ServerConstants.CARBON_HOME) + File.separator + "repository"
+                + File.separator + "logs" + File.separator + "apim_metrics.log";
+        File file = new File(metricsFile);
+        assertTrue(file.exists(), "Metrics file not found in " + metricsFile);
+        assertTrue(validateFileContent(metricsFile), "Metrics file does not contain the expected content");
+
+    }
+
+    public void addNewOperationPolicy() throws ApiException {
+        String policySpecPath = getAMResourceLocation() + File.separator + "configFiles"
+                + File.separator + "ElkAnalytics" + File.separator + "respondMediatorPolicy.json";
+
+        String synapsePolicyDefPath = getAMResourceLocation() + File.separator + "configFiles"
+                + File.separator + "ElkAnalytics" + File.separator + "respondMediatorPolicy.j2";
+
+        File specification = new File(policySpecPath);
+        File synapseDefinition = new File(synapsePolicyDefPath);
+
+        HttpResponse response = restAPIPublisher.addCommonOperationPolicy(specification, synapseDefinition,
+                null);
+        OperationPolicyDataDTO policyDTO =
+                new Gson().fromJson(response.getData(), OperationPolicyDataDTO.class);
+        policyId = policyDTO.getId();
+    }
+
+    public boolean validateFileContent(String path) {
+        try (BufferedReader br = new BufferedReader(new FileReader(path))) {
+            String line;
+            while ((line = br.readLine()) != null) {
+                if (line.contains(ELK_API_NAME) && line.contains("\"destination\":\"dummy_endpoint_address\"")) {
+                    return true;
+                }
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return false;
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void destroy() throws Exception {
+
+        restAPIStore.deleteApplication(applicationId);
+        undeployAndDeleteAPIRevisionsUsingRest(apiId, restAPIPublisher);
+        restAPIPublisher.deleteAPI(apiId);
+        restAPIPublisher.deleteCommonOperationPolicy(policyId);
+        serverConfigurationManager.restoreToLastConfiguration();
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/analytics/ELKAnalyticsWithRespondMediatorTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/analytics/ELKAnalyticsWithRespondMediatorTestCase.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.wso2.am.integration.tests.analytics;
 
 import com.google.gson.Gson;

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/analytics/ELKAnalyticsWithRespondMediatorTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/analytics/ELKAnalyticsWithRespondMediatorTestCase.java
@@ -36,6 +36,8 @@ import org.wso2.am.integration.test.utils.APIManagerIntegrationTestException;
 import org.wso2.am.integration.test.utils.base.APIMIntegrationConstants;
 import org.wso2.am.integration.test.utils.bean.APIRequest;
 import org.wso2.am.integration.tests.api.lifecycle.APIManagerLifecycleBaseTest;
+import org.wso2.carbon.automation.engine.context.AutomationContext;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
 import org.wso2.carbon.automation.test.utils.http.client.HttpRequestUtil;
 import org.wso2.carbon.automation.test.utils.http.client.HttpResponse;
 import org.wso2.carbon.integration.common.utils.FileManager;
@@ -68,7 +70,9 @@ public class ELKAnalyticsWithRespondMediatorTestCase extends APIManagerLifecycle
             IOException, AutomationUtilException, XPathExpressionException,
             org.wso2.am.integration.clients.store.api.ApiException {
         super.init();
-
+        superTenantKeyManagerContext = new AutomationContext(APIMIntegrationConstants.AM_PRODUCT_GROUP_NAME,
+                APIMIntegrationConstants.AM_KEY_MANAGER_INSTANCE,
+                TestUserMode.SUPER_TENANT_ADMIN);
         serverConfigurationManager = new ServerConfigurationManager(superTenantKeyManagerContext);
 
         serverConfigurationManager.applyConfiguration(new File(getAMResourceLocation()
@@ -107,6 +111,7 @@ public class ELKAnalyticsWithRespondMediatorTestCase extends APIManagerLifecycle
         String log4jPropertiesTargetLocation = System.getProperty(ServerConstants.CARBON_HOME) + File.separator
                 + "repository" + File.separator + "conf" + File.separator + "log4j2.properties";
         FileManager.copyFile(new File(log4jPropertiesFile), log4jPropertiesTargetLocation);
+
 
         // Add common operation policy with respond mediator
         addNewOperationPolicy();

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/ElkAnalytics/deployment.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/ElkAnalytics/deployment.toml
@@ -2,8 +2,9 @@
 hostname = "localhost"
 #offset=0
 base_path = "${carbon.protocol}://${carbon.host}:${carbon.management.port}"
-#discard_empty_caches = false
 server_role = "default"
+enable_shutdown_from_api = true
+enable_restart_from_api = true
 
 [super_admin]
 username = "admin"
@@ -14,16 +15,18 @@ create_admin_account = true
 type = "database_unique_id"
 
 [database.apim_db]
-type = "h2"
-url = "jdbc:h2:./repository/database/WSO2AM_DB;AUTO_SERVER=TRUE;DB_CLOSE_ON_EXIT=FALSE"
-username = "wso2carbon"
-password = "wso2carbon"
+driver = "$env{API_MANAGER_DATABASE_DRIVER}"
+url = "$env{API_MANAGER_DATABASE_URL}"
+username = "$env{API_MANAGER_DATABASE_USERNAME}"
+password = "$env{API_MANAGER_DATABASE_PASSWORD}"
+validationQuery = "$env{API_MANAGER_DATABASE_VALIDATION_QUERY}"
 
 [database.shared_db]
-type = "h2"
-url = "jdbc:h2:./repository/database/WSO2SHARED_DB;DB_CLOSE_ON_EXIT=FALSE"
-username = "wso2carbon"
-password = "wso2carbon"
+driver = "$env{SHARED_DATABASE_DRIVER}"
+url = "$env{SHARED_DATABASE_URL}"
+username = "$env{SHARED_DATABASE_USERNAME}"
+password = "$env{SHARED_DATABASE_PASSWORD}"
+validationQuery = "$env{SHARED_DATABASE_VALIDATION_QUERY}"
 
 [keystore.tls]
 file_name =  "wso2carbon.jks"
@@ -31,23 +34,6 @@ type =  "JKS"
 password =  "wso2carbon"
 alias =  "wso2carbon"
 key_password =  "wso2carbon"
-
-#[keystore.listener_profile]
-#bind_address = "0.0.0.0"
-
-#[keystore.primary]
-#file_name =  "wso2carbon.jks"
-#type =  "JKS"
-#password =  "wso2carbon"
-#alias =  "wso2carbon"
-#key_password =  "wso2carbon"
-
-#[keystore.internal]
-#file_name =  "wso2carbon.jks"
-#type =  "JKS"
-#password =  "wso2carbon"
-#alias =  "wso2carbon"
-#key_password =  "wso2carbon"
 
 [[apim.gateway.environment]]
 name = "Default"
@@ -57,25 +43,39 @@ display_in_api_console = true
 description = "This is a hybrid gateway that handles both production and sandbox token traffic."
 show_as_token_endpoint_url = true
 service_url = "https://localhost:${mgt.transport.https.port}/services/"
-username= "${admin.username}"
-password= "${admin.password}"
+username = "admin"
+password = "admin"
 ws_endpoint = "ws://localhost:9099"
-wss_endpoint = "wss://localhost:8099"
 http_endpoint = "http://localhost:${http.nio.port}"
 https_endpoint = "https://localhost:${https.nio.port}"
-websub_event_receiver_http_endpoint = "http://localhost:9021"
-websub_event_receiver_https_endpoint = "https://localhost:8021"
 
-[apim.sync_runtime_artifacts.gateway]
-gateway_labels =["Default"]
+[[apim.gateway.environment]]
+name = "devportalEnv"
+display_name = "Developer portal Test Environment"
+type = "hybrid"
+display_in_api_console = false
+description = "development api gateway broker"
+provider = "solace"
+service_url = "http://localhost:9960"
+username = "testUser"
+ws_endpoint = "ws://localhost:9960/"
+wss_endpoint = "wss://localhost:9960/"
+http_endpoint = "http://localhost:9960"
+https_endpoint = "https://localhost:9960/"
+password = "testPassword"
+show_as_token_endpoint_url = false
+
+[apim.gateway.environment.properties]
+Organization = "TestWSO2"
+DisplayName = "Developer portal Test Environment"
+DevAccountName = "devPortTestEnv"
 
 #[apim.cache.gateway_token]
 #enable = true
-#expiry_time = "900s"
+#expiry_time = "15m"
 
 #[apim.cache.resource]
 #enable = true
-#expiry_time = "900s"
 
 #[apim.cache.km_token]
 #enable = false
@@ -100,9 +100,26 @@ gateway_labels =["Default"]
 [apim.analytics]
 enable = true
 type = "elk"
+#store_api_url = "https://localhost:7444"
+#username = "$ref{super_admin.username}"
+#password = "$ref{super_admin.password}"
+#event_publisher_type = "default"
+#event_publisher_type = "custom"
+#event_publisher_impl = "org.wso2.carbon.apimgt.usage.publisher.APIMgtUsageDataBridgeDataPublisher"
+#publish_response_size = true
 
-[apim.key_manager]
-enable_apikey_subscription_validation = true
+#[[apim.analytics.url_group]]
+#analytics_url =["tcp://analytics1:7611","tcp://analytics2:7611"]
+#analytics_auth_url =["ssl://analytics1:7711","ssl://analytics2:7711"]
+#type = "loadbalance"
+
+#[[apim.analytics.url_group]]
+#analytics_url =["tcp://analytics1:7612","tcp://analytics2:7612"]
+#analytics_auth_url =["ssl://analytics1:7712","ssl://analytics2:7712"]
+#type = "failover"
+
+
+#[apim.key_manager]
 #service_url = "https://localhost:${mgt.transport.https.port}/services/"
 #username = "$ref{super_admin.username}"
 #password = "$ref{super_admin.password}"
@@ -112,22 +129,15 @@ enable_apikey_subscription_validation = true
 #key_validation_handler_type = "custom"
 #key_validation_handler_impl = "org.wso2.carbon.apimgt.keymgt.handlers.DefaultKeyValidationHandler"
 
-#[apim.idp]
-#server_url = "https://localhost:${mgt.transport.https.port}"
-#authorize_endpoint = "https://localhost:${mgt.transport.https.port}/oauth2/authorize"
-#oidc_logout_endpoint = "https://localhost:${mgt.transport.https.port}/oidc/logout"
-#oidc_check_session_endpoint = "https://localhost:${mgt.transport.https.port}/oidc/checksession"
-
 #[apim.jwt]
 #enable = true
 #encoding = "base64" # base64,base64url
 #generator_impl = "org.wso2.carbon.apimgt.keymgt.token.JWTGenerator"
 #claim_dialect = "http://wso2.org/claims"
-#convert_dialect = false
 #header = "X-JWT-Assertion"
 #signing_algorithm = "SHA256withRSA"
 #enable_user_claims = true
-#claims_extractor_impl = "org.wso2.carbon.apimgt.impl.token.ExtendedDefaultClaimsRetriever"
+#claims_extractor_impl = "org.wso2.carbon.apimgt.impl.token.DefaultClaimsRetriever"
 
 #[apim.oauth_config]
 #enable_outbound_auth_header = false
@@ -147,22 +157,26 @@ enable_apikey_subscription_validation = true
 #enable_comments = true
 #enable_ratings = true
 #enable_forum = true
-#enable_anonymous_mode=true
-#enable_cross_tenant_subscriptions = true
-#default_reserved_username = "apim_reserved_user"
 
 [apim.cors]
 allow_origins = "*"
 allow_methods = ["GET","PUT","POST","DELETE","PATCH","OPTIONS"]
-allow_headers = ["authorization","Access-Control-Allow-Origin","Content-Type","SOAPAction","apikey","Internal-Key"]
+allow_headers = ["authorization","Access-Control-Allow-Origin","Content-Type","SOAPAction"]
 allow_credentials = false
+
+#[[apim.throttling.url_group]]
+#analytics_url = ["tcp://localhost:7611","tcp://localhost:7611"]
+#analytics_auth_url = ["ssl://localhost:7711","ssl://localhost:7711"]
+#type = "loadbalance"
 
 #[apim.throttling]
 #enable_data_publishing = true
 #enable_policy_deploy = true
 #enable_blacklist_condition = true
-#enable_persistence = true
+
 #throttle_decision_endpoints = ["tcp://localhost:5672","tcp://localhost:5672"]
+#
+#enable_persistence = true
 
 #[apim.throttling.blacklist_condition]
 #start_delay = "5m"
@@ -174,7 +188,7 @@ allow_credentials = false
 #[apim.throttling.event_sync]
 #hostName = "0.0.0.0"
 #port = 11224
-
+#
 #[apim.throttling.event_management]
 #hostName = "0.0.0.0"
 #port = 10005
@@ -183,7 +197,7 @@ allow_credentials = false
 #traffic_manager_urls = ["tcp://localhost:9611","tcp://localhost:9611"]
 #traffic_manager_auth_urls = ["ssl://localhost:9711","ssl://localhost:9711"]
 #type = "loadbalance"
-
+#
 #[[apim.throttling.url_group]]
 #traffic_manager_urls = ["tcp://localhost:9611","tcp://localhost:9611"]
 #traffic_manager_auth_urls = ["ssl://localhost:9711","ssl://localhost:9711"]
@@ -194,7 +208,7 @@ allow_credentials = false
 #service_url = "https://localhost:9445/bpmn"
 #username = "$ref{super_admin.username}"
 #password = "$ref{super_admin.password}"
-#callback_endpoint = "https://localhost:${mgt.transport.https.port}/api/am/admin/v0.17/workflows/update-workflow-status"
+#callback_endpoint = "https://localhost:${mgt.transport.https.port}/api/am/publisher/v0.16/workflows/update-workflow-status"
 #token_endpoint = "https://localhost:${https.nio.port}/token"
 #client_registration_endpoint = "https://localhost:${mgt.transport.https.port}/client-registration/v0.17/register"
 #client_registration_username = "$ref{super_admin.username}"
@@ -237,8 +251,18 @@ allow_credentials = false
 name="userPostSelfRegistration"
 subscriptions=["POST_ADD_USER"]
 
-[service_provider]
-sp_name_regex = "^[\\sa-zA-Z0-9._-]*$"
+[transport]
+passthru_https.listener.ssl_profile_interval = 6000
+passthru_https.sender.ssl_profile.interval = 6000
+
+[security_audit]
+api_token="b57973cf-b74c-4ade-921d-ece83251eceb"
+collection_id="f73b8171-4f71-499b-891a-d34aa71f2d45"
+base_url="https://localhost:9943/am-auditApi-sample/api/auditapi"
+global=true
+
+[apim.certificate_reloader]
+period = "1m"
 
 [database.local]
 url = "jdbc:h2:./repository/database/WSO2CARBON_DB;DB_CLOSE_ON_EXIT=FALSE"
@@ -254,7 +278,6 @@ username = "${admin.username}"
 password = "${admin.password}"
 'header.X-WSO2-KEY-MANAGER' = "default"
 
-[oauth.grant_type.token_exchange]
-enable = true
-allow_refresh_tokens = true
-iat_validity_period = "1h"
+[apim.sync_runtime_artifacts.gateway.skip_list]
+apis = ["admin--git2231head_v1.0.0.xml","admin--PizzaShackAPI_v1.0.0.xml","admin--ScriptMediatorAPI_v1.0.xml",
+    "APIThrottleBackendAPI.xml","BackEndSecurity.xml","DigestAuth_API.xml","git2231.xml","HttpPATCHSupport_API.xml","JWKS-Backend.xml","JWTBackendAPI.xml","multiVSR_v1.0.0.xml","Response_API_1.xml","Response_API_2.xml","Response_Custom_API.xml","Response_Error_API.xml","Response_Loc_API.xml","SpecialCRN_v1.0.0.xml","status_code_204_API.xml","stockquote.xml","XML_API.xml","Version1.xml","Version2.xml","schemaValidationAPI.xml"]

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/ElkAnalytics/log4j2.properties
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/ElkAnalytics/log4j2.properties
@@ -1,0 +1,478 @@
+# list of all appenders
+#add entry "syslog" to use the syslog appender
+appenders=APIM_METRICS_APPENDER, CARBON_CONSOLE, CARBON_LOGFILE, AUDIT_LOGFILE, ATOMIKOS_LOGFILE, CARBON_TRACE_LOGFILE, ERROR_LOGFILE, OPEN_TRACING,SERVICE_APPENDER, TRACE_APPENDER, osgi, CORRELATION, BOTDATA_APPENDER, API_LOGFILE
+#, syslog
+
+# CARBON_CONSOLE is set to be a ConsoleAppender using a PatternLayout.
+appender.CARBON_CONSOLE.type = Console
+appender.CARBON_CONSOLE.name = CARBON_CONSOLE
+appender.CARBON_CONSOLE.layout.type = PatternLayout
+appender.CARBON_CONSOLE.layout.pattern = [%d{DEFAULT}] %5p - %c{1} %m%n
+appender.CARBON_CONSOLE.filter.threshold.type = ThresholdFilter
+appender.CARBON_CONSOLE.filter.threshold.level = DEBUG
+
+# CARBON_LOGFILE is set to be a DailyRollingFileAppender using a PatternLayout.
+appender.CARBON_LOGFILE.type = RollingFile
+appender.CARBON_LOGFILE.name = CARBON_LOGFILE
+appender.CARBON_LOGFILE.fileName = ${sys:carbon.home}/repository/logs/wso2carbon.log
+appender.CARBON_LOGFILE.filePattern = ${sys:carbon.home}/repository/logs/wso2carbon-%d{MM-dd-yyyy}-%i.log
+appender.CARBON_LOGFILE.layout.type = PatternLayout
+appender.CARBON_LOGFILE.layout.pattern = TID: [%tenantId] [%appName] [%d] %5p {%c} - %m%ex%n
+appender.CARBON_LOGFILE.policies.type = Policies
+appender.CARBON_LOGFILE.policies.time.type = TimeBasedTriggeringPolicy
+appender.CARBON_LOGFILE.policies.time.interval = 1
+appender.CARBON_LOGFILE.policies.time.modulate = true
+appender.CARBON_LOGFILE.policies.size.type = SizeBasedTriggeringPolicy
+appender.CARBON_LOGFILE.policies.size.size = 10MB
+appender.CARBON_LOGFILE.strategy.type = DefaultRolloverStrategy
+appender.CARBON_LOGFILE.strategy.max = 20
+appender.CARBON_LOGFILE.filter.threshold.type = ThresholdFilter
+appender.CARBON_LOGFILE.filter.threshold.level = DEBUG
+
+# Appender config to AUDIT_LOGFILE
+appender.AUDIT_LOGFILE.type = RollingFile
+appender.AUDIT_LOGFILE.name = AUDIT_LOGFILE
+appender.AUDIT_LOGFILE.fileName = ${sys:carbon.home}/repository/logs/audit.log
+appender.AUDIT_LOGFILE.filePattern = ${sys:carbon.home}/repository/logs/audit-%d{MM-dd-yyyy}.log
+appender.AUDIT_LOGFILE.layout.type = PatternLayout
+appender.AUDIT_LOGFILE.layout.pattern = TID: [%tenantId] [%d] %5p {%c} - %m%ex%n
+appender.AUDIT_LOGFILE.policies.type = Policies
+appender.AUDIT_LOGFILE.policies.time.type = TimeBasedTriggeringPolicy
+appender.AUDIT_LOGFILE.policies.time.interval = 1
+appender.AUDIT_LOGFILE.policies.time.modulate = true
+appender.AUDIT_LOGFILE.policies.size.type = SizeBasedTriggeringPolicy
+appender.AUDIT_LOGFILE.policies.size.size = 10MB
+appender.AUDIT_LOGFILE.strategy.type = DefaultRolloverStrategy
+appender.AUDIT_LOGFILE.strategy.max = 20
+appender.AUDIT_LOGFILE.filter.threshold.type = ThresholdFilter
+appender.AUDIT_LOGFILE.filter.threshold.level = INFO
+
+appender.APIM_METRICS_APPENDER.type = RollingFile
+appender.APIM_METRICS_APPENDER.name = APIM_METRICS_APPENDER
+appender.APIM_METRICS_APPENDER.fileName = ${sys:carbon.home}/repository/logs/apim_metrics.log
+appender.APIM_METRICS_APPENDER.filePattern = ${sys:carbon.home}/repository/logs/apim_metrics-%d{MM-dd-yyyy}-%i.log
+appender.APIM_METRICS_APPENDER.layout.type = PatternLayout
+appender.APIM_METRICS_APPENDER.layout.pattern = %d{HH:mm:ss,SSS} [%X{ip}-%X{host}] [%t] %5p %c{1} %m%n
+appender.APIM_METRICS_APPENDER.policies.type = Policies
+appender.APIM_METRICS_APPENDER.policies.time.type = TimeBasedTriggeringPolicy
+appender.APIM_METRICS_APPENDER.policies.time.interval = 1
+appender.APIM_METRICS_APPENDER.policies.time.modulate = true
+appender.APIM_METRICS_APPENDER.policies.size.type = SizeBasedTriggeringPolicy
+appender.APIM_METRICS_APPENDER.policies.size.size=1000MB
+appender.APIM_METRICS_APPENDER.strategy.type = DefaultRolloverStrategy
+appender.APIM_METRICS_APPENDER.strategy.max = 10
+
+# Appender config API logging
+appender.API_LOGFILE.type = RollingFile
+appender.API_LOGFILE.name = API_LOGFILE
+appender.API_LOGFILE.fileName = ${sys:carbon.home}/repository/logs/api.log
+appender.API_LOGFILE.filePattern = ${sys:carbon.home}/repository/logs/api-%d{MM-dd-yyyy}-%i.log
+appender.API_LOGFILE.layout.type = PatternLayout
+appender.API_LOGFILE.layout.pattern = [%d] %5p {%c} %X{apiName} - %m%ex%n
+appender.API_LOGFILE.policies.type = Policies
+appender.API_LOGFILE.policies.time.type = TimeBasedTriggeringPolicy
+appender.API_LOGFILE.policies.time.interval = 1
+appender.API_LOGFILE.policies.time.modulate = true
+appender.API_LOGFILE.policies.size.type = SizeBasedTriggeringPolicy
+appender.API_LOGFILE.policies.size.size = 10MB
+appender.API_LOGFILE.strategy.type = DefaultRolloverStrategy
+appender.API_LOGFILE.strategy.max = 20
+appender.API_LOGFILE.filter.threshold.type = ThresholdFilter
+appender.API_LOGFILE.filter.threshold.level = DEBUG
+
+# Appender config to send Atomikos transaction logs to new log file tm.out.
+appender.ATOMIKOS_LOGFILE.type = RollingFile
+appender.ATOMIKOS_LOGFILE.name = ATOMIKOS_LOGFILE
+appender.ATOMIKOS_LOGFILE.fileName = ${sys:carbon.home}/repository/logs/tm.out
+appender.ATOMIKOS_LOGFILE.filePattern = ${sys:carbon.home}/repository/logs/tm-%d{MM-dd-yyyy}.out
+appender.ATOMIKOS_LOGFILE.layout.type = PatternLayout
+appender.ATOMIKOS_LOGFILE.layout.pattern = [%d] [%tenantId] %5p {%c} - %m%ex%n
+appender.ATOMIKOS_LOGFILE.policies.type = Policies
+appender.ATOMIKOS_LOGFILE.policies.time.type = TimeBasedTriggeringPolicy
+appender.ATOMIKOS_LOGFILE.policies.time.interval = 1
+appender.ATOMIKOS_LOGFILE.policies.time.modulate = true
+appender.ATOMIKOS_LOGFILE.strategy.type = DefaultRolloverStrategy
+appender.ATOMIKOS_LOGFILE.strategy.max = 20
+
+# Appender config to CARBON_TRACE_LOGFILE
+appender.CARBON_TRACE_LOGFILE.type = RollingFile
+appender.CARBON_TRACE_LOGFILE.name = CARBON_TRACE_LOGFILE
+appender.CARBON_TRACE_LOGFILE.fileName = ${sys:carbon.home}/repository/logs/wso2carbon-trace-messages.log
+appender.CARBON_TRACE_LOGFILE.filePattern = ${sys:carbon.home}/repository/logs/wso2carbon-trace-messages-%d{MM-dd-yyyy}.log
+appender.CARBON_TRACE_LOGFILE.layout.type = PatternLayout
+appender.CARBON_TRACE_LOGFILE.layout.pattern = [%d] [%tenantId] %5p {%c} - %m%ex%n
+appender.CARBON_TRACE_LOGFILE.policies.type = Policies
+appender.CARBON_TRACE_LOGFILE.policies.time.type = TimeBasedTriggeringPolicy
+appender.CARBON_TRACE_LOGFILE.policies.time.interval = 1
+appender.CARBON_TRACE_LOGFILE.policies.time.modulate = true
+appender.CARBON_TRACE_LOGFILE.policies.size.type = SizeBasedTriggeringPolicy
+appender.CARBON_TRACE_LOGFILE.policies.size.size = 10MB
+appender.CARBON_TRACE_LOGFILE.strategy.type = DefaultRolloverStrategy
+appender.CARBON_TRACE_LOGFILE.strategy.max = 20
+
+# Appender config to put correlation Log.
+appender.CORRELATION.type = RollingFile
+appender.CORRELATION.name = CORRELATION
+appender.CORRELATION.fileName = ${sys:carbon.home}/repository/logs/correlation.log
+appender.CORRELATION.filePattern =${sys:carbon.home}/repository/logs/correlation-%d{MM-dd-yyyy}-%i.log.gz
+appender.CORRELATION.layout.type = PatternLayout
+appender.CORRELATION.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS}|%X{Correlation-ID}|%t|%m%n
+appender.CORRELATION.policies.type = Policies
+appender.CORRELATION.policies.time.type = TimeBasedTriggeringPolicy
+appender.CORRELATION.policies.time.interval = 1
+appender.CORRELATION.policies.time.modulate = true
+appender.CORRELATION.policies.size.type = SizeBasedTriggeringPolicy
+appender.CORRELATION.policies.size.size = 10MB
+appender.CORRELATION.strategy.type = DefaultRolloverStrategy
+appender.CORRELATION.strategy.max = 20
+appender.CORRELATION.filter.threshold.type = ThresholdFilter
+appender.CORRELATION.filter.threshold.level = INFO
+
+appender.ERROR_LOGFILE.type = RollingFile
+appender.ERROR_LOGFILE.name = ERROR_LOGFILE
+appender.ERROR_LOGFILE.fileName = ${sys:carbon.home}/repository/logs/wso2-apigw-errors.log
+appender.ERROR_LOGFILE.filePattern = ${sys:carbon.home}/repository/logs/wso2-apigw-errors-%d{MM-dd-yyyy}-%i.log.gz
+appender.ERROR_LOGFILE.layout.type = PatternLayout
+appender.ERROR_LOGFILE.layout.pattern = %d{ISO8601} [%X{ip}-%X{host}] [%t] %5p %c{1} %m%n
+appender.ERROR_LOGFILE.policies.type = Policies
+appender.ERROR_LOGFILE.policies.time.type = TimeBasedTriggeringPolicy
+appender.ERROR_LOGFILE.policies.time.interval = 1
+appender.ERROR_LOGFILE.policies.time.modulate = true
+appender.ERROR_LOGFILE.policies.size.type = SizeBasedTriggeringPolicy
+appender.ERROR_LOGFILE.policies.size.size = 10MB
+appender.ERROR_LOGFILE.strategy.type = DefaultRolloverStrategy
+appender.ERROR_LOGFILE.strategy.max = 20
+appender.ERROR_LOGFILE.filter.threshold.type = ThresholdFilter
+appender.ERROR_LOGFILE.filter.threshold.level = WARN
+
+appender.CARBON_SYS_LOG.type = Syslog
+appender.CARBON_SYS_LOG.name = CARBON_SYS_LOG
+appender.CARBON_SYS_LOG.host = localhost
+appender.CARBON_SYS_LOG.facility = USER
+appender.CARBON_SYS_LOG.layout.type = PatternLayout
+appender.CARBON_SYS_LOG.layout.pattern = [%d] %5p - %x %m {%c}%n
+appender.CARBON_SYS_LOG.filter.threshold.type = ThresholdFilter
+appender.CARBON_SYS_LOG.filter.threshold.level = DEBUG
+
+appender.OPEN_TRACING.type = RollingFile
+appender.OPEN_TRACING.name = OPEN_TRACING
+appender.OPEN_TRACING.fileName = ${sys:carbon.home}/repository/logs/wso2-apimgt-open-tracing.log
+appender.OPEN_TRACING.filePattern = ${sys:carbon.home}/repository/logs/wso2-apimgt-open-tracing-%d{MM-dd-yyyy}-%i.log.gz
+appender.OPEN_TRACING.layout.type = PatternLayout
+appender.OPEN_TRACING.layout.pattern = %d{HH:mm:ss,SSS} [%X{ip}-%X{host}] [%t] %5p %m%nn
+appender.OPEN_TRACING.policies.type = Policies
+appender.OPEN_TRACING.policies.time.type = TimeBasedTriggeringPolicy
+appender.OPEN_TRACING.policies.time.interval = 1
+appender.OPEN_TRACING.policies.time.modulate = true
+appender.OPEN_TRACING.policies.size.type = SizeBasedTriggeringPolicy
+appender.OPEN_TRACING.policies.size.size = 10MB
+appender.OPEN_TRACING.strategy.type = DefaultRolloverStrategy
+appender.OPEN_TRACING.strategy.max = 20
+appender.OPEN_TRACING.filter.threshold.type = ThresholdFilter
+appender.OPEN_TRACING.filter.threshold.level = TRACE
+
+appender.TRACE_APPENDER.type = RollingFile
+appender.TRACE_APPENDER.name = TRACE_APPENDER
+appender.TRACE_APPENDER.fileName = ${sys:carbon.home}/repository/logs/wso2-apigw-trace.log
+appender.TRACE_APPENDER.filePattern = ${sys:carbon.home}/repository/logs/wso2-apigw-trace-%d{MM-dd-yyyy}.log
+appender.TRACE_APPENDER.layout.type = PatternLayout
+appender.TRACE_APPENDER.layout.pattern = %d{HH:mm:ss,SSS} [%X{ip}-%X{host}] [%t] %5p %c{1} %m%n
+appender.TRACE_APPENDER.policies.type = Policies
+appender.TRACE_APPENDER.policies.time.type = TimeBasedTriggeringPolicy
+appender.TRACE_APPENDER.policies.time.interval = 1
+appender.TRACE_APPENDER.policies.time.modulate = true
+appender.TRACE_APPENDER.strategy.type = DefaultRolloverStrategy
+appender.TRACE_APPENDER.strategy.max = 20
+
+appender.SERVICE_APPENDER.type = RollingFile
+appender.SERVICE_APPENDER.name = SERVICE_APPENDER
+appender.SERVICE_APPENDER.fileName = ${sys:carbon.home}/repository/logs/wso2-apigw-service.log
+appender.SERVICE_APPENDER.filePattern = ${sys:carbon.home}/repository/logs/wso2-apigw-service-%i.log
+appender.SERVICE_APPENDER.layout.type = PatternLayout
+appender.SERVICE_APPENDER.layout.pattern = %d{ISO8601} [%X{ip}-%X{host}] [%t] %5p %c{1} %m%n
+appender.SERVICE_APPENDER.policies.type = Policies
+appender.SERVICE_APPENDER.policies.size.type = SizeBasedTriggeringPolicy
+appender.SERVICE_APPENDER.policies.size.size=1000KB
+appender.SERVICE_APPENDER.strategy.type = DefaultRolloverStrategy
+appender.SERVICE_APPENDER.strategy.max = 10
+
+appender.osgi.type = PaxOsgi
+appender.osgi.name = PaxOsgi
+appender.osgi.filter = *
+
+loggers = reporter, AUDIT_LOG, trace-messages, org-apache-coyote, com-hazelcast, Owasp-CsrfGuard, org-apache-axis2-wsdl-codegen-writer-PrettyPrinter, org-apache-axis2-clustering, org-apache-catalina, org-apache-tomcat, org-wso2-carbon-apacheds, org-apache-directory-server-ldap, org-apache-directory-server-core-event, com-atomikos, org-quartz, org-apache-jackrabbit-webdav, org-apache-juddi, org-apache-commons-digester-Digester, org-apache-jasper-compiler-TldLocationsCache, org-apache-qpid, org-apache-qpid-server-Main, qpid-message, qpid-message-broker-listening, org-apache-tiles, org-apache-commons-httpclient, org-apache-solr, me-prettyprint-cassandra-hector-TimingLogger, org-apache-axis-enterprise, org-apache-directory-shared-ldap, org-apache-directory-server-ldap-handlers, org-apache-directory-shared-ldap-entry-DefaultServerAttribute, org-apache-directory-server-core-DefaultDirectoryService, org-apache-directory-shared-ldap-ldif-LdifReader, org-apache-directory-server-ldap-LdapProtocolHandler, org-apache-directory-server-core, org-apache-directory-server-ldap-LdapSession, DataNucleus, Datastore, Datastore-Schema, JPOX-Datastore, JPOX-Plugin, JPOX-MetaData, JPOX-Query, JPOX-General, JPOX-Enhancer, org-apache-hadoop-hive, hive, ExecMapper, ExecReducer, net-sf-ehcache-config-ConfigurationFactory, axis2Deployment, equinox, tomcat2, StAXDialectDetector, trace, synapse, synapse_transport, axis2, axis2_transport, org-wso2-carbon, hunsicker, thrift-publisher, service_logger, trace_logger, org-wso2-carbon-apimgt-gateway-mediators-BotDetectionMediator, wso2-callhome, correlation, API_LOG
+
+logger.API_LOG.name = API_LOG
+logger.API_LOG.level = INFO
+logger.API_LOG.appenderRef.API_LOGFILE.ref = API_LOGFILE
+logger.API_LOG.additivity = false
+
+logger.reporter.name = org.wso2.am.analytics.publisher.reporter.elk
+logger.reporter.level = INFO
+logger.reporter.additivity = false
+logger.reporter.appenderRef.APIM_METRICS_APPENDER.ref = APIM_METRICS_APPENDER
+
+logger.AUDIT_LOG.name = AUDIT_LOG
+logger.AUDIT_LOG.level = INFO
+logger.AUDIT_LOG.appenderRef.AUDIT_LOGFILE.ref = AUDIT_LOGFILE
+logger.AUDIT_LOG.additivity = false
+
+logger.trace-messages.name = trace.messages
+logger.trace-messages.level = TRACE
+logger.trace-messages.appenderRef.CARBON_TRACE_LOGFILE.ref = CARBON_TRACE_LOGFILE
+
+logger.org-apache-coyote.name = org.apache.coyote
+logger.org-apache-coyote.level = WARN
+
+logger.com-hazelcast.name = com.hazelcast
+logger.com-hazelcast.level = ERROR
+
+logger.Owasp-CsrfGuard.name = Owasp.CsrfGuard
+logger.Owasp-CsrfGuard.level = WARN
+
+logger.org-apache-axis2-wsdl-codegen-writer-PrettyPrinter.name = org.apache.axis2.wsdl.codegen.writer.PrettyPrinter
+logger.org-apache-axis2-wsdl-codegen-writer-PrettyPrinter.level = ERROR
+logger.org-apache-axis2-wsdl-codegen-writer-PrettyPrinter.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
+
+logger.org-apache-axis2-clustering.name = org.apache.axis2.clustering
+logger.org-apache-axis2-clustering.level = INFO
+logger.org-apache-axis2-clustering.additivity = false
+
+logger.org-apache.name = org.apache
+logger.org-apache.level = INFO
+logger.org-apache.additivity = false
+logger.org-apache.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
+
+logger.org-apache-catalina.name = org.apache.catalina
+logger.org-apache-catalina.level = ERROR
+
+logger.org-apache-tomcat.name = org.apache.tomcat
+logger.org-apache-tomcat.level = INFO
+
+logger.org-wso2-carbon-apacheds.name = org.wso2.carbon.apacheds
+logger.org-wso2-carbon-apacheds.level = WARN
+
+logger.org-apache-directory-server-ldap.name = org.apache.directory.server.ldap
+logger.org-apache-directory-server-ldap.level = ERROR
+
+logger.org-apache-directory-server-core-event.name = org.apache.directory.server.core.event
+logger.org-apache-directory-server-core-event.level = WARN
+
+logger.com-atomikos.name = com.atomikos
+logger.com-atomikos.level = INFO
+logger.com-atomikos.additivity = false
+logger.com-atomikos.appenderRef.ATOMIKOS_LOGFILE.ref = ATOMIKOS_LOGFILE
+
+logger.org-quartz.name = org.quartz
+logger.org-quartz.level = WARN
+
+logger.org-apache-jackrabbit-webdav.name = org.apache.jackrabbit.webdav
+logger.org-apache-jackrabbit-webdav.level = WARN
+
+logger.org-apache-juddi.name = org.apache.juddi
+logger.org-apache-juddi.level = ERROR
+
+logger.org-apache-commons-digester-Digester.name = org.apache.commons.digester.Digester
+logger.org-apache-commons-digester-Digester.level = WARN
+
+logger.org-apache-jasper-compiler-TldLocationsCache.name = org.apache.jasper.compiler.TldLocationsCache
+logger.org-apache-jasper-compiler-TldLocationsCache.level = WARN
+
+logger.org-apache-qpid.name = org.apache.qpid
+logger.org-apache-qpid.level = WARN
+
+logger.org-apache-qpid-server-Main.name = org.apache.qpid.server.Main
+logger.org-apache-qpid-server-Main.level = INFO
+
+logger.qpid-message.name = qpid.message
+logger.qpid-message.level = WARN
+
+logger.qpid-message-broker-listening.name = qpid.message.broker.listening
+logger.qpid-message-broker-listening.level = INFO
+
+logger.org-apache-tiles.name = org.apache.tiles
+logger.org-apache-tiles.level = WARN
+
+logger.org-apache-commons-httpclient.name = org.apache.commons.httpclient
+logger.org-apache-commons-httpclient.level = ERROR
+
+logger.org-apache-solr.name = org.apache.solr
+logger.org-apache-solr.level = ERROR
+
+logger.me-prettyprint-cassandra-hector-TimingLogger.name = me.prettyprint.cassandra.hector.TimingLogger
+logger.me-prettyprint-cassandra-hector-TimingLogger.level = ERROR
+
+logger.org-wso2.name = org.wso2
+logger.org-wso2.level = INFO
+
+logger.org-wso2-carbon.name = org.wso2.carbon
+logger.org-wso2-carbon.level = INFO
+
+logger.org-apache-axis-enterprise.name = org.apache.axis2.enterprise
+logger.org-apache-axis-enterprise.level = FATAL
+logger.org-apache-axis-enterprise.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
+
+logger.org-apache-directory-shared-ldap.name = org.apache.directory.shared.ldap
+logger.org-apache-directory-shared-ldap.level = WARN
+logger.org-apache-directory-shared-ldap.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
+
+logger.org-apache-directory-server-ldap-handlers.name = org.apache.directory.server.ldap.handlers
+logger.org-apache-directory-server-ldap-handlers.level = WARN
+logger.org-apache-directory-server-ldap-handlers.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
+
+# Following are to remove false error messages from startup (IS)
+logger.org-apache-directory-shared-ldap-entry-DefaultServerAttribute.name = org.apache.directory.shared.ldap.entry.DefaultServerAttribute
+logger.org-apache-directory-shared-ldap-entry-DefaultServerAttribute.level = FATAL
+logger.org-apache-directory-shared-ldap-entry-DefaultServerAttribute.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
+
+logger.org-apache-directory-server-core-DefaultDirectoryService.name = org.apache.directory.server.core.DefaultDirectoryService
+logger.org-apache-directory-server-core-DefaultDirectoryService.level = ERROR
+logger.org-apache-directory-server-core-DefaultDirectoryService.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
+
+logger.org-apache-directory-shared-ldap-ldif-LdifReader.name = org.apache.directory.shared.ldap.ldif.LdifReader
+logger.org-apache-directory-shared-ldap-ldif-LdifReader.level = ERROR
+logger.org-apache-directory-shared-ldap-ldif-LdifReader.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
+
+logger.org-apache-directory-server-ldap-LdapProtocolHandler.name = org.apache.directory.server.ldap.LdapProtocolHandler
+logger.org-apache-directory-server-ldap-LdapProtocolHandler.level = ERROR
+logger.org-apache-directory-server-ldap-LdapProtocolHandler.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
+
+logger.org-apache-directory-server-core.name = org.apache.directory.server.core
+logger.org-apache-directory-server-core.level = ERROR
+logger.org-apache-directory-server-core.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
+
+logger.org-apache-directory-server-ldap-LdapSession.name = org.apache.directory.server.ldap.LdapSession
+logger.org-apache-directory-server-ldap-LdapSession.level = Error
+logger.org-apache-directory-server-ldap-LdapSession.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
+
+logger.correlation.name = correlation
+logger.correlation.level = INFO
+logger.correlation.appenderRef.CORRELATION.ref = CORRELATION
+logger.correlation.additivity = false
+
+# Hive Related Log configurations
+logger.DataNucleus.name = DataNucleus
+logger.DataNucleus.level = ERROR
+
+logger.Datastore.name = Datastore
+logger.Datastore.level = ERROR
+
+logger.Datastore-Schema.name = Datastore.Schema
+logger.Datastore-Schema.level = ERROR
+
+logger.JPOX-Datastore.name = JPOX.Datastore
+logger.JPOX-Datastore.level = ERROR
+
+logger.JPOX-Plugin.name = JPOX.Plugin
+logger.JPOX-Plugin.level = ERROR
+
+logger.JPOX-MetaData.name = JPOX.MetaData
+logger.JPOX-MetaData.level = ERROR
+
+logger.JPOX-Query.name = JPOX.Query
+logger.JPOX-Query.level = ERROR
+
+logger.JPOX-General.name = JPOX.General
+logger.JPOX-General.level = ERROR
+
+logger.JPOX-Enhancer.name = JPOX.Enhancer
+logger.JPOX-Enhancer.level = ERROR
+
+logger.org-apache-hadoop-hive.name = org.apache.hadoop.hive
+logger.org-apache-hadoop-hive.level = WARN
+
+logger.hive.name = hive
+logger.hive.level = WARN
+
+logger.ExecMapper.name = ExecMapper
+logger.ExecMapper.level = WARN
+
+logger.ExecReducer.name = ExecReducer
+logger.ExecReducer.level = WARN
+
+logger.net-sf-ehcache-config-ConfigurationFactory.name = net.sf.ehcache.config.ConfigurationFactory
+logger.net-sf-ehcache-config-ConfigurationFactory.level = ERROR
+
+logger.axis2Deployment.name = org.apache.axis2.deployment
+logger.axis2Deployment.level = WARN
+
+logger.equinox.name = org.eclipse.equinox
+logger.equinox.level = FATAL
+
+logger.tomcat2.name = tomcat
+logger.tomcat2.level = FATAL
+
+logger.StAXDialectDetector.name = org.apache.axiom.util.stax.dialect.StAXDialectDetector
+logger.StAXDialectDetector.level = ERROR
+
+logger.trace.name = tracer
+logger.trace.level = TRACE
+logger.trace.appenderRef.OPEN_TRACING.ref = OPEN_TRACING
+
+logger.synapse.name = org.apache.synapse
+logger.synapse.level = INFO
+
+logger.synapse_transport.name = org.apache.synapse.transport
+logger.synapse_transport.level = INFO
+
+logger.axis2.name = org.apache.axis2
+logger.axis2.level = INFO
+
+logger.axis2_transport.name = org.apache.axis2.transport
+logger.axis2_transport.level = INFO
+
+logger.hunsicker.name = de.hunsicker.jalopy.io
+logger.hunsicker.level = FATAL
+
+logger.synapse-headers.name = org.apache.synapse.transport.http.headers
+logger.synapse-headers.level = DEBUG
+
+logger.synapse-wire.name = org.apache.synapse.transport.http.wire
+logger.synapse-wire.level = DEBUG
+
+logger.thrift-publisher.name = org.wso2.carbon.databridge.agent.thrift.AsyncDataPublisher
+logger.thrift-publisher.level = WARN
+
+logger.service_logger.name = SERVICE_LOGGER
+logger.service_logger.level = INFO
+logger.service_logger.additivity = false
+logger.service_logger.appenderRef.SERVICE_APPENDER.ref = SERVICE_APPENDER
+
+logger.wso2-callhome.name = org.wso2.callhome
+logger.wso2-callhome.level = INFO
+
+logger.trace_logger.name = TRACE_LOGGER
+logger.trace_logger.level = INFO
+logger.trace_logger.appenderRef.TRACE_APPENDER.ref = TRACE_APPENDER
+
+# root loggers
+rootLogger.level = ERROR
+rootLogger.appenderRef.CARBON_CONSOLE.ref = CARBON_CONSOLE
+rootLogger.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
+rootLogger.appenderRef.ERROR_LOGFILE.ref = ERROR_LOGFILE
+rootLogger.appenderRef.PaxOsgi.ref = PaxOsgi
+#rootLogger.appenderReg.CARBON_SYS_LOG.ref = CARBON_SYS_LOG
+#rootLogger.appenderRef.syslog.ref = syslog
+
+# bot detection feature appender
+appender.BOTDATA_APPENDER.type = RollingFile
+appender.BOTDATA_APPENDER.name = BOTDATA_APPENDER
+appender.BOTDATA_APPENDER.fileName = ${sys:carbon.home}/repository/logs/wso2-BotDetectedData.log
+appender.BOTDATA_APPENDER.filePattern = ${sys:carbon.home}/repository/logs/wso2-BotDetectedData-%d{MM-dd-yyyy}.log
+appender.BOTDATA_APPENDER.layout.type = PatternLayout
+appender.BOTDATA_APPENDER.layout.pattern = [%d] [%tenantId] %5p {%c} - %m%ex%n
+appender.BOTDATA_APPENDER.policies.type = Policies
+appender.BOTDATA_APPENDER.policies.time.type = TimeBasedTriggeringPolicy
+appender.BOTDATA_APPENDER.policies.time.interval = 1
+appender.BOTDATA_APPENDER.policies.time.modulate = true
+appender.BOTDATA_APPENDER.policies.size.type = SizeBasedTriggeringPolicy
+appender.BOTDATA_APPENDER.policies.size.size = 10MB
+appender.BOTDATA_APPENDER.strategy.type = DefaultRolloverStrategy
+appender.BOTDATA_APPENDER.strategy.max = 20
+
+logger.org-wso2-carbon-apimgt-gateway-mediators-BotDetectionMediator.name = org.wso2.carbon.apimgt.gateway.mediators.BotDetectionMediator
+logger.org-wso2-carbon-apimgt-gateway-mediators-BotDetectionMediator.level = INFO
+logger.org-wso2-carbon-apimgt-gateway-mediators-BotDetectionMediator.appenderRef.BOTDATA_APPENDER.ref = BOTDATA_APPENDER
+logger.org-wso2-carbon-apimgt-gateway-mediators-BotDetectionMediator.additivity = false
+
+category.SERVICE_APPENDER._OpenService_ = TRACE_APPENDER, BOTDATA_APPENDER

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/ElkAnalytics/respondMediatorPolicy.j2
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/ElkAnalytics/respondMediatorPolicy.j2
@@ -1,0 +1,10 @@
+<property name="switchExpression"
+             expression="fn:concat($ctx:REST_METHOD,'_',$ctx:API_ELECTED_RESOURCE)"/>
+<switch source="$ctx:switchExpression">
+   <case regex="GET_\/customers\/123">
+      <log level="full">
+         <property name="MESSAGE" value="MESSAGE"/>
+      </log>
+   </case>
+</switch>
+<respond/>

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/ElkAnalytics/respondMediatorPolicy.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/ElkAnalytics/respondMediatorPolicy.json
@@ -1,0 +1,18 @@
+{
+  "category": "Mediation",
+  "name": "respondMediatorPolicy",
+  "version": "v1",
+  "displayName": "Respond Mediator Policy",
+  "description": "Adds a respond medaitor to the in/out/fault sequence",
+  "applicableFlows": [
+    "request",
+    "response",
+    "fault"
+  ],
+  "supportedGateways": [
+    "Synapse"
+  ],
+  "supportedApiTypes": [
+    "HTTP"
+  ]
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -197,6 +197,7 @@
             <class name="org.wso2.am.integration.tests.other.APICategoriesTestCase"/>
             <class name="org.wso2.am.integration.tests.other.SharedScopeTestCase"/>
             <class name="org.wso2.am.integration.tests.analytics.APIMAnalyticsTest"/>
+            <class name="org.wso2.am.integration.tests.analytics.ELKAnalyticsWithRespondMediatorTestCase"/>
         </classes>
     </test>
 


### PR DESCRIPTION
This covers the scenario where an operation policy containing a respond mediator is added to the request flow when ELK analytics is enabled.

Related issue: https://github.com/wso2/api-manager/issues/2364

Related fix: https://github.com/wso2/carbon-apimgt/pull/12211