### PR TITLE
Add Config Values to modify the read only property for governance and config registry.

### DIFF
--- a/modules/distribution/product/src/main/resources/conf/templates/repository/conf/registry.xml.j2
+++ b/modules/distribution/product/src/main/resources/conf/templates/repository/conf/registry.xml.j2
@@ -44,7 +44,7 @@
         <id>gov</id>
         <cacheId>{{governance_data.cache_id}}</cacheId>
         <dbConfig>govregistry</dbConfig>
-        <readOnly>false</readOnly>
+        <readOnly>{{!governance_data.overwrite}}</readOnly>
         <enableCache>{{governance_data.enable_cache}}</enableCache>
         <registryRoot>/</registryRoot>
     </remoteInstance>
@@ -53,7 +53,7 @@
         <id>conf</id>
         <cacheId>{{config_data.cache_id}}</cacheId>
         <dbConfig>configregistry</dbConfig>
-        <readOnly>false</readOnly>
+        <readOnly>{{!config_data.overwrite}}</readOnly>
         <enableCache>{{config_data.enable_cache}}</enableCache>
         <registryRoot>/</registryRoot>
     </remoteInstance>


### PR DESCRIPTION
Fixes https://github.com/wso2/api-manager/issues/3031

If you need to make the config and/ or governance registries read only, add the following configuration in ```<APIM_HOME>/repository/conf/deployment.toml``` file : 

```
[config_data]
overwrite = false

[governance_data]
overwrite = false
```
Note : overwrite=false implies that readOnly value is set to true and overwrite=true implies that readOnly value is set to false