### PR TITLE
Update client secret assertions to support empty client secret

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/AddEndPointSecurityPerTypeTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/AddEndPointSecurityPerTypeTestCase.java
@@ -408,8 +408,7 @@ public class AddEndPointSecurityPerTypeTestCase extends APIManagerLifecycleBaseT
         Assert.assertEquals(sandboxEndpointSecurityModel.get("type"), "OAUTH");
         Assert.assertEquals(sandboxEndpointSecurityModel.get("tokenUrl"), "https://localhost:9943/oauth2/token");
         Assert.assertEquals(sandboxEndpointSecurityModel.get("clientId"), applicationKeyBeanSandbox.getConsumerKey());
-        Assert.assertEquals(sandboxEndpointSecurityModel.get("clientSecret"),
-                applicationKeyBeanSandbox.getConsumerSecret());
+        Assert.assertEquals(sandboxEndpointSecurityModel.get("clientSecret"), "");
         Assert.assertNotNull(endpointSecurityModel.get("production"));
         Map productionEndpointSecurityModel = (Map) endpointSecurityModel.get("production");
         Assert.assertTrue((Boolean) productionEndpointSecurityModel.get("enabled"));
@@ -417,8 +416,7 @@ public class AddEndPointSecurityPerTypeTestCase extends APIManagerLifecycleBaseT
         Assert.assertEquals(productionEndpointSecurityModel.get("tokenUrl"), "https://localhost:9943/oauth2/token");
         Assert.assertEquals(productionEndpointSecurityModel.get("clientId"),
                 applicationKeyBeanProduction.getConsumerKey());
-        Assert.assertEquals(productionEndpointSecurityModel.get("clientSecret"),
-                applicationKeyBeanProduction.getConsumerSecret());
+        Assert.assertEquals(productionEndpointSecurityModel.get("clientSecret"), "");
 
         String prodAppTokenJti = TokenUtils.getJtiOfJwtToken(productionApplication.getToken().getAccessToken());
         requestHeadersGet.put("Authorization", "Bearer " + prodAppTokenJti);
@@ -484,8 +482,7 @@ public class AddEndPointSecurityPerTypeTestCase extends APIManagerLifecycleBaseT
         Assert.assertEquals(sandboxEndpointSecurityModel.get("type"), "OAUTH");
         Assert.assertEquals(sandboxEndpointSecurityModel.get("tokenUrl"), "https://localhost:9943/oauth2/token");
         Assert.assertEquals(sandboxEndpointSecurityModel.get("clientId"), applicationKeyBeanSandbox.getConsumerKey());
-        Assert.assertEquals(sandboxEndpointSecurityModel.get("clientSecret"),
-                applicationKeyBeanSandbox.getConsumerSecret());
+        Assert.assertEquals(sandboxEndpointSecurityModel.get("clientSecret"), "");
         Assert.assertNotNull(endpointSecurityModel.get("production"));
         Map productionEndpointSecurityModel = (Map) endpointSecurityModel.get("production");
         Assert.assertTrue((Boolean) productionEndpointSecurityModel.get("enabled"));
@@ -493,8 +490,7 @@ public class AddEndPointSecurityPerTypeTestCase extends APIManagerLifecycleBaseT
         Assert.assertEquals(productionEndpointSecurityModel.get("tokenUrl"), "https://localhost:9943/oauth2/token");
         Assert.assertEquals(productionEndpointSecurityModel.get("clientId"),
                 applicationKeyBeanProduction.getConsumerKey());
-        Assert.assertEquals(productionEndpointSecurityModel.get("clientSecret"),
-                applicationKeyBeanProduction.getConsumerSecret());
+        Assert.assertEquals(productionEndpointSecurityModel.get("clientSecret"), "");
     }
 
     @Test(groups = { "wso2.am"}, description = "Test add OAuth endpoint security for PASSWORD grant type",
@@ -562,8 +558,7 @@ public class AddEndPointSecurityPerTypeTestCase extends APIManagerLifecycleBaseT
         Assert.assertEquals(sandboxEndpointSecurityModel.get("type"), "OAUTH");
         Assert.assertEquals(sandboxEndpointSecurityModel.get("tokenUrl"), "https://localhost:9943/oauth2/token");
         Assert.assertEquals(sandboxEndpointSecurityModel.get("clientId"), applicationKeyBeanSandbox.getConsumerKey());
-        Assert.assertEquals(sandboxEndpointSecurityModel.get("clientSecret"),
-                applicationKeyBeanSandbox.getConsumerSecret());
+        Assert.assertEquals(sandboxEndpointSecurityModel.get("clientSecret"), "");
         Assert.assertNotNull(endpointSecurityModel.get("production"));
         Map productionEndpointSecurityModel = (Map) endpointSecurityModel.get("production");
         Assert.assertTrue((Boolean) productionEndpointSecurityModel.get("enabled"));
@@ -571,8 +566,7 @@ public class AddEndPointSecurityPerTypeTestCase extends APIManagerLifecycleBaseT
         Assert.assertEquals(productionEndpointSecurityModel.get("tokenUrl"), "https://localhost:9943/oauth2/token");
         Assert.assertEquals(productionEndpointSecurityModel.get("clientId"),
                 applicationKeyBeanProduction.getConsumerKey());
-        Assert.assertEquals(productionEndpointSecurityModel.get("clientSecret"),
-                applicationKeyBeanProduction.getConsumerSecret());
+        Assert.assertEquals(productionEndpointSecurityModel.get("clientSecret"), "");
 
         String prodAppTokenJti = TokenUtils.getJtiOfJwtToken(productionApplication.getToken().getAccessToken());
         requestHeadersGet.put("Authorization", "Bearer " + prodAppTokenJti);

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/ChangeEndPointSecurityPerTypeTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/ChangeEndPointSecurityPerTypeTestCase.java
@@ -384,8 +384,7 @@ public class ChangeEndPointSecurityPerTypeTestCase extends APIManagerLifecycleBa
         Assert.assertEquals(sandboxEndpointSecurityModel.get("type"), "OAUTH");
         Assert.assertEquals(sandboxEndpointSecurityModel.get("tokenUrl"), "https://localhost:9943/oauth2/token");
         Assert.assertEquals(sandboxEndpointSecurityModel.get("clientId"), applicationKeyBeanSandbox.getConsumerKey());
-        Assert.assertEquals(sandboxEndpointSecurityModel.get("clientSecret"),
-                applicationKeyBeanSandbox.getConsumerSecret());
+        Assert.assertEquals(sandboxEndpointSecurityModel.get("clientSecret"), "");
         Assert.assertNotNull(endpointSecurityModel.get("production"));
         Map productionEndpointSecurityModel = (Map) endpointSecurityModel.get("production");
         Assert.assertTrue((Boolean) productionEndpointSecurityModel.get("enabled"));
@@ -393,8 +392,7 @@ public class ChangeEndPointSecurityPerTypeTestCase extends APIManagerLifecycleBa
         Assert.assertEquals(productionEndpointSecurityModel.get("tokenUrl"), "https://localhost:9943/oauth2/token");
         Assert.assertEquals(productionEndpointSecurityModel.get("clientId"),
                 applicationKeyBeanProduction.getConsumerKey());
-        Assert.assertEquals(productionEndpointSecurityModel.get("clientSecret"),
-                applicationKeyBeanProduction.getConsumerSecret());
+        Assert.assertEquals(productionEndpointSecurityModel.get("clientSecret"), "");
 
         String prodAppTokenJti = TokenUtils.getJtiOfJwtToken(productionApplication.getToken().getAccessToken());
         requestHeadersGet.put("Authorization", "Bearer " + prodAppTokenJti);
@@ -476,8 +474,7 @@ public class ChangeEndPointSecurityPerTypeTestCase extends APIManagerLifecycleBa
         Assert.assertEquals(sandboxEndpointSecurityModel.get("type"), "OAUTH");
         Assert.assertEquals(sandboxEndpointSecurityModel.get("tokenUrl"), "https://localhost:9943/oauth2/token");
         Assert.assertEquals(sandboxEndpointSecurityModel.get("clientId"), applicationKeyBeanSandbox.getConsumerKey());
-        Assert.assertEquals(sandboxEndpointSecurityModel.get("clientSecret"),
-                applicationKeyBeanSandbox.getConsumerSecret());
+        Assert.assertEquals(sandboxEndpointSecurityModel.get("clientSecret"), "");
         Assert.assertNotNull(endpointSecurityModel.get("production"));
         Map productionEndpointSecurityModel = (Map) endpointSecurityModel.get("production");
         Assert.assertTrue((Boolean) productionEndpointSecurityModel.get("enabled"));
@@ -485,8 +482,7 @@ public class ChangeEndPointSecurityPerTypeTestCase extends APIManagerLifecycleBa
         Assert.assertEquals(productionEndpointSecurityModel.get("tokenUrl"), "https://localhost:9943/oauth2/token");
         Assert.assertEquals(productionEndpointSecurityModel.get("clientId"),
                 applicationKeyBeanProduction.getConsumerKey());
-        Assert.assertEquals(productionEndpointSecurityModel.get("clientSecret"),
-                applicationKeyBeanProduction.getConsumerSecret());
+        Assert.assertEquals(productionEndpointSecurityModel.get("clientSecret"), "");
 
         String prodAppTokenJti = TokenUtils.getJtiOfJwtToken(productionApplication.getToken().getAccessToken());
         requestHeadersGet.put("Authorization", "Bearer " + prodAppTokenJti);


### PR DESCRIPTION
This PR fixed the test failures caused by the PR https://github.com/wso2/carbon-apimgt/pull/12312.