### PR TITLE
[4.3.0] Upgrade IS and Kernel Versions in carbon-apimgt

### DIFF
--- a/modules/distribution/product/src/main/assembly/filter.properties
+++ b/modules/distribution/product/src/main/assembly/filter.properties
@@ -3,7 +3,7 @@ product.key=AM
 product.version=4.3.0
 product.wum.name=wso2am
 
-carbon.version=4.9.0
+carbon.version=4.9.26.alpha
 am.version=4.3.0
 default.server.role=APIManager
 bundle.creators=org.wso2.carbon.mediator.bridge.MediatorBundleCreator

--- a/modules/distribution/product/src/main/assembly/filter.properties
+++ b/modules/distribution/product/src/main/assembly/filter.properties
@@ -3,7 +3,7 @@ product.key=AM
 product.version=4.3.0
 product.wum.name=wso2am
 
-carbon.version=4.8.1
+carbon.version=4.9.0
 am.version=4.3.0
 default.server.role=APIManager
 bundle.creators=org.wso2.carbon.mediator.bridge.MediatorBundleCreator

--- a/modules/p2-profile/product/carbon.product
+++ b/modules/p2-profile/product/carbon.product
@@ -2,7 +2,7 @@
 <?pde version="3.5"?>
 
 <product name="Carbon Product" uid="carbon.product.id" id="carbon.product" application="carbon.application"
-version="4.9.0" useFeatures="true" includeLaunchers="true">
+version="4.9.26.alpha" useFeatures="true" includeLaunchers="true">
 
    <configIni use="default">
    </configIni>
@@ -14,7 +14,7 @@ version="4.9.0" useFeatures="true" includeLaunchers="true">
    </plugins>
 
    <features>
-      <feature id="org.wso2.carbon.core.runtime" version="4.9.0"/>
+      <feature id="org.wso2.carbon.core.runtime" version="4.9.26.alpha"/>
    </features>
 
   <configurations>

--- a/modules/p2-profile/product/carbon.product
+++ b/modules/p2-profile/product/carbon.product
@@ -2,7 +2,7 @@
 <?pde version="3.5"?>
 
 <product name="Carbon Product" uid="carbon.product.id" id="carbon.product" application="carbon.application"
-version="4.8.1" useFeatures="true" includeLaunchers="true">
+version="4.9.0" useFeatures="true" includeLaunchers="true">
 
    <configIni use="default">
    </configIni>
@@ -14,7 +14,7 @@ version="4.8.1" useFeatures="true" includeLaunchers="true">
    </plugins>
 
    <features>
-      <feature id="org.wso2.carbon.core.runtime" version="4.8.1"/>
+      <feature id="org.wso2.carbon.core.runtime" version="4.9.0"/>
    </features>
 
   <configurations>

--- a/modules/p2-profile/product/pom.xml
+++ b/modules/p2-profile/product/pom.xml
@@ -673,6 +673,10 @@
                                 <featureArtifactDef>
                                     org.wso2.carbon.identity.framework:org.wso2.carbon.identity.user.store.configuration.server.feature:${carbon.identity.version}
                                 </featureArtifactDef>
+                                <!-- Identity Branding Preference Management feature -->
+                                <featureArtifactDef>
+                                    org.wso2.carbon.identity.branding.preference.management:org.wso2.carbon.identity.branding.preference.management.core.server.feature:${identity.branding.preference.management.version}
+                                </featureArtifactDef>
 
                             </featureArtifacts>
                         </configuration>
@@ -1503,6 +1507,10 @@
                                 <feature>
                                     <id>org.wso2.carbon.identity.user.store.configuration.server.feature.group</id>
                                     <version>${carbon.identity.version}</version>
+                                </feature>
+                                <feature>
+                                    <id>org.wso2.carbon.identity.branding.preference.management.core.server.feature.group</id>
+                                    <version>${identity.branding.preference.management.version}</version>
                                 </feature>
                             </features>
                         </configuration>

--- a/modules/p2-profile/product/pom.xml
+++ b/modules/p2-profile/product/pom.xml
@@ -662,6 +662,9 @@
                                     org.wso2.carbon.identity.organization.management:org.wso2.carbon.identity.organization.management.server.feature:${identity.org.mgt.version}
                                 </featureArtifactDef>
                                 <featureArtifactDef>
+                                    org.wso2.carbon.identity.organization.management.core:org.wso2.carbon.identity.organization.management.core.server.feature:${identity.org.mgt.core.version}
+                                </featureArtifactDef>
+                                <featureArtifactDef>
                                     org.wso2.carbon.identity.outbound.auth.oidc:org.wso2.carbon.identity.application.authenticator.oidc.server.feature:${identity.outbound.auth.oidc.version}
                                 </featureArtifactDef>
                                 <featureArtifactDef>
@@ -904,6 +907,10 @@
                                 <feature>
                                     <id>org.wso2.carbon.identity.organization.management.server.feature.group</id>
                                     <version>${identity.org.mgt.version}</version>
+                                </feature>
+                                <feature>
+                                    <id>org.wso2.carbon.identity.organization.management.core.server.feature.group</id>
+                                    <version>${identity.org.mgt.core.version}</version>
                                 </feature>
                                 <feature>
                                     <id>org.wso2.carbon.identity.central.log.mgt.server.feature.group</id>

--- a/pom.xml
+++ b/pom.xml
@@ -1306,26 +1306,26 @@
         <carbon.mediation.version>4.7.180</carbon.mediation.version>
 
         <!-- carbon identity -->
-        <carbon.identity.version>5.24.10</carbon.identity.version>
-        <carbon.identity.governance.version>1.7.2</carbon.identity.governance.version>
-        <carbon.identity.event.handler.account.lock.version>1.7.1</carbon.identity.event.handler.account.lock.version>
-        <carbon.identity.event.handler.notification.version>1.6.0</carbon.identity.event.handler.notification.version>
-        <carbon.identity-inbound-auth-oauth.version>6.9.8</carbon.identity-inbound-auth-oauth.version>
-        <carbon.identity-data-publisher-oauth.version>1.5.1</carbon.identity-data-publisher-oauth.version>
-        <carbon.identity-user-ws.version>5.6.1</carbon.identity-user-ws.version>
-        <carbon.identity-inbound-auth-openid.version>5.8.0</carbon.identity-inbound-auth-openid.version>
-        <carbon.identity-local-auth-basicauth.version>6.6.0</carbon.identity-local-auth-basicauth.version>
-        <carbon.identity-outbound-auth-samlsso.version>5.6.2</carbon.identity-outbound-auth-samlsso.version>
-        <carbon.identity-metadata-saml2.version>1.6.1</carbon.identity-metadata-saml2.version>
-        <carbon.identity-data-publisher-application-authentication.version>5.5.1</carbon.identity-data-publisher-application-authentication.version>
-        <carbon.extension.identity.oauth2.grantType.jwt.version>2.1.1</carbon.extension.identity.oauth2.grantType.jwt.version>
-        <carbon.identity.carbon.auth.saml2.version>5.7.2</carbon.identity.carbon.auth.saml2.version>
-        <carbon.identity.auth.version>1.7.1</carbon.identity.auth.version>
-        <identity.apps.version>1.5.0</identity.apps.version>
-        <identity.oauth.addons.version>2.4.8</identity.oauth.addons.version>
+        <carbon.identity.version>5.25.92</carbon.identity.version>
+        <carbon.identity.governance.version>1.8.14</carbon.identity.governance.version>
+        <carbon.identity.event.handler.account.lock.version>1.8.6</carbon.identity.event.handler.account.lock.version>
+        <carbon.identity.event.handler.notification.version>1.6.2</carbon.identity.event.handler.notification.version>
+        <carbon.identity-inbound-auth-oauth.version>6.11.21</carbon.identity-inbound-auth-oauth.version>
+        <carbon.identity-data-publisher-oauth.version>1.6.2</carbon.identity-data-publisher-oauth.version>
+        <carbon.identity-user-ws.version>5.7.2</carbon.identity-user-ws.version>
+        <carbon.identity-inbound-auth-openid.version>5.9.0</carbon.identity-inbound-auth-openid.version>
+        <carbon.identity-local-auth-basicauth.version>6.7.8</carbon.identity-local-auth-basicauth.version>
+        <carbon.identity-outbound-auth-samlsso.version>5.8.1</carbon.identity-outbound-auth-samlsso.version>
+        <carbon.identity-metadata-saml2.version>1.7.2</carbon.identity-metadata-saml2.version>
+        <carbon.identity-data-publisher-application-authentication.version>5.6.6</carbon.identity-data-publisher-application-authentication.version>
+        <carbon.extension.identity.oauth2.grantType.jwt.version>2.2.0</carbon.extension.identity.oauth2.grantType.jwt.version>
+        <carbon.identity.carbon.auth.saml2.version>5.8.3</carbon.identity.carbon.auth.saml2.version>
+        <carbon.identity.auth.version>1.8.11</carbon.identity.auth.version>
+        <identity.apps.version>1.6.191</identity.apps.version>
+        <identity.oauth.addons.version>2.4.11</identity.oauth.addons.version>
 
         <!--SAML Common Utils Version-->
-        <saml.common.util.version>1.2.1</saml.common.util.version>
+        <saml.common.util.version>1.3.0</saml.common.util.version>
         <saml.common.util.version.range>[1.0.0,2.0.0)</saml.common.util.version.range>
 
         <!-- carbon deployment -->
@@ -1444,7 +1444,7 @@
         <!-- Forget-me tool -->
         <forgetme.tool.version>1.3.8</forgetme.tool.version>
         <!--Consent Management dependencies-->
-        <carbon.consent.mgt.version>2.4.1</carbon.consent.mgt.version>
+        <carbon.consent.mgt.version>2.5.0</carbon.consent.mgt.version>
         <carbon.database.utils.version>2.1.5</carbon.database.utils.version>
 
         <com.jayway.jsonpath.version>2.6.0.wso2v1</com.jayway.jsonpath.version>
@@ -1459,7 +1459,7 @@
         <config.mapper.version>1.0.2</config.mapper.version>
 
         <!-- Authenticator Properties -->
-        <identity.outbound.auth.oidc.version>5.9.0</identity.outbound.auth.oidc.version>
+        <identity.outbound.auth.oidc.version>5.11.5</identity.outbound.auth.oidc.version>
         <swagger-parser-version>2.0.14</swagger-parser-version>
         <nimbus.jwt.version>7.3.0.wso2v1</nimbus.jwt.version>
 
@@ -1487,12 +1487,12 @@
         <com.squareup.okhttp3.version>4.9.0</com.squareup.okhttp3.version>
         <io.gsonfire.version>1.8.3</io.gsonfire.version>
         <org.apache.oltu.oauth2.version>1.0.1</org.apache.oltu.oauth2.version>
-        <identity.org.mgt.version>1.2.1</identity.org.mgt.version>
+        <identity.org.mgt.version>1.3.22</identity.org.mgt.version>
         <identity.inbound.provisioning.scim2.version>3.1.1</identity.inbound.provisioning.scim2.version>
         <xmlsec.wso2.version>1.5.6-wso2v1</xmlsec.wso2.version>
         <xmlsec.version>2.3.0</xmlsec.version>
         <identity.user.workflow.version>5.6.0</identity.user.workflow.version>
-        <identity.carbon.auth.rest.version>1.4.9</identity.carbon.auth.rest.version>
+        <identity.carbon.auth.rest.version>1.8.11</identity.carbon.auth.rest.version>
     </properties>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1325,7 +1325,7 @@
         <carbon.identity-user-ws.version>5.7.2</carbon.identity-user-ws.version>
         <carbon.identity-inbound-auth-openid.version>5.9.0</carbon.identity-inbound-auth-openid.version>
         <carbon.identity-local-auth-basicauth.version>6.7.8</carbon.identity-local-auth-basicauth.version>
-        <carbon.identity-outbound-auth-samlsso.version>5.8.1</carbon.identity-outbound-auth-samlsso.version>
+        <carbon.identity-outbound-auth-samlsso.version>5.8.11</carbon.identity-outbound-auth-samlsso.version>
         <carbon.identity-metadata-saml2.version>1.7.2</carbon.identity-metadata-saml2.version>
         <carbon.identity-data-publisher-application-authentication.version>5.6.6</carbon.identity-data-publisher-application-authentication.version>
         <carbon.extension.identity.oauth2.grantType.jwt.version>2.2.0</carbon.extension.identity.oauth2.grantType.jwt.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1266,6 +1266,11 @@
                 <artifactId>xmlsec</artifactId>
                 <version>${xmlsec.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
+                <artifactId>org.wso2.carbon.identity.organization.management.core.server.feature</artifactId>
+                <version>${identity.org.mgt.core.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -1488,6 +1493,7 @@
         <io.gsonfire.version>1.8.3</io.gsonfire.version>
         <org.apache.oltu.oauth2.version>1.0.1</org.apache.oltu.oauth2.version>
         <identity.org.mgt.version>1.3.22</identity.org.mgt.version>
+        <identity.org.mgt.core.version>1.0.34</identity.org.mgt.core.version>
         <identity.inbound.provisioning.scim2.version>3.1.1</identity.inbound.provisioning.scim2.version>
         <xmlsec.wso2.version>1.5.6-wso2v1</xmlsec.wso2.version>
         <xmlsec.version>2.3.0</xmlsec.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1271,6 +1271,11 @@
                 <artifactId>org.wso2.carbon.identity.organization.management.core.server.feature</artifactId>
                 <version>${identity.org.mgt.core.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.branding.preference.management</groupId>
+                <artifactId>org.wso2.carbon.identity.branding.preference.management.core</artifactId>
+                <version>${identity.branding.preference.management.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -1499,6 +1504,9 @@
         <xmlsec.version>2.3.0</xmlsec.version>
         <identity.user.workflow.version>5.6.0</identity.user.workflow.version>
         <identity.carbon.auth.rest.version>1.8.11</identity.carbon.auth.rest.version>
+
+        <!-- Identity Branding Preference Management Versions -->
+        <identity.branding.preference.management.version>1.0.1</identity.branding.preference.management.version>
     </properties>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1309,7 +1309,7 @@
         <carbon.identity.version>5.25.92</carbon.identity.version>
         <carbon.identity.governance.version>1.8.14</carbon.identity.governance.version>
         <carbon.identity.event.handler.account.lock.version>1.8.6</carbon.identity.event.handler.account.lock.version>
-        <carbon.identity.event.handler.notification.version>1.6.2</carbon.identity.event.handler.notification.version>
+        <carbon.identity.event.handler.notification.version>1.7.7</carbon.identity.event.handler.notification.version>
         <carbon.identity-inbound-auth-oauth.version>6.11.21</carbon.identity-inbound-auth-oauth.version>
         <carbon.identity-data-publisher-oauth.version>1.6.2</carbon.identity-data-publisher-oauth.version>
         <carbon.identity-user-ws.version>5.7.2</carbon.identity-user-ws.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1331,7 +1331,7 @@
         <carbon.extension.identity.oauth2.grantType.jwt.version>2.2.0</carbon.extension.identity.oauth2.grantType.jwt.version>
         <carbon.identity.carbon.auth.saml2.version>5.8.3</carbon.identity.carbon.auth.saml2.version>
         <carbon.identity.auth.version>1.8.11</carbon.identity.auth.version>
-        <identity.apps.version>1.6.191</identity.apps.version>
+        <identity.apps.version>1.5.0</identity.apps.version>
         <identity.oauth.addons.version>2.4.11</identity.oauth.addons.version>
 
         <!--SAML Common Utils Version-->

--- a/pom.xml
+++ b/pom.xml
@@ -1294,7 +1294,7 @@
         <carbon.governance.version>4.8.30</carbon.governance.version>
 
         <!--carbon versions-->
-        <carbon.kernel.version>4.8.1</carbon.kernel.version>
+        <carbon.kernel.version>4.9.0</carbon.kernel.version>
         <apimserver.version>4.3.0-SNAPSHOT</apimserver.version>
 
         <cipher.tool.version>1.1.20</cipher.tool.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1291,7 +1291,7 @@
 
         <!-- APIM Component Version -->
 
-        <carbon.apimgt.version>9.29.10</carbon.apimgt.version>
+        <carbon.apimgt.version>9.29.11-SNAPSHOT</carbon.apimgt.version>
 
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1304,7 +1304,7 @@
         <carbon.governance.version>4.8.30</carbon.governance.version>
 
         <!--carbon versions-->
-        <carbon.kernel.version>4.9.0</carbon.kernel.version>
+        <carbon.kernel.version>4.9.26-alpha</carbon.kernel.version>
         <apimserver.version>4.3.0-SNAPSHOT</apimserver.version>
 
         <cipher.tool.version>1.1.20</cipher.tool.version>


### PR DESCRIPTION
- Upgrades kernel version to 4.9.26.alpha and IS components to IS 6.1 compatible versions
- Adds `org.wso2.carbon.identity.organization.management.core.server.feature` and `identity.branding.preference.management feature` to solve p2-profile-gen issues

- Related carbon-apimgt PR : https://github.com/wso2/carbon-apimgt/pull/12243