### PR TITLE
Change the tests to call product APIs with JWT

### DIFF
--- a/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/ClientAuthenticator.java
+++ b/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/ClientAuthenticator.java
@@ -136,6 +136,7 @@ public class ClientAuthenticator {
             json.addProperty("grantType", dcrParamRequest.getGrantType());
             json.addProperty("saasApp", true);
             json.addProperty("tokenType", "JWT");
+            json.addProperty("userStoreDomainInSubject", true);
 
             String clientEncoded;
 

--- a/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/ClientAuthenticator.java
+++ b/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/ClientAuthenticator.java
@@ -135,6 +135,7 @@ public class ClientAuthenticator {
             json.addProperty("tokenScope", dcrParamRequest.getTokenScope());
             json.addProperty("grantType", dcrParamRequest.getGrantType());
             json.addProperty("saasApp", true);
+            json.addProperty("tokenType", "JWT");
 
             String clientEncoded;
 


### PR DESCRIPTION
As a part of supporting JWT for portal logins in https://github.com/wso2/api-manager/issues/2496 change the integration test tokens to JWT