### PR TITLE
Added soap velocity variables for soapNamespace and mediaType

### DIFF
--- a/modules/distribution/resources/api_templates/soap_to_rest_in_seq_template.xml
+++ b/modules/distribution/resources/api_templates/soap_to_rest_in_seq_template.xml
@@ -26,7 +26,7 @@ $mapping.get('properties')
     #end
 <payloadFactory description="transform" media-type="xml">
       <format>
-        <soapenv:Envelope xmlns:soapenv="http://www.w3.org/2003/05/soap-envelope" xmlns:web="${namespace}">
+        <soapenv:Envelope xmlns:soapenv="${soapNamespace}" xmlns:web="${namespace}">
           <soapenv:Header/>
           <soapenv:Body>
             $mapping.get('sequence')
@@ -37,7 +37,7 @@ $mapping.get('properties')
         $mapping.get('args')
       </args>
     </payloadFactory>
-    <property description="messageProperty" name="messageType" scope="axis2" type="STRING" value="application/soap+xml"/>
+    <property description="messageProperty" name="messageType" scope="axis2" type="STRING" value="${mediaType}"/>
   </then>
   <else>
     <payloadFactory media-type="json" description="transform">

--- a/pom.xml
+++ b/pom.xml
@@ -1287,7 +1287,7 @@
         <carbon.apimgt.ui.version>9.1.83</carbon.apimgt.ui.version>
 
         <!-- APIM Component Version -->
-        <carbon.apimgt.version>9.29.142</carbon.apimgt.version>
+        <carbon.apimgt.version>9.29.164</carbon.apimgt.version>
 
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 


### PR DESCRIPTION
### Purpose

The `soapNamespace` and `mediaType` is hardcoded in [soap_to_rest_in_seq_template.xml](https://github.com/wso2/product-apim/blob/master/modules/distribution/resources/api_templates/soap_to_rest_in_seq_template.xml). This caused the issue https://github.com/wso2/api-manager/issues/2939, where creating a SOAP 1.1 to REST API, results in configurations having SOAP 1.2 namespace and media type.

With the fix, the correct soapNamespace and mediaType will be placed in the variable locations.

### Resolves

https://github.com/wso2/api-manager/issues/2939