### PR TITLE
Upgrade CXF version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1337,7 +1337,7 @@
         <saml.common.util.version.range>[1.0.0,2.0.0)</saml.common.util.version.range>
 
         <!-- carbon deployment -->
-        <carbon.deployment.version>4.11.14</carbon.deployment.version>
+        <carbon.deployment.version>4.11.15</carbon.deployment.version>
 
         <!-- Carbon Multitenancy version-->
         <carbon.multitenancy.version>4.9.27</carbon.multitenancy.version>
@@ -1397,7 +1397,7 @@
         <carbon.automation.version>4.4.10</carbon.automation.version>
         <carbon.automationutils.version>4.5.3</carbon.automationutils.version>
         <testng.version>6.11</testng.version>
-        <org.apache.cxf.version>3.6.3</org.apache.cxf.version>
+        <org.apache.cxf.version>3.6.4</org.apache.cxf.version>
         <org.apache.axis2.transport.version>2.0.0-wso2v66</org.apache.axis2.transport.version> <!-- not used -->
         <org.springframework.version>5.1.13.RELEASE</org.springframework.version>
         <org.apache.tomcat>7.0.96</org.apache.tomcat>


### PR DESCRIPTION
### Purpose

Upgrades CXF version from 3.6.3 to 3.6.4.

Related carbon-deployment PR: https://github.com/wso2/carbon-deployment/pull/401
Related carbon-apimgt PR: https://github.com/wso2/carbon-apimgt/pull/12556