### PR TITLE
Remove unused UIs from carbon console

### DIFF
--- a/modules/distribution/product/src/main/resources/conf/default.json
+++ b/modules/distribution/product/src/main/resources/conf/default.json
@@ -294,7 +294,9 @@
     "claim_mgt_menu",
     "identity_mgt_emailtemplate_menu",
     "identity_security_questions_menu",
-    "metrics_menu"
+    "metrics_menu",
+    "new_datasource_menu",
+    "shutdown_restart_menu"
   ],
     "error_page.code_400.location": "/carbon/errors/error_400.html",
     "error_page.code_401.location": "/carbon/errors/error_401.html",

--- a/modules/p2-profile/product/pom.xml
+++ b/modules/p2-profile/product/pom.xml
@@ -322,9 +322,6 @@
                                 <featureArtifactDef>
                                     org.wso2.carbon.registry:org.wso2.carbon.registry.ws.feature:${carbon.registry.version}
                                 </featureArtifactDef>
-                                <featureArtifactDef>
-                                    org.wso2.carbon.registry:org.wso2.carbon.registry.ui.menu.governance.feature:${carbon.registry.version}
-                                </featureArtifactDef>
 
                                 <!--Governance Feature-->
                                 <featureArtifactDef>
@@ -1030,7 +1027,7 @@
                                     <version>${carbon.identity.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.identity.functions.library.mgt.feature.group</id>
+                                    <id>org.wso2.carbon.identity.functions.library.mgt.server.feature.group</id>
                                     <version>${carbon.identity.version}</version>
                                 </feature>
                                 <feature>
@@ -1060,10 +1057,6 @@
                                 </feature>
                                 <feature>
                                     <id>org.wso2.carbon.registry.ui.menu.feature.group</id>
-                                    <version>${carbon.registry.version}</version>
-                                </feature>
-                                <feature>
-                                    <id>org.wso2.carbon.registry.ui.menu.governance.feature.group</id>
                                     <version>${carbon.registry.version}</version>
                                 </feature>
                                 <feature>
@@ -1706,7 +1699,7 @@
                                     <version>${carbon.identity.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.identity.functions.library.mgt.feature.group</id>
+                                    <id>org.wso2.carbon.identity.functions.library.mgt.server.feature.group</id>
                                     <version>${carbon.identity.version}</version>
                                 </feature>
                                 <feature>
@@ -1736,10 +1729,6 @@
                                 </feature>
                                 <feature>
                                     <id>org.wso2.carbon.registry.ui.menu.feature.group</id>
-                                    <version>${carbon.registry.version}</version>
-                                </feature>
-                                <feature>
-                                    <id>org.wso2.carbon.registry.ui.menu.governance.feature.group</id>
                                     <version>${carbon.registry.version}</version>
                                 </feature>
                                 <feature>
@@ -2328,10 +2317,6 @@
                                     <version>${carbon.registry.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.registry.ui.menu.governance.feature.group</id>
-                                    <version>${carbon.registry.version}</version>
-                                </feature>
-                                <feature>
                                     <id>org.wso2.carbon.registry.resource.properties.feature.group</id>
                                     <version>${carbon.registry.version}</version>
                                 </feature>
@@ -2413,7 +2398,7 @@
                                     <version>${carbon.identity.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.identity.functions.library.mgt.feature.group</id>
+                                    <id>org.wso2.carbon.identity.functions.library.mgt.server.feature.group</id>
                                     <version>${carbon.identity.version}</version>
                                 </feature>
                                 <feature>
@@ -2849,10 +2834,6 @@
                                     <version>${carbon.registry.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.registry.ui.menu.governance.feature.group</id>
-                                    <version>${carbon.registry.version}</version>
-                                </feature>
-                                <feature>
                                     <id>org.wso2.carbon.registry.resource.properties.feature.group</id>
                                     <version>${carbon.registry.version}</version>
                                 </feature>
@@ -2974,7 +2955,7 @@
                                     <version>${carbon.identity.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.identity.functions.library.mgt.feature.group</id>
+                                    <id>org.wso2.carbon.identity.functions.library.mgt.server.feature.group</id>
                                     <version>${carbon.identity.version}</version>
                                 </feature>
                                 <feature>
@@ -3349,10 +3330,6 @@
                                     <version>${carbon.registry.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.registry.ui.menu.governance.feature.group</id>
-                                    <version>${carbon.registry.version}</version>
-                                </feature>
-                                <feature>
                                     <id>org.wso2.carbon.registry.resource.properties.feature.group</id>
                                     <version>${carbon.registry.version}</version>
                                 </feature>
@@ -3474,7 +3451,7 @@
                                     <version>${carbon.identity.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.identity.functions.library.mgt.feature.group</id>
+                                    <id>org.wso2.carbon.identity.functions.library.mgt.server.feature.group</id>
                                     <version>${carbon.identity.version}</version>
                                 </feature>
                                 <feature>
@@ -3777,7 +3754,7 @@
                                     <version>${carbon.commons.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.identity.functions.library.mgt.feature.group</id>
+                                    <id>org.wso2.carbon.identity.functions.library.mgt.server.feature.group</id>
                                     <version>${carbon.identity.version}</version>
                                 </feature>
                                 <feature>
@@ -3896,10 +3873,6 @@
                                     <version>${carbon.registry.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.registry.ui.menu.governance.feature.group</id>
-                                    <version>${carbon.registry.version}</version>
-                                </feature>
-                                <feature>
                                     <id>org.wso2.carbon.registry.resource.properties.feature.group</id>
                                     <version>${carbon.registry.version}</version>
                                 </feature>
@@ -3970,7 +3943,7 @@
                                     <version>${carbon.identity-data-publisher-oauth.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.identity.functions.library.mgt.feature.group</id>
+                                    <id>org.wso2.carbon.identity.functions.library.mgt.server.feature.group</id>
                                     <version>${carbon.identity.version}</version>
                                 </feature>
                                 <feature>
@@ -4320,7 +4293,7 @@
                                     <version>${carbon.identity.version}</version>
                                 </feature>
                                 <feature>
-                                    <id>org.wso2.carbon.identity.functions.library.mgt.feature.group</id>
+                                    <id>org.wso2.carbon.identity.functions.library.mgt.server.feature.group</id>
                                     <version>${carbon.identity.version}</version>
                                 </feature>
                                 <feature>


### PR DESCRIPTION
This will remove 
- Governance metadata menu
- Datasource menu
- Shutdown Restart menu
- Library management menu