### PR TITLE
Upgrade Fasterxml, Guava, Snakeyaml, Analytics Common, Swagger Parser, and xmlsec dependencies 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1489,7 +1489,7 @@
         <identity.org.mgt.version>1.2.1</identity.org.mgt.version>
         <identity.inbound.provisioning.scim2.version>3.1.1</identity.inbound.provisioning.scim2.version>
         <xmlsec.wso2.version>1.5.6-wso2v1</xmlsec.wso2.version>
-        <xmlsec.version>2.3.0</xmlsec.version>
+        <xmlsec.version>2.3.4</xmlsec.version>
         <identity.user.workflow.version>5.6.0</identity.user.workflow.version>
         <identity.carbon.auth.rest.version>1.4.9</identity.carbon.auth.rest.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -1274,7 +1274,7 @@
 
         <project.scm.id>scm-server</project.scm.id>
 
-        <carbon.analytics.common.version>5.3.5</carbon.analytics.common.version>
+        <carbon.analytics.common.version>5.3.6</carbon.analytics.common.version>
 
         <!-- APIM Portals Component Version -->
         <carbon.apimgt.ui.version>9.0.494</carbon.apimgt.ui.version>
@@ -1411,7 +1411,7 @@
         <maven-resources-plugin.version>2.5</maven-resources-plugin.version>
         <eclipse.version>3.2.0</eclipse.version>
         <jacoco.agent.version>0.8.8</jacoco.agent.version>
-        <google.guava.version>27.0-jre</google.guava.version>
+        <google.guava.version>33.0.0-jre</google.guava.version>
 
         <carbon.metrics.version>1.3.12</carbon.metrics.version>
         <!-- MB Features -->
@@ -1422,12 +1422,12 @@
         <orbit.version.geronimo-jms_1.1_spec>1.1.1.wso2v1</orbit.version.geronimo-jms_1.1_spec>
         <commons-digester.version>1.8.1</commons-digester.version>
         <commons.scxml.version>0.9.0.wso2v1</commons.scxml.version>
-        <version.snake.yaml>1.33</version.snake.yaml>
+        <version.snake.yaml>2.0</version.snake.yaml>
 
         <!--Sample scenarios dependencies -->
         <swagger-annotations-version>1.5.23</swagger-annotations-version>
         <jersey-version>1.19.4</jersey-version>
-        <jackson-version>2.14.1</jackson-version>
+        <jackson-version>2.16.1</jackson-version>
         <jodatime-version>2.10.6</jodatime-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>
         <log4j.version>1.2.13</log4j.version>
@@ -1453,13 +1453,13 @@
         <javax.jms.version>2.0.1</javax.jms.version>
 
         <!-- API Import/Export Dependencies -->
-        <com.fasterxml.jackson.dataformat.version>2.14.1</com.fasterxml.jackson.dataformat.version>
+        <com.fasterxml.jackson.dataformat.version>2.16.1</com.fasterxml.jackson.dataformat.version>
         <versions.pax.logging>2.1.0</versions.pax.logging>
         <config.mapper.version>1.0.2</config.mapper.version>
 
         <!-- Authenticator Properties -->
         <identity.outbound.auth.oidc.version>5.9.0</identity.outbound.auth.oidc.version>
-        <swagger-parser-version>2.0.14</swagger-parser-version>
+        <swagger-parser-version>2.1.20</swagger-parser-version>
         <nimbus.jwt.version>7.3.0.wso2v1</nimbus.jwt.version>
 
         <!-- CallHome version -->


### PR DESCRIPTION
### Purpose

Upgrade the following dependencies to their latest:

- Fasterxml Jackson versions to 2.16.1,
- Google Guava version to 33.0.0-jre,
- Carbon Analytics Common version to 5.3.6,
- Snakeyaml version to 2.0,
- Swagger Parser version to 2.1.20,
- xmlsec version to 2.3.4.