### PR TITLE
Add json-smart as a test dependency to fix a CNF

### DIFF
--- a/modules/integration/tests-integration/tests-backend/pom.xml
+++ b/modules/integration/tests-integration/tests-backend/pom.xml
@@ -807,6 +807,11 @@ under the License.
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>net.minidev</groupId>
+            <artifactId>json-smart</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.am</groupId>
             <artifactId>org.wso2.am.integration.clients.internal.api</artifactId>
             <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -1215,6 +1215,11 @@
                 <version>${nimbus.jwt.version}</version>
             </dependency>
             <dependency>
+                <groupId>net.minidev</groupId>
+                <artifactId>json-smart</artifactId>
+                <version>${json-smart.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.am.integration.clients.publisher.api</artifactId>
                 <version>${apimserver.version}</version>
@@ -1471,6 +1476,7 @@
         <identity.outbound.auth.oidc.version>5.11.32</identity.outbound.auth.oidc.version>
         <swagger-parser-version>2.0.14</swagger-parser-version>
         <nimbus.jwt.version>7.3.0.wso2v1</nimbus.jwt.version>
+        <json-smart.version>2.5.0</json-smart.version>
 
         <!-- CallHome version -->
         <callhome.version>4.5.x_1.0.15</callhome.version>


### PR DESCRIPTION
Fixes below issue in integration tests.
```
Caused by: java.lang.ClassNotFoundException: net.minidev.json.JSONAware
	at org.wso2.am.integration.tests.api.lifecycle.APISecurityTestCase.testInvokeJWTUserToken(APISecurityTestCase.java:1090)
```