### PR TITLE
JNDI2 Config Upgrade for the Broker Connect Timeout and Upgrade Andes, Analytics Common, and Broker Versions

### DIFF
--- a/modules/distribution/product/src/main/resources/conf/templates/repository/conf/jndi2.properties.j2
+++ b/modules/distribution/product/src/main/resources/conf/templates/repository/conf/jndi2.properties.j2
@@ -20,7 +20,7 @@
 
 
         {% if apim.throttling.event_duplicate_url is defined %}
-        connectionfactory.TopicConnectionFactory = amqp://{{apim.throttling.jms.username}}:{{apim.throttling.jms.password}}@clientid/carbon?brokerlist='{% for url in apim.throttling.event_duplicate_url %}{{url}}?retries='5'%26connectdelay='50'{% if apim.throttling.jms.ssl is defined %}%26ssl='{{apim.throttling.jms.ssl}}'{% endif %};{% endfor %}'
+        connectionfactory.TopicConnectionFactory = amqp://{{apim.throttling.jms.username}}:{{apim.throttling.jms.password}}@clientid/carbon?brokerlist='{% for url in apim.throttling.event_duplicate_url %}{{url}}{% if '?' in url %}%26{% else %}?{% endif %}retries='5'%26connectdelay='50'{% if apim.throttling.jms.ssl is defined %}%26ssl='{{apim.throttling.jms.ssl}}'{% endif %};{% endfor %}'
         {% endif %}
 
         # register some queues in JNDI using the form

--- a/pom.xml
+++ b/pom.xml
@@ -1281,14 +1281,14 @@
 
         <project.scm.id>scm-server</project.scm.id>
 
-        <carbon.analytics.common.version>5.3.14</carbon.analytics.common.version>
+        <carbon.analytics.common.version>5.3.15</carbon.analytics.common.version>
 
         <!-- APIM Portals Component Version -->
         <carbon.apimgt.ui.version>9.1.143</carbon.apimgt.ui.version>
 
         <!-- APIM Component Version -->
 
-        <carbon.apimgt.version>9.30.51</carbon.apimgt.version>
+        <carbon.apimgt.version>9.30.53</carbon.apimgt.version>
 
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 
@@ -1422,9 +1422,9 @@
         <carbon.metrics.version>1.3.12</carbon.metrics.version>
         <!-- MB Features -->
 
-        <carbon.messaging.version>3.3.34</carbon.messaging.version>
+        <carbon.messaging.version>3.3.35</carbon.messaging.version>
         <carbon.event-processing.version>2.3.12</carbon.event-processing.version>
-        <andes.version>3.3.32</andes.version>
+        <andes.version>3.3.33</andes.version>
         <orbit.version.geronimo-jms_1.1_spec>1.1.1.wso2v1</orbit.version.geronimo-jms_1.1_spec>
         <commons-digester.version>1.8.1</commons-digester.version>
         <commons.scxml.version>0.9.0.wso2v1</commons.scxml.version>


### PR DESCRIPTION
## Purpose
- Broker connect timeout cannot be explicitly configured for TM duplication URLs.
- Upgrade Andes, Analytics Common, and the Carbon Broker versions.

### Fix
Add a logic to the .j2 file to handle "connecttimeout" broker parameter.

- Related issue https://github.com/wso2/api-manager/issues/3125