### PR TITLE
Adds strictServicePathValidation config for axis2

### DIFF
--- a/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/axis2.xml.j2
+++ b/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/axis2.xml.j2
@@ -46,6 +46,9 @@
     <!-- Sandesha2 persistance storage manager -->
     <parameter name="Sandesha2StorageManager" locked="false">inmemory</parameter>
 
+    <!-- This property will enable strict service URL validation -->
+    <parameter name="strictServicePathValidation" locked="false">{{server.strict_service_path_validation}}</parameter>
+
     <!-- Our HTTP endpoints can handle both REST and SOAP under the following service path. In -->
     <!-- case of a servlet container, if you change this you have to manually change the -->
     <!-- settings of your servlet container to map this context path to proper Axis2 servlets -->


### PR DESCRIPTION
## Overview
Resolves https://github.com/wso2/api-manager/issues/2313

When "/services/Version" is added after the actual API Invocation URL, API Manager's Version is getting displayed.

Ex:
Actual API Invocation URL: https://localhost:8243/pizzashack/1.0.0/menu

Executing https://localhost:8243/pizzashack/1.0.0/menu/services/Version results in the following response.

<ns:getVersionResponse xmlns:ns="[http://version.services.core.carbon.wso2.org">](http://version.services.core.carbon.wso2.org"%3E/)
WSO2 API Manager-<version number>
</ns:getVersionResponse>

The expectation is to return an HTTP 404 error if the endpoint does not have the "/services/Version" path available.

## Related Fix
https://github.com/wso2/wso2-axis2/pull/282

