### PR TITLE
Fix startup issue with Gateway profile

### DIFF
--- a/modules/distribution/product/src/main/resources/conf/default.json
+++ b/modules/distribution/product/src/main/resources/conf/default.json
@@ -9,7 +9,7 @@
   "server.send_stacktrace_details_with_faults": false,
   "server.drill_down_to_root_cause_for_fault_reason": false,
   "identity.data_source": "jdbc/WSO2AM_DB",
-  "database.apim_db.url": "jdbc:h2:./repository/database/WSO2AM_DB;DB_CLOSE_ON_EXIT=FALSE;AUTO_SERVER=TRUE;LOCK_TIMEOUT=60000",
+  "database.apim_db.url": "jdbc:h2:./repository/database/WSO2AM_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000",
   "database.apim_db.driver": "org.h2.Driver",
   "database.mb.store_db.url": "jdbc:h2:./repository/database/WSO2MB_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000",
   "database.mb.store_db.driver": "org.h2.Driver",


### PR DESCRIPTION
This fixes the startup issue in Gateway caused by unsupported h2 url parameters.