### PR TITLE
Added Integration test for enabling empty values passing for custom application attributes in backend JWT

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/jwt/JWTTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/jwt/JWTTestCase.java
@@ -251,6 +251,13 @@ public class JWTTestCase extends APIManagerLifecycleBaseTest {
             verifyUserProfileInfoClaims(jsonObject, endUser);
             // check wrong claims
             BackendJWTUtil.verifyWrongClaims(jsonObject);
+
+            // http://wso2.org/claims/applicationAttributes should contain 'Optional attribute' as
+            // enable_empty_values_in_application_attributes is true and therefore empty values are allowed for custom
+            // application attributes
+            assertTrue(jsonObject.getString("http://wso2.org/claims/applicationAttributes").
+                    equals("{\"Required attribute 2\":\"Default value of Required attribute 2\",\"Required attribute 1\"" +
+                            ":\"Default value of Required attribute 1\",\"Optional attribute\":\"\"}"));
         }
     }
 
@@ -303,6 +310,13 @@ public class JWTTestCase extends APIManagerLifecycleBaseTest {
             assertTrue("JWT claim mobile  not received" + claim, claim.contains("ABC".concat(endUser)));
             // verify wrong claims
             BackendJWTUtil.verifyWrongClaims(jsonObject);
+
+            // http://wso2.org/claims/applicationAttributes should contain 'Optional attribute' as
+            // enable_empty_values_in_application_attributes is true and therefore empty values are allowed for custom
+            // application attributes
+            assertTrue(jsonObject.getString("http://wso2.org/claims/applicationAttributes").
+                    equals("{\"Required attribute 2\":\"Default value of Required attribute 2\",\"Required attribute 1\"" +
+                            ":\"Default value of Required attribute 1\",\"Optional attribute\":\"\"}"));
         }
     }
 

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/jwt/urlsafe/URLSafeJWTTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/jwt/urlsafe/URLSafeJWTTestCase.java
@@ -55,6 +55,7 @@ import java.util.ArrayList;
 import javax.ws.rs.core.Response;
 
 import static org.testng.AssertJUnit.assertTrue;
+import static org.testng.AssertJUnit.assertFalse;
 
 public class URLSafeJWTTestCase extends APIManagerLifecycleBaseTest {
 
@@ -173,6 +174,15 @@ public class URLSafeJWTTestCase extends APIManagerLifecycleBaseTest {
             bExceptionOccured = true;
         }
         assertTrue("JWT claim received is invalid", bExceptionOccured);
+
+        // http://wso2.org/claims/applicationAttributes should not contain 'Optional attribute' as
+        // enable_empty_values_in_application_attributes is false and therefore empty values for custom application
+        // attributes are not allowed
+        assertTrue(jsonObject.getString("http://wso2.org/claims/applicationAttributes").
+                equals("{\"Production access required\":\"Yes\",\"Sandbox access required\":\"Yes\"}"));
+        assertFalse(jsonObject.getString("http://wso2.org/claims/applicationAttributes").
+                equals("{\"Production access required\":\"Yes\",\"Optional attribute\":\"\",\"Sandbox access required\":" +
+                        "\"Yes\"}"));
     }
 
     @Test(groups = {"wso2.am"}, description = "Backend JWT Token Generation for JWT Based App")
@@ -219,6 +229,15 @@ public class URLSafeJWTTestCase extends APIManagerLifecycleBaseTest {
         checkDefaultUserClaims(jsonObject, jwtApplicationName);
         // check user profile info claims
         log.info("JWT Received ==" + jsonObject.toString());
+
+        // http://wso2.org/claims/applicationAttributes should not contain 'Optional attribute' as
+        // enable_empty_values_in_application_attributes is false and therefore empty values for custom application
+        // attributes are not allowed
+        assertTrue(jsonObject.getString("http://wso2.org/claims/applicationAttributes").
+                equals("{\"Production access required\":\"Yes\",\"Sandbox access required\":\"Yes\"}"));
+        assertFalse(jsonObject.getString("http://wso2.org/claims/applicationAttributes").
+                equals("{\"Production access required\":\"Yes\",\"Optional attribute\":\"\",\"Sandbox access required\":" +
+                        "\"Yes\"}"));
     }
 
     @AfterClass(alwaysRun = true)

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/tokenTest/deployment.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/tokenTest/deployment.toml
@@ -110,3 +110,26 @@ enable_query_param_based_throttling = true
 [apim.sync_runtime_artifacts.gateway.skip_list]
 apis = ["admin--git2231head_v1.0.0.xml","admin--PizzaShackAPI_v1.0.0.xml","admin--ScriptMediatorAPI_v1.0.xml",
 "APIThrottleBackendAPI.xml","BackEndSecurity.xml","DigestAuth_API.xml","git2231.xml","HttpPATCHSupport_API.xml","JWKS-Backend.xml","JWTBackendAPI.xml","multiVSR_v1.0.0.xml","Response_API_1.xml","Response_API_2.xml","Response_Custom_API.xml","Response_Error_API.xml","Response_Loc_API.xml","SpecialCRN_v1.0.0.xml","status_code_204_API.xml","stockquote.xml","XML_API.xml","Version1.xml","Version2.xml","schemaValidationAPI.xml"]
+
+[apim.devportal]
+enable_empty_values_in_application_attributes = true
+
+[[apim.devportal.application_attributes]]
+required=false
+hidden=false
+name="Optional attribute"
+description="Description of Optional attribute"
+
+[[apim.devportal.application_attributes]]
+required=true
+hidden=false
+default="Default value of Required attribute 1"
+name="Required attribute 1"
+description="Description of Required attribute 1"
+
+[[apim.devportal.application_attributes]]
+required=true
+hidden=false
+default="Default value of Required attribute 2"
+name="Required attribute 2"
+description="Description of Required attribute 2"

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/tokenTest/urlSafeTokenTest/deployment.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/tokenTest/urlSafeTokenTest/deployment.toml
@@ -103,6 +103,15 @@ password = "${admin.password}"
 apis = ["admin--git2231head_v1.0.0.xml","admin--PizzaShackAPI_v1.0.0.xml","admin--ScriptMediatorAPI_v1.0.xml",
 "APIThrottleBackendAPI.xml","BackEndSecurity.xml","DigestAuth_API.xml","git2231.xml","HttpPATCHSupport_API.xml","JWKS-Backend.xml","JWTBackendAPI.xml","multiVSR_v1.0.0.xml","Response_API_1.xml","Response_API_2.xml","Response_Custom_API.xml","Response_Error_API.xml","Response_Loc_API.xml","SpecialCRN_v1.0.0.xml","status_code_204_API.xml","stockquote.xml","XML_API.xml","Version1.xml","Version2.xml","schemaValidationAPI.xml"]
 
+[apim.devportal]
+enable_empty_values_in_application_attributes = false
+
+[[apim.devportal.application_attributes]]
+required=false
+hidden=false
+name="Optional attribute"
+description="Description of Optional attribute"
+
 [[apim.devportal.application_attributes]]
 required=true
 hidden=false


### PR DESCRIPTION
$subject
Fix https://github.com/wso2/api-manager/issues/2745