### PR TITLE
Stop servers properly after running the tests

### DIFF
--- a/modules/integration/tests-integration/pom.xml
+++ b/modules/integration/tests-integration/pom.xml
@@ -31,7 +31,7 @@ under the License.
     <packaging>pom</packaging>
 
     <modules>
-        <module>tests-benchmark</module>
+        <!--module>tests-benchmark</module-->
         <module>tests-backend</module>
         <module>tests-restart</module>
         <!--module>tests-config</module-->

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/SOAPAPIImportExportTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/SOAPAPIImportExportTestCase.java
@@ -220,6 +220,9 @@ public class SOAPAPIImportExportTestCase extends APIManagerLifecycleBaseTest {
 
     @AfterClass(alwaysRun = true)
     public void destroy() throws Exception {
+        if (wireMockServer != null) {
+            wireMockServer.stop();
+        }
         restAPIPublisher.deleteAPI(newSoapToRestAPIId);
         userManagementClient.deleteRole(SOAPTOREST_ROLE);
         userManagementClient.deleteUser(SOAPTOREST_TEST_USER);


### PR DESCRIPTION
Stop servers properly after running the tests to fix port already in use error when running the benchmark tests