### PR TITLE
Bump apim-apps version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1279,7 +1279,7 @@
         <carbon.analytics.common.version>5.3.11</carbon.analytics.common.version>
 
         <!-- APIM Portals Component Version -->
-        <carbon.apimgt.ui.version>9.1.29</carbon.apimgt.ui.version>
+        <carbon.apimgt.ui.version>9.1.30</carbon.apimgt.ui.version>
 
         <!-- APIM Component Version -->
         <carbon.apimgt.version>9.29.80</carbon.apimgt.version>


### PR DESCRIPTION
### Purpose

Bumps the apim-apps version so that the changes done via [1] is available in latest pack.

1. https://github.com/wso2/apim-apps/pull/631