### PR TITLE
Add default configuration for AI features

### DIFF
--- a/modules/distribution/product/src/main/conf/deployment.toml
+++ b/modules/distribution/product/src/main/conf/deployment.toml
@@ -102,6 +102,11 @@ gateway_labels =["Default"]
 enable = false
 auth_token = ""
 
+[apim.ai]
+enable = true
+auth_token = ""
+endpoint = "http://localhost:9090"
+
 [apim.key_manager]
 enable_apikey_subscription_validation = true
 #service_url = "https://localhost:${mgt.transport.https.port}/services/"

--- a/modules/distribution/product/src/main/conf/deployment.toml
+++ b/modules/distribution/product/src/main/conf/deployment.toml
@@ -104,7 +104,7 @@ auth_token = ""
 
 [apim.ai]
 enable = true
-auth_token = ""
+token = ""
 endpoint = "http://localhost:9090"
 
 [apim.key_manager]

--- a/pom.xml
+++ b/pom.xml
@@ -1279,10 +1279,10 @@
         <carbon.analytics.common.version>5.3.11</carbon.analytics.common.version>
 
         <!-- APIM Portals Component Version -->
-        <carbon.apimgt.ui.version>9.1.23</carbon.apimgt.ui.version>
+        <carbon.apimgt.ui.version>9.1.29</carbon.apimgt.ui.version>
 
         <!-- APIM Component Version -->
-        <carbon.apimgt.version>9.29.74</carbon.apimgt.version>
+        <carbon.apimgt.version>9.29.77</carbon.apimgt.version>
 
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 


### PR DESCRIPTION
## Purpose

With this PR, a default configuration is added to `deployment.toml` for AI feature usage (API Chat and Marketplace Assistant).

```toml
[apim.ai]
enable = true
token = "<on-prem key>"
endpoint="http://localhost:9090"

```

#### Related PRs:

- Carbon PR: https://github.com/wso2/carbon-apimgt/pull/12347
- UI PR: https://github.com/wso2/apim-apps/pull/614