### PR TITLE
[4.3.0-kernel-upgrade] Upgrade xmlsec dependency version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1500,7 +1500,7 @@
         <identity.org.mgt.core.version>1.0.99</identity.org.mgt.core.version>
         <identity.inbound.provisioning.scim2.version>3.1.1</identity.inbound.provisioning.scim2.version>
         <xmlsec.wso2.version>1.5.6-wso2v1</xmlsec.wso2.version>
-        <xmlsec.version>2.3.0</xmlsec.version>
+        <xmlsec.version>2.3.4</xmlsec.version>
         <identity.user.workflow.version>5.6.0</identity.user.workflow.version>
         <identity.carbon.auth.rest.version>1.8.40</identity.carbon.auth.rest.version>
 


### PR DESCRIPTION
### Purpose

Upgrade the xmlsec dependency version to the latest non-vulnerable version in 2.3 versions: 2.3.4 and the `carbon.identity-metadata-saml2.version` and `carbon.messaging.version` versions changed accordingly to build the APIM product successfully.