### PR TITLE
json smart and json path bump

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1284,7 +1284,7 @@
 
         <project.scm.id>scm-server</project.scm.id>
 
-        <carbon.analytics.common.version>5.3.7</carbon.analytics.common.version>
+        <carbon.analytics.common.version>5.3.8</carbon.analytics.common.version>
 
         <!-- APIM Portals Component Version -->
         <carbon.apimgt.ui.version>9.0.494</carbon.apimgt.ui.version>
@@ -1314,7 +1314,7 @@
         <carbon.kernel.imp.pkg.version>[4.5.0, 5.0.0)</carbon.kernel.imp.pkg.version>
 
         <!-- carbon mediation -->
-        <carbon.mediation.version>4.7.189</carbon.mediation.version>
+        <carbon.mediation.version>4.7.191</carbon.mediation.version>
 
         <!-- carbon identity -->
         <carbon.identity.version>5.25.690</carbon.identity.version>
@@ -1324,7 +1324,7 @@
         <carbon.identity-inbound-auth-oauth.version>6.13.4</carbon.identity-inbound-auth-oauth.version>
         <carbon.identity-data-publisher-oauth.version>1.6.10</carbon.identity-data-publisher-oauth.version>
         <carbon.identity-user-ws.version>5.7.5</carbon.identity-user-ws.version>
-        <carbon.identity-inbound-auth-openid.version>5.9.7</carbon.identity-inbound-auth-openid.version>
+        <carbon.identity-inbound-auth-openid.version>5.9.8</carbon.identity-inbound-auth-openid.version>
         <carbon.identity-local-auth-basicauth.version>6.7.32</carbon.identity-local-auth-basicauth.version>
         <carbon.identity-outbound-auth-samlsso.version>5.8.11</carbon.identity-outbound-auth-samlsso.version>
         <carbon.identity-metadata-saml2.version>1.7.70</carbon.identity-metadata-saml2.version>
@@ -1357,7 +1357,7 @@
         <opencsv.version>1.8</opencsv.version>
         <poi.version>3.0-FINAL</poi.version>
         <woden.version>1.0.0.M8-wso2v1</woden.version>
-        <synapse.version>4.0.0-wso2v77</synapse.version>
+        <synapse.version>4.0.0-wso2v82</synapse.version>
         <passthru.transport.patch.version>1.0.2</passthru.transport.patch.version>
         <axis2.wso2.version>1.6.1-wso2v85</axis2.wso2.version>
         <axiom.wso2.version>1.2.11-wso2v25</axiom.wso2.version>
@@ -1456,7 +1456,7 @@
         <carbon.consent.mgt.version>2.5.3</carbon.consent.mgt.version>
         <carbon.database.utils.version>2.1.5</carbon.database.utils.version>
 
-        <com.jayway.jsonpath.version>2.6.0.wso2v1</com.jayway.jsonpath.version>
+        <com.jayway.jsonpath.version>2.9.0.wso2v1</com.jayway.jsonpath.version>
         <!-- xml testing library -->
         <xml.unit.verions>2.6.2</xml.unit.verions>
         <version.cava-toml>0.5.0</version.cava-toml>


### PR DESCRIPTION
### Purpose
Bump json-smart, json-path and related repositories,

jsonpath : 2.9.0.wso2v1
synapse : 4.0.0-wso2v82
analytics.common : 5.3.8
carbon.mediation : 4.7.191
identity-inbound-auth-openid: 5.9.8
### Need to bump carbon.apimgt version too.