### PR TITLE
Add Config Values to modify the read only property for governance and config registry.

### DIFF
--- a/modules/distribution/product/src/main/resources/conf/default.json
+++ b/modules/distribution/product/src/main/resources/conf/default.json
@@ -339,6 +339,8 @@
   "apim.auth_manager.service_url" : "https://localhost:${mgt.transport.https.port}${carbon.context}services/",
   "config_data.overwrite": "true",
   "governance_data.overwrite": "true",
+  "config_data.readonly": "false",
+  "governance_data.readonly": "false",
   "static_configuration.versioning_properties.enable": false,
   "static_configuration.versioning_comments.enable": false,
   "static_configuration.versioning_tags.enable": false,

--- a/modules/distribution/product/src/main/resources/conf/templates/repository/conf/registry.xml.j2
+++ b/modules/distribution/product/src/main/resources/conf/templates/repository/conf/registry.xml.j2
@@ -44,7 +44,7 @@
         <id>gov</id>
         <cacheId>{{governance_data.cache_id}}</cacheId>
         <dbConfig>govregistry</dbConfig>
-        <readOnly>{{!governance_data.overwrite}}</readOnly>
+        <readOnly>{{governance_data.readonly}}</readOnly>
         <enableCache>{{governance_data.enable_cache}}</enableCache>
         <registryRoot>/</registryRoot>
     </remoteInstance>
@@ -53,7 +53,7 @@
         <id>conf</id>
         <cacheId>{{config_data.cache_id}}</cacheId>
         <dbConfig>configregistry</dbConfig>
-        <readOnly>{{!config_data.overwrite}}</readOnly>
+        <readOnly>{{config_data.readonly}}</readOnly>
         <enableCache>{{config_data.enable_cache}}</enableCache>
         <registryRoot>/</registryRoot>
     </remoteInstance>


### PR DESCRIPTION
Since the 'overwrite' config had a separate usecase, adding a new config called 'readonly'.
Fixes https://github.com/wso2/api-manager/issues/3031