### PR TITLE
Add missing llm related scope mappings

### DIFF
--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/common/tenant-conf.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/common/tenant-conf.json
@@ -368,6 +368,14 @@
       {
         "Name": "apim:api_provider_change",
         "Roles": "admin"
+      },
+      {
+        "Name": "apim:llm_provider_manage",
+        "Roles": "admin"
+      },
+      {
+        "Name": "apim:llm_provider_read",
+        "Roles": "admin,Internal/publisher,Internal/creator"
       }
     ]
   },

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/linterCustomRulesTest/tenant-conf.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/linterCustomRulesTest/tenant-conf.json
@@ -384,6 +384,14 @@
       {
         "Name": "apim:api_provider_change",
         "Roles": "admin"
+      },
+      {
+        "Name": "apim:llm_provider_manage",
+        "Roles": "admin"
+      },
+      {
+        "Name": "apim:llm_provider_read",
+        "Roles": "admin,Internal/publisher,Internal/creator"
       }
     ]
   },

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/monetization/tenant-conf.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/monetization/tenant-conf.json
@@ -368,6 +368,14 @@
       {
         "Name": "apim:api_provider_change",
         "Roles": "admin"
+      },
+      {
+        "Name": "apim:llm_provider_manage",
+        "Roles": "admin"
+      },
+      {
+        "Name": "apim:llm_provider_read",
+        "Roles": "admin,Internal/publisher,Internal/creator"
       }
     ]
   },

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/notification/tenant-conf.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/notification/tenant-conf.json
@@ -368,6 +368,14 @@
       {
         "Name": "apim:api_provider_change",
         "Roles": "admin"
+      },
+      {
+        "Name": "apim:llm_provider_manage",
+        "Roles": "admin"
+      },
+      {
+        "Name": "apim:llm_provider_read",
+        "Roles": "admin,Internal/publisher,Internal/creator"
       }
     ]
   },

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/tenantConf/tenant-conf.json
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/tenantConf/tenant-conf.json
@@ -368,6 +368,14 @@
       {
         "Name": "apim:api_provider_change",
         "Roles": "admin"
+      },
+      {
+        "Name": "apim:llm_provider_manage",
+        "Roles": "admin"
+      },
+      {
+        "Name": "apim:llm_provider_read",
+        "Roles": "admin,Internal/publisher,Internal/creator"
       }
     ]
   },


### PR DESCRIPTION
## Purpose

This pull request addresses the missing scope mappings for the newly introduced `apim:llm_provider_manage` and `apim:llm_provider_read`. 

Adding these scope mappings, ensures that the test failures related to the feature in https://github.com/wso2/carbon-apimgt/pull/12678 are addressed.