### PR TITLE
[APIM-4.4.0] Bump the bouncycastle version to 1.78.1 and Fips version to 1.0.2.5

### DIFF
--- a/modules/distribution/product/src/main/startup-scripts/fips.bat
+++ b/modules/distribution/product/src/main/startup-scripts/fips.bat
@@ -16,10 +16,10 @@ rem KIND, either express or implied.  See the License for the
 rem specific language governing permissions and limitations
 rem under the License.
 
-set BC_FIPS_VERSION=1.0.2.4
+set BC_FIPS_VERSION=1.0.2.5
 set BCPKIX_FIPS_VERSION=1.0.7
 
-set EXPECTED_BC_FIPS_CHECKSUM=9008d04fc13da6455e6a792935b93b629757335d
+set EXPECTED_BC_FIPS_CHECKSUM=704e65f7e4fe679e5ab2aa8a840f27f8ced4c522
 set EXPECTED_BCPKIX_FIPS_CHECKSUM=fe07959721cfa2156be9722ba20fdfee2b5441b0
 
 

--- a/modules/distribution/product/src/main/startup-scripts/fips.sh
+++ b/modules/distribution/product/src/main/startup-scripts/fips.sh
@@ -14,10 +14,10 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-BC_FIPS_VERSION=1.0.2.4;
+BC_FIPS_VERSION=1.0.2.5;
 BCPKIX_FIPS_VERSION=1.0.7;
 
-EXPECTED_BC_FIPS_CHECKSUM="9008d04fc13da6455e6a792935b93b629757335d"
+EXPECTED_BC_FIPS_CHECKSUM="704e65f7e4fe679e5ab2aa8a840f27f8ced4c522"
 EXPECTED_BCPKIX_FIPS_CHECKSUM="fe07959721cfa2156be9722ba20fdfee2b5441b0"
 
 # Get standard environment variables

--- a/modules/p2-profile/product/carbon.product
+++ b/modules/p2-profile/product/carbon.product
@@ -14,7 +14,7 @@ version="4.9.26" useFeatures="true" includeLaunchers="true">
    </plugins>
 
    <features>
-      <feature id="org.wso2.carbon.core.runtime" version="4.9.26"/>
+      <feature id="org.wso2.carbon.core.runtime" version="4.9.27"/>
    </features>
 
   <configurations>

--- a/pom.xml
+++ b/pom.xml
@@ -1301,7 +1301,7 @@
         <carbon.governance.version>4.8.34</carbon.governance.version>
 
         <!--carbon versions-->
-        <carbon.kernel.version>4.9.26</carbon.kernel.version>
+        <carbon.kernel.version>4.9.27</carbon.kernel.version>
         <apimserver.version>4.4.0-SNAPSHOT</apimserver.version>
 
         <cipher.tool.version>1.1.26</cipher.tool.version>
@@ -1340,7 +1340,7 @@
         <carbon.deployment.version>4.11.14</carbon.deployment.version>
 
         <!-- Carbon Multitenancy version-->
-        <carbon.multitenancy.version>4.9.27</carbon.multitenancy.version>
+        <carbon.multitenancy.version>4.9.28</carbon.multitenancy.version>
 
         <siddhi.version>3.2.13</siddhi.version>
 
@@ -1354,7 +1354,7 @@
         <opencsv.version>1.8</opencsv.version>
         <poi.version>3.0-FINAL</poi.version>
         <woden.version>1.0.0.M8-wso2v1</woden.version>
-        <synapse.version>4.0.0-wso2v105</synapse.version>
+        <synapse.version>4.0.0-wso2v122</synapse.version>
         <passthru.transport.patch.version>1.0.2</passthru.transport.patch.version>
         <axis2.wso2.version>1.6.1-wso2v99</axis2.wso2.version>
         <axiom.wso2.version>1.2.11-wso2v29</axiom.wso2.version>


### PR DESCRIPTION
### Purpose

- This PR bumps the carbon kernel, carbon multitenancy, and synapse versions to upgrade the bouncycastle version to bcprov-jdk18on 1.78.1.
- Bumps the Fips version to non-vulnerable 1.0.2.5.
#### Related PRs:

carbon-multitenancy PR: https://github.com/wso2/carbon-multitenancy/pull/270
wso2-synapse PR: https://github.com/wso2/wso2-synapse/pull/2217
carbon-apimgt PR: https://github.com/wso2/carbon-apimgt/pull/12567
carbon-kernel PR: https://github.com/wso2/carbon-kernel/pull/4074