### PR TITLE
Perform SHA-256 Hash for Certificate Signature Validation

### DIFF
--- a/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/utils/generic/APIMTestCaseUtils.java
+++ b/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/utils/generic/APIMTestCaseUtils.java
@@ -1276,7 +1276,7 @@ public class APIMTestCaseUtils {
         JSONObject jsonHeaderObject = null;
         try {
             jsonHeaderObject = new JSONObject(jsonHeader);
-            thumbPrint = new String(Base64.decodeBase64(jsonHeaderObject.get("x5t").toString().getBytes()));
+            thumbPrint = new String(Base64.decodeBase64(jsonHeaderObject.get("x5t#S256").toString().getBytes()));
             signatureAlgorithm = (String) jsonHeaderObject.get("alg");
         } catch (JSONException e) {
             log.error("Error while parsing json" + e);
@@ -1490,7 +1490,7 @@ public class APIMTestCaseUtils {
         Certificate cert = null;
         MessageDigest sha = null;
         try {
-            sha = MessageDigest.getInstance("SHA-1");
+            sha = MessageDigest.getInstance("SHA-256");
             for (Enumeration e = keyStore.aliases(); e.hasMoreElements();) {
                 String alias = (String) e.nextElement();
                 Certificate[] certs = keyStore.getCertificateChain(alias);


### PR DESCRIPTION
### Purpose
The PR [1] changed the default certificate hashing algorithm to SHA-256. This PR incorporates that change in to integration tests by performing SHA-256 hashing for certificate signature validation.

This should be merged after merging [1]

[1] https://github.com/wso2/carbon-apimgt/pull/12365