### PR TITLE
Add config default for setting service provider subject claim value

### DIFF
--- a/modules/distribution/product/src/main/resources/conf/default.json
+++ b/modules/distribution/product/src/main/resources/conf/default.json
@@ -541,5 +541,6 @@
       "pattern.executors": "ServerInfo",
       "pattern.reload_time": "10"
     }
-  ]
+  ],
+  "service_provider.use_username_as_sub_claim": false
 }


### PR DESCRIPTION
### Purpose

- Resolves: https://github.com/wso2/api-manager/issues/2932 

This PR adds the default value for `service_provider.use_username_as_sub_claim`. With this default behaviour, on SP creation for application key generation, the default subject claim will be userID. If set to `true` using deployment.toml, the username will be used as the subject claim.

### Related PRs

- https://github.com/wso2/carbon-identity-framework/pull/5746
- https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2495
- https://github.com/wso2/carbon-identity-framework/pull/5745
- https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2492
