### PR TITLE
Add Config Values for Enable SHA-256 Hashing Algorithm

### DIFF
--- a/modules/distribution/product/src/main/conf/deployment.toml
+++ b/modules/distribution/product/src/main/conf/deployment.toml
@@ -134,6 +134,7 @@ enable_apikey_subscription_validation = true
 #signing_algorithm = "SHA256withRSA"
 #enable_user_claims = true
 #claims_extractor_impl = "org.wso2.carbon.apimgt.impl.token.ExtendedDefaultClaimsRetriever"
+#use_sha1_hash = false
 
 #[apim.oauth_config]
 #enable_outbound_auth_header = false

--- a/modules/distribution/product/src/main/conf/deployment.toml
+++ b/modules/distribution/product/src/main/conf/deployment.toml
@@ -134,7 +134,7 @@ enable_apikey_subscription_validation = true
 #signing_algorithm = "SHA256withRSA"
 #enable_user_claims = true
 #claims_extractor_impl = "org.wso2.carbon.apimgt.impl.token.ExtendedDefaultClaimsRetriever"
-#use_sha1_hash = false
+#use_sha256_hash = false
 
 #[apim.oauth_config]
 #enable_outbound_auth_header = false

--- a/modules/distribution/product/src/main/resources/conf/default.json
+++ b/modules/distribution/product/src/main/resources/conf/default.json
@@ -480,7 +480,7 @@
   "apim.analytics.properties.truststore_password": "$ref{truststore.password}",
   "tenant_mgt.disable_email_domain_validation": true,
   "apim.jwt.use_kid_property": true,
-  "apim.jwt.use_sha1_hash": false,
+  "apim.jwt.use_sha256_hash": false,
   "server_configuration": {
     "deployment_toml_path": "../conf/deployment.toml",
     "logs_directory": "../repository/logs",

--- a/modules/distribution/product/src/main/resources/conf/default.json
+++ b/modules/distribution/product/src/main/resources/conf/default.json
@@ -480,6 +480,7 @@
   "apim.analytics.properties.truststore_password": "$ref{truststore.password}",
   "tenant_mgt.disable_email_domain_validation": true,
   "apim.jwt.use_kid_property": true,
+  "apim.jwt.use_sha1_hash": false,
   "server_configuration": {
     "deployment_toml_path": "../conf/deployment.toml",
     "logs_directory": "../repository/logs",


### PR DESCRIPTION
### Purpose
With [1] and [2], the support for SHA-256 was given for certificate hashing algorithm in backend JWT generation. To enable this support, a config was provided. This PR provides the default value for the config and add this config to the deployment.toml by commenting its value

[1] https://github.com/wso2/carbon-apimgt/pull/12365
[2] https://github.com/wso2/carbon-apimgt/pull/12387