### PR TITLE
[APIM-4.4.0] Upgrade swagger-parser version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1310,7 +1310,7 @@
         <carbon.kernel.imp.pkg.version>[4.5.0, 5.0.0)</carbon.kernel.imp.pkg.version>
 
         <!-- carbon mediation -->
-        <carbon.mediation.version>4.7.218</carbon.mediation.version>
+        <carbon.mediation.version>4.7.219</carbon.mediation.version>
 
         <!-- carbon identity -->
         <carbon.identity.version>5.25.713</carbon.identity.version>


### PR DESCRIPTION
### Purpose

This PR Upgrades the swagger-parser version to 2.1.22.

#### Related PRs:

Orbit bundles: https://github.com/wso2/orbit/pull/1133
carbon-mediation PR: https://github.com/wso2/carbon-mediation/pull/1733
carbon-apimgt PR: https://github.com/wso2/carbon-apimgt/pull/12586
