### PR TITLE
User defined endpoint mediator

### DIFF
--- a/modules/distribution/resources/api_templates/velocity_template.xml
+++ b/modules/distribution/resources/api_templates/velocity_template.xml
@@ -94,6 +94,13 @@
 #end
 #end
 </class>
+## user defined Mediator
+		#else
+        #if($endpointsecurity.type == "userDefined")
+<class name="org.wso2.carbon.apimgt.gateway.mediators.endpointsecurity.UserDefinedMediator">
+<property name="customParameters" value="$util.escapeXml($endpointsecurity.customParameters)" type="STRING"/>
+</class>
+## user defined Mediator
         #end
         #end
         #end


### PR DESCRIPTION
With this update, any user can publish an API with a custom mediator that authenticate the endpoint. The mediator must be deployed as JAR in the API manager instance.

The user can publish the API with Publisher API (https://localhost:9443/api/am/publisher/v4/apis) passing the custom endpoint security configuration
```
      "endpoint_security": {
            "sandbox": {
                "type": "userDefined",
                "enabled": true,
                "customParameters": {
                    "parameter": "value",
                    "boolparameter": true,
[...]
                }
            }
        }
```
In this case, the sandbox endpoint is secured by the user defined mediator with the specified parameters.
