### PR TITLE
Changed the order of synapse handlers

### DIFF
--- a/modules/distribution/product/src/main/resources/conf/templates/repository/conf/synapse-handlers.xml.j2
+++ b/modules/distribution/product/src/main/resources/conf/templates/repository/conf/synapse-handlers.xml.j2
@@ -1,6 +1,6 @@
 <handlers xmlns:svns="http://org.wso2.securevault/configuration">
-    <handler name="external_call_logger" class="org.wso2.carbon.apimgt.gateway.handlers.LogsHandler"/>
     <handler name="external_call_logger" class="org.wso2.carbon.apimgt.gateway.handlers.DefaultAPIHandler"/>
+    <handler name="external_call_logger" class="org.wso2.carbon.apimgt.gateway.handlers.LogsHandler"/>
     <handler name="open_tracing" class="org.wso2.carbon.apimgt.gateway.handlers.common.APIMgtLatencySynapseHandler"/>
 {% if apim.transport_headers is defined %}
 {% if apim.transport_headers.enable %}


### PR DESCRIPTION
## Purpose
Fixes https://github.com/wso2/api-manager/issues/3098

## Implementation
- Handling the default version before the logs makes sure that the version is available for logging when an API is invoked without the version.