### PR TITLE
Disable benchmark tests

### DIFF
--- a/modules/integration/tests-integration/pom.xml
+++ b/modules/integration/tests-integration/pom.xml
@@ -31,7 +31,7 @@ under the License.
     <packaging>pom</packaging>
 
     <modules>
-        <module>tests-benchmark</module>
+        <!--module>tests-benchmark</module-->
         <module>tests-backend</module>
         <module>tests-restart</module>
         <!--module>tests-config</module-->


### PR DESCRIPTION
Disable benchmark tests for the release as jenkins release build gives a port already used error due to not getting the server shutdown properly after running the backend tests.