### PR TITLE
Fix error logs at server startup

### DIFF
--- a/modules/distribution/product/src/main/resources/conf/templates/diagnostics-tool/conf/config.toml.j2
+++ b/modules/distribution/product/src/main/resources/conf/templates/diagnostics-tool/conf/config.toml.j2
@@ -74,7 +74,7 @@ executor = "{{action.executor}}"
 [cpu_watcher]
 enabled = "{{cpu_watcher.enabled}}"
 threshold = "{{cpu_watcher.threshold}}"
-attempts = "{{cpu_watcher.attempts}}
+attempts = "{{cpu_watcher.attempts}}"
 interval = "{{cpu_watcher.interval}}"
 action_executors = "{{cpu_watcher.action_executors}}"
 


### PR DESCRIPTION
### Purpose

- Fix https://github.com/wso2/api-manager/issues/2783
- Add missing `"`