### PR TITLE
Bump pax-logging version to 2.2.1-wso2v2

### DIFF
--- a/modules/integration/tests-common/backend-service/monitor-app/pom.xml
+++ b/modules/integration/tests-common/backend-service/monitor-app/pom.xml
@@ -49,7 +49,7 @@ under the License.
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/modules/integration/tests-common/backend-service/monitor-app/war/META-INF/maven/ArtifactDeploymentMonitor/ArtifactDeploymentMonitor/pom.xml
+++ b/modules/integration/tests-common/backend-service/monitor-app/war/META-INF/maven/ArtifactDeploymentMonitor/ArtifactDeploymentMonitor/pom.xml
@@ -59,7 +59,7 @@ under the License.
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/modules/integration/tests-integration/tests-backend/pom.xml
+++ b/modules/integration/tests-integration/tests-backend/pom.xml
@@ -151,7 +151,7 @@ under the License.
                             </environmentVariables>
                             <workingDirectory>${basedir}/target</workingDirectory>
                             <classpathDependencyExcludes>
-                                <classpathDependencyExclude>org.ops4j.pax.logging</classpathDependencyExclude>
+                                <classpathDependencyExclude>org.wso2.org.ops4j.pax.logging</classpathDependencyExclude>
                             </classpathDependencyExcludes>
                             <systemPropertyVariables>
                                 <okHttpLogs>false</okHttpLogs>
@@ -250,7 +250,7 @@ under the License.
                             </systemProperties>
                             <workingDirectory>${basedir}/target</workingDirectory>
                             <classpathDependencyExcludes>
-                                <classpathDependencyExclude>org.ops4j.pax.logging</classpathDependencyExclude>
+                                <classpathDependencyExclude>org.wso2.org.ops4j.pax.logging</classpathDependencyExclude>
                             </classpathDependencyExcludes>
                             <systemPropertyVariables>
                                 <okHttpLogs>false</okHttpLogs>
@@ -357,7 +357,7 @@ under the License.
                             </systemPropertyVariables>
                             <workingDirectory>${basedir}/target</workingDirectory>
                             <classpathDependencyExcludes>
-                                <classpathDependencyExclude>org.ops4j.pax.logging</classpathDependencyExclude>
+                                <classpathDependencyExclude>org.wso2.org.ops4j.pax.logging</classpathDependencyExclude>
                             </classpathDependencyExcludes>
                         </configuration>
                     </plugin>
@@ -565,7 +565,7 @@ under the License.
                     <artifactId>pax-logging-api</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>org.ops4j.pax.logging</groupId>
+                    <groupId>org.wso2.org.ops4j.pax.logging</groupId>
                     <artifactId>pax-logging-api</artifactId>
                 </exclusion>
                 <exclusion>
@@ -599,11 +599,11 @@ under the License.
                     <artifactId>jcl-over-slf4j</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>org.ops4j.pax.logging</groupId>
+                    <groupId>org.wso2.org.ops4j.pax.logging</groupId>
                     <artifactId>pax-logging-api</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>org.ops4j.pax.logging</groupId>
+                    <groupId>org.wso2.org.ops4j.pax.logging</groupId>
                     <artifactId>pax-logging-log4j2</artifactId>
                 </exclusion>
                 <exclusion>
@@ -837,7 +837,7 @@ under the License.
                     <artifactId>pax-logging-api</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>org.ops4j.pax.logging</groupId>
+                    <groupId>org.wso2.org.ops4j.pax.logging</groupId>
                     <artifactId>pax-logging-api</artifactId>
                 </exclusion>
                 <exclusion>

--- a/modules/integration/tests-integration/tests-benchmark/pom.xml
+++ b/modules/integration/tests-integration/tests-benchmark/pom.xml
@@ -133,7 +133,7 @@ under the License.
                             </environmentVariables>
                             <workingDirectory>${basedir}/target</workingDirectory>
                             <classpathDependencyExcludes>
-                                <classpathDependencyExclude>org.ops4j.pax.logging</classpathDependencyExclude>
+                                <classpathDependencyExclude>org.wso2.org.ops4j.pax.logging</classpathDependencyExclude>
                             </classpathDependencyExcludes>
                             <systemPropertyVariables>
                                 <okHttpLogs>true</okHttpLogs>
@@ -254,7 +254,7 @@ under the License.
                             <skipTests>${skipBenchMarkTest}</skipTests>
                             <workingDirectory>${basedir}/target</workingDirectory>
                             <classpathDependencyExcludes>
-                                <classpathDependencyExclude>org.ops4j.pax.logging</classpathDependencyExclude>
+                                <classpathDependencyExclude>org.wso2.org.ops4j.pax.logging</classpathDependencyExclude>
                             </classpathDependencyExcludes>
                             <systemPropertyVariables>
                                 <okHttpLogs>true</okHttpLogs>
@@ -354,7 +354,7 @@ under the License.
                             </systemPropertyVariables>
                             <workingDirectory>${basedir}/target</workingDirectory>
                             <classpathDependencyExcludes>
-                                <classpathDependencyExclude>org.ops4j.pax.logging</classpathDependencyExclude>
+                                <classpathDependencyExclude>org.wso2.org.ops4j.pax.logging</classpathDependencyExclude>
                             </classpathDependencyExcludes>
                         </configuration>
                     </plugin>
@@ -409,11 +409,11 @@ under the License.
                     <artifactId>jcl-over-slf4j</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>org.ops4j.pax.logging</groupId>
+                    <groupId>org.wso2.org.ops4j.pax.logging</groupId>
                     <artifactId>pax-logging-api</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>org.ops4j.pax.logging</groupId>
+                    <groupId>org.wso2.org.ops4j.pax.logging</groupId>
                     <artifactId>pax-logging-log4j2</artifactId>
                 </exclusion>
                 <exclusion>

--- a/modules/integration/tests-integration/tests-restart/pom.xml
+++ b/modules/integration/tests-integration/tests-restart/pom.xml
@@ -151,7 +151,7 @@ under the License.
                             </environmentVariables>
                             <workingDirectory>${basedir}/target</workingDirectory>
                             <classpathDependencyExcludes>
-                                <classpathDependencyExclude>org.ops4j.pax.logging</classpathDependencyExclude>
+                                <classpathDependencyExclude>org.wso2.org.ops4j.pax.logging</classpathDependencyExclude>
                             </classpathDependencyExcludes>
                             <systemPropertyVariables>
                                 <okHttpLogs>false</okHttpLogs>
@@ -250,7 +250,7 @@ under the License.
                             </systemProperties>
                             <workingDirectory>${basedir}/target</workingDirectory>
                             <classpathDependencyExcludes>
-                                <classpathDependencyExclude>org.ops4j.pax.logging</classpathDependencyExclude>
+                                <classpathDependencyExclude>org.wso2.org.ops4j.pax.logging</classpathDependencyExclude>
                             </classpathDependencyExcludes>
                             <systemPropertyVariables>
                                 <okHttpLogs>false</okHttpLogs>
@@ -357,7 +357,7 @@ under the License.
                             </systemPropertyVariables>
                             <workingDirectory>${basedir}/target</workingDirectory>
                             <classpathDependencyExcludes>
-                                <classpathDependencyExclude>org.ops4j.pax.logging</classpathDependencyExclude>
+                                <classpathDependencyExclude>org.wso2.org.ops4j.pax.logging</classpathDependencyExclude>
                             </classpathDependencyExcludes>
                         </configuration>
                     </plugin>
@@ -565,7 +565,7 @@ under the License.
                     <artifactId>pax-logging-api</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>org.ops4j.pax.logging</groupId>
+                    <groupId>org.wso2.org.ops4j.pax.logging</groupId>
                     <artifactId>pax-logging-api</artifactId>
                 </exclusion>
                 <exclusion>
@@ -599,11 +599,11 @@ under the License.
                     <artifactId>jcl-over-slf4j</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>org.ops4j.pax.logging</groupId>
+                    <groupId>org.wso2.org.ops4j.pax.logging</groupId>
                     <artifactId>pax-logging-api</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>org.ops4j.pax.logging</groupId>
+                    <groupId>org.wso2.org.ops4j.pax.logging</groupId>
                     <artifactId>pax-logging-log4j2</artifactId>
                 </exclusion>
                 <exclusion>
@@ -827,7 +827,7 @@ under the License.
                     <artifactId>pax-logging-api</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>org.ops4j.pax.logging</groupId>
+                    <groupId>org.wso2.org.ops4j.pax.logging</groupId>
                     <artifactId>pax-logging-api</artifactId>
                 </exclusion>
                 <exclusion>

--- a/modules/styles/product/pom.xml
+++ b/modules/styles/product/pom.xml
@@ -86,7 +86,7 @@
             <artifactId>org.apache.felix.framework</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -348,7 +348,7 @@
                 <version>${carbon.kernel.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.ops4j.pax.logging</groupId>
+                <groupId>org.wso2.org.ops4j.pax.logging</groupId>
                 <artifactId>pax-logging-api</artifactId>
                 <version>${versions.pax.logging}</version>
             </dependency>
@@ -1467,7 +1467,7 @@
 
         <!-- API Import/Export Dependencies -->
         <com.fasterxml.jackson.dataformat.version>2.16.1</com.fasterxml.jackson.dataformat.version>
-        <versions.pax.logging>2.1.0</versions.pax.logging>
+        <versions.pax.logging>2.2.1-wso2v2</versions.pax.logging>
         <config.mapper.version>1.0.2</config.mapper.version>
 
         <!-- Authenticator Properties -->

--- a/sample-scenarios/sample-utils/pom.xml
+++ b/sample-scenarios/sample-utils/pom.xml
@@ -49,7 +49,7 @@
             <artifactId>log4j</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ops4j.pax.logging</groupId>
+            <groupId>org.wso2.org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Purpose

This PR bumps the pax-logging version to 2.2.1-wso2v2.