### PR TITLE
Add Integration Test for Lightweight API Key and Fix WebSocket API Invocation Test Issues

### DIFF
--- a/modules/distribution/product/src/main/conf/deployment.toml
+++ b/modules/distribution/product/src/main/conf/deployment.toml
@@ -107,7 +107,7 @@ enable = true
 token = ""
 
 [apim.key_manager]
-enable_apikey_subscription_validation = true
+enable_lightweight_apikey_generation = true
 #service_url = "https://localhost:${mgt.transport.https.port}/services/"
 #username = "$ref{super_admin.username}"
 #password = "$ref{super_admin.password}"

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/websocket/WebSocketAPITestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/websocket/WebSocketAPITestCase.java
@@ -807,9 +807,11 @@ public class WebSocketAPITestCase extends APIMIntegrationBaseTest {
         } else if (AUTH_IN.OAUTH_QUERY == in) {
             echoUri = new URI(apiEndPoint + "?access_token=" + accessToken);
         } else if (AUTH_IN.APIKEY_HEADER == in) {
+            Thread.sleep(24000);
             request.setHeader("apikey", accessToken);
             echoUri = new URI(apiEndPoint);
         } else if (AUTH_IN.APIKEY_QUERY == in) {
+            Thread.sleep(24000);
             echoUri = new URI(apiEndPoint + "?apikey=" + accessToken);
         }
 

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/applicationSharing/deployment.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/applicationSharing/deployment.toml
@@ -108,8 +108,5 @@ password = "${admin.password}"
 apis = ["admin--git2231head_v1.0.0.xml","admin--PizzaShackAPI_v1.0.0.xml","admin--ScriptMediatorAPI_v1.0.xml",
 "APIThrottleBackendAPI.xml","BackEndSecurity.xml","DigestAuth_API.xml","git2231.xml","HttpPATCHSupport_API.xml","JWKS-Backend.xml","JWTBackendAPI.xml","multiVSR_v1.0.0.xml","Response_API_1.xml","Response_API_2.xml","Response_Custom_API.xml","Response_Error_API.xml","Response_Loc_API.xml","SpecialCRN_v1.0.0.xml","status_code_204_API.xml","stockquote.xml","XML_API.xml","Version1.xml","Version2.xml","schemaValidationAPI.xml"]
 
-[apim.key_manager]
-enable_lightweight_apikey_generation = false
-
 [apimgt.mutual_ssl]
 enable_certificate_chain_validation = true

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/applicationSharing/deployment.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/applicationSharing/deployment.toml
@@ -108,5 +108,8 @@ password = "${admin.password}"
 apis = ["admin--git2231head_v1.0.0.xml","admin--PizzaShackAPI_v1.0.0.xml","admin--ScriptMediatorAPI_v1.0.xml",
 "APIThrottleBackendAPI.xml","BackEndSecurity.xml","DigestAuth_API.xml","git2231.xml","HttpPATCHSupport_API.xml","JWKS-Backend.xml","JWTBackendAPI.xml","multiVSR_v1.0.0.xml","Response_API_1.xml","Response_API_2.xml","Response_Custom_API.xml","Response_Error_API.xml","Response_Loc_API.xml","SpecialCRN_v1.0.0.xml","status_code_204_API.xml","stockquote.xml","XML_API.xml","Version1.xml","Version2.xml","schemaValidationAPI.xml"]
 
+[apim.key_manager]
+enable_lightweight_apikey_generation = false
+
 [apimgt.mutual_ssl]
 enable_certificate_chain_validation = true

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/common/deployment.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/common/deployment.toml
@@ -35,6 +35,9 @@ password =  "wso2carbon"
 alias =  "wso2carbon"
 key_password =  "wso2carbon"
 
+[apim.key_manager]
+enable_lightweight_apikey_generation = false
+
 [[apim.gateway.environment]]
 name = "Default"
 type = "hybrid"

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -355,6 +355,7 @@
         <parameter name="group" value="group4"/>
         <classes>
             <class name="org.wso2.am.integration.tests.other.AdvancedConfigDeploymentConfig"/>
+            <class name="org.wso2.am.integration.tests.api.lifecycle.APISecurityTestCase" />
             <class name="org.wso2.am.integration.tests.other.NotificationTestCase"/>
             <class name="org.wso2.am.integration.tests.json.ESBJAVA3380TestCase"/>
             <!--THis test will be enabled once the stats event streams are finalized  -->
@@ -369,13 +370,10 @@
         </classes>
     </test>
 
-
-
     <test name="apim-integration-tests-application-sharing" preserve-order="true" parallel="false" group-by-instances="true">
         <parameter name="group" value="group1"/>
         <classes>
             <class name="org.wso2.am.integration.tests.application.groupSharing.ApplicationSharingConfig"/>
-            <class name="org.wso2.am.integration.tests.api.lifecycle.APISecurityTestCase" />
             <class name="org.wso2.am.integration.tests.application.groupSharing.ApplicationSharingTestCase"/>
 <!--            <class name="org.wso2.am.integration.tests.api.lifecycle.APISecurityMutualSSLCertificateChainValidationTestCase" />-->
         </classes>

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -375,6 +375,7 @@
         <parameter name="group" value="group1"/>
         <classes>
             <class name="org.wso2.am.integration.tests.application.groupSharing.ApplicationSharingConfig"/>
+            <class name="org.wso2.am.integration.tests.api.lifecycle.APISecurityTestCase" />
             <class name="org.wso2.am.integration.tests.application.groupSharing.ApplicationSharingTestCase"/>
 <!--            <class name="org.wso2.am.integration.tests.api.lifecycle.APISecurityMutualSSLCertificateChainValidationTestCase" />-->
         </classes>


### PR DESCRIPTION
## Purpose
- Added a new integration test case to validate the lightweight API Key functionality in the WSO2 API Manager.
- Fixed existing test issues in WebSocket API invocation test cases that arose after implementing the lightweight API Key feature.
- Ensured all tests run successfully to maintain code stability and feature integrity.