### PR TITLE
Re enable commented out test cases

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -187,7 +187,7 @@
             <class name="org.wso2.am.integration.tests.header.ESBJAVA3447PreserveCharsetInContentTypeTestCase"/>
             <!--class name="org.wso2.am.integration.tests.header.ESBJAVA5121CheckAuthHeaderOrderTestCase"/-->
             <!--<class name="org.wso2.am.integration.tests.other.APIEndpointTypeUpdateTestCase"/>-->
-            <!--<class name="org.wso2.am.integration.tests.other.APIImportExportTestCase"/>-->
+            <class name="org.wso2.am.integration.tests.other.APIImportExportTestCase"/>
             <class name="org.wso2.am.integration.tests.other.SOAPAPIImportExportTestCase"/>
             <class name="org.wso2.am.integration.tests.other.WSDLImportTestCase"/>
             <class name="org.wso2.am.integration.tests.other.SoapToRestTestCase"/>
@@ -198,7 +198,7 @@
             <class name="org.wso2.am.integration.tests.other.APICategoriesTestCase"/>
             <class name="org.wso2.am.integration.tests.other.SharedScopeTestCase"/>
             <class name="org.wso2.am.integration.tests.analytics.APIMAnalyticsTest"/>
-            <!--<class name="org.wso2.am.integration.tests.analytics.ELKAnalyticsWithRespondMediatorTestCase"/>-->
+            <class name="org.wso2.am.integration.tests.analytics.ELKAnalyticsWithRespondMediatorTestCase"/>
         </classes>
     </test>
 


### PR DESCRIPTION
This PR re enables the commented out test cases `APIImportExportTestCase` and `ELKAnalyticsWithRespondMediatorTestCase`

**References :** 
1. https://github.com/wso2/product-apim/pull/13405
2. https://github.com/wso2/product-apim/pull/13401