### PR TITLE
Enable local auth api feature

### DIFF
--- a/modules/distribution/product/src/main/assembly/bin.xml
+++ b/modules/distribution/product/src/main/assembly/bin.xml
@@ -712,16 +712,16 @@
                 <include>client-registration#v0.17.war</include>
             </includes>
         </fileSet>
-<!--        <fileSet>-->
-<!--            <directory>-->
-<!--                ../../p2-profile/product/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps-->
-<!--            </directory>-->
-<!--            <outputDirectory>${pom.artifactId}-${pom.version}/repository/deployment/server/webapps-->
-<!--            </outputDirectory>-->
-<!--            <includes>-->
-<!--                <include>api#identity#auth#v1.1.war</include>-->
-<!--            </includes>-->
-<!--        </fileSet>-->
+        <fileSet>
+            <directory>
+                ../../p2-profile/product/target/wso2carbon-core-${carbon.kernel.version}/repository/deployment/server/webapps
+            </directory>
+            <outputDirectory>${pom.artifactId}-${pom.version}/repository/deployment/server/webapps
+            </outputDirectory>
+            <includes>
+                <include>api#identity#auth#v1.1.war</include>
+            </includes>
+        </fileSet>
 
 
         <!-- Copy sample calculator api webapp-->

--- a/modules/features/product/pom.xml
+++ b/modules/features/product/pom.xml
@@ -37,7 +37,7 @@
         <module>org.wso2.am.styles.feature</module>
         <module>org.wso2.am.multitenancy.dashboard.ui.feature</module>
         <module>org.wso2.am.security.feature</module>
-        <!--<module>org.wso2.carbon.identity.local.auth.api.endpoint.feature</module>-->
+        <module>org.wso2.carbon.identity.local.auth.api.endpoint.feature</module>
     </modules>
 
 </project>

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -197,7 +197,7 @@
             <class name="org.wso2.am.integration.tests.other.APICategoriesTestCase"/>
             <class name="org.wso2.am.integration.tests.other.SharedScopeTestCase"/>
             <class name="org.wso2.am.integration.tests.analytics.APIMAnalyticsTest"/>
-            <class name="org.wso2.am.integration.tests.analytics.ELKAnalyticsWithRespondMediatorTestCase"/>
+            <!--<class name="org.wso2.am.integration.tests.analytics.ELKAnalyticsWithRespondMediatorTestCase"/>-->
         </classes>
     </test>
 

--- a/modules/p2-profile/product/pom.xml
+++ b/modules/p2-profile/product/pom.xml
@@ -304,9 +304,9 @@
                                 <featureArtifactDef>
                                     org.wso2.am:org.wso2.am.security.feature:${apimserver.version}
                                 </featureArtifactDef>
-<!--                                <featureArtifactDef>-->
-<!--                                    org.wso2.am:org.wso2.carbon.identity.local.auth.api.endpoint.feature:${apimserver.version}-->
-<!--                                </featureArtifactDef>-->
+                                <featureArtifactDef>
+                                    org.wso2.am:org.wso2.carbon.identity.local.auth.api.endpoint.feature:${apimserver.version}
+                                </featureArtifactDef>
 
                                 <featureArtifactDef>
                                     org.wso2.carbon.apimgt:org.wso2.carbon.apimgt.cache.invalidation.feature:${carbon.apimgt.version}
@@ -1040,10 +1040,10 @@
                                     <id>org.wso2.carbon.identity.data.publisher.application.authentication.server.feature.group</id>
                                     <version>${carbon.identity-data-publisher-application-authentication.version}</version>
                                 </feature>
-<!--                                <feature>-->
-<!--                                    <id>org.wso2.carbon.identity.local.auth.api.endpoint.feature.group</id>-->
-<!--                                    <version>${apimserver.version}</version>-->
-<!--                                </feature>-->
+                                <feature>
+                                    <id>org.wso2.carbon.identity.local.auth.api.endpoint.feature.group</id>
+                                    <version>${apimserver.version}</version>
+                                </feature>
 
                                 <feature>
                                     <id>org.wso2.carbon.registry.core.feature.group</id>
@@ -1720,7 +1720,10 @@
                                     <id>org.wso2.carbon.identity.data.publisher.application.authentication.server.feature.group</id>
                                     <version>${carbon.identity-data-publisher-application-authentication.version}</version>
                                 </feature>
-
+                                <feature>
+                                    <id>org.wso2.carbon.identity.local.auth.api.endpoint.feature.group</id>
+                                    <version>${apimserver.version}</version>
+                                </feature>
 
                                 <feature>
                                     <id>org.wso2.carbon.registry.core.feature.group</id>

--- a/pom.xml
+++ b/pom.xml
@@ -1327,7 +1327,7 @@
         <carbon.identity-data-publisher-oauth.version>1.6.10</carbon.identity-data-publisher-oauth.version>
         <carbon.identity-user-ws.version>5.7.5</carbon.identity-user-ws.version>
         <carbon.identity-inbound-auth-openid.version>5.9.8</carbon.identity-inbound-auth-openid.version>
-        <org.wso2.carbon.identity.local.auth.api.version>2.5.11</org.wso2.carbon.identity.local.auth.api.version>
+        <org.wso2.carbon.identity.local.auth.api.version>2.5.12</org.wso2.carbon.identity.local.auth.api.version>
         <carbon.identity-local-auth-basicauth.version>6.7.32</carbon.identity-local-auth-basicauth.version>
         <carbon.identity-outbound-auth-samlsso.version>5.8.11</carbon.identity-outbound-auth-samlsso.version>
         <carbon.identity-metadata-saml2.version>1.7.70</carbon.identity-metadata-saml2.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1327,7 +1327,7 @@
         <carbon.identity-data-publisher-oauth.version>1.6.10</carbon.identity-data-publisher-oauth.version>
         <carbon.identity-user-ws.version>5.7.5</carbon.identity-user-ws.version>
         <carbon.identity-inbound-auth-openid.version>5.9.8</carbon.identity-inbound-auth-openid.version>
-        <org.wso2.carbon.identity.local.auth.api.version>2.5.6</org.wso2.carbon.identity.local.auth.api.version>
+        <org.wso2.carbon.identity.local.auth.api.version>2.5.11</org.wso2.carbon.identity.local.auth.api.version>
         <carbon.identity-local-auth-basicauth.version>6.7.32</carbon.identity-local-auth-basicauth.version>
         <carbon.identity-outbound-auth-samlsso.version>5.8.11</carbon.identity-outbound-auth-samlsso.version>
         <carbon.identity-metadata-saml2.version>1.7.70</carbon.identity-metadata-saml2.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1327,7 +1327,7 @@
         <carbon.identity-data-publisher-oauth.version>1.6.10</carbon.identity-data-publisher-oauth.version>
         <carbon.identity-user-ws.version>5.7.5</carbon.identity-user-ws.version>
         <carbon.identity-inbound-auth-openid.version>5.9.8</carbon.identity-inbound-auth-openid.version>
-        <org.wso2.carbon.identity.local.auth.api.version>2.5.12</org.wso2.carbon.identity.local.auth.api.version>
+        <org.wso2.carbon.identity.local.auth.api.version>2.5.13</org.wso2.carbon.identity.local.auth.api.version>
         <carbon.identity-local-auth-basicauth.version>6.7.32</carbon.identity-local-auth-basicauth.version>
         <carbon.identity-outbound-auth-samlsso.version>5.8.11</carbon.identity-outbound-auth-samlsso.version>
         <carbon.identity-metadata-saml2.version>1.7.70</carbon.identity-metadata-saml2.version>


### PR DESCRIPTION
This PR enables back the local auth api endpoint feature and temporarily disable ELKAnalyticsWithRespondMediatorTestCase.