### PR TITLE
Fix Runtime Error for API Invocation with Security Set to 'None' When Production Endpoint is Missing

### DIFF
--- a/modules/distribution/resources/api_templates/velocity_template.xml
+++ b/modules/distribution/resources/api_templates/velocity_template.xml
@@ -335,14 +335,18 @@ $in_sequences.get("$resource.getUriTemplate()").get($uri)
     </then>
     <else>
                         #if( $environmentType !='hybrid' )
+                            #if( $resource.getAuthType() == 'None' && $environmentType == 'sandbox'
+                                && $endpoint_config.get("sandbox_endpoints") )
+                                #draw_endpoint( "sandbox" $endpoint_config )
+                            #else
         <payloadFactory>
             <format>
                 <error xmlns="">
-                            #if( $environmentType == 'production' )
+                                #if( $environmentType == 'production' )
                     <message>Sandbox Key Provided for Production Gateway</message>
-                            #elseif( $environmentType == 'sandbox' )
+                                #elseif( $environmentType == 'sandbox' )
                     <message>Production Key Provided for Sandbox Gateway</message>
-                            #end
+                                #end
                 </error>
             </format>
         </payloadFactory>
@@ -352,6 +356,7 @@ $in_sequences.get("$resource.getUriTemplate()").get($uri)
         <property name="HTTP_SC" value="401" scope="axis2"/>
         <property name="NO_ENTITY_BODY" scope="axis2" action="remove"/>
         <send/>
+                            #end
                         #else
                             #if( $endpoint_config.get("production_endpoints")
                                 && $endpoint_config.get("sandbox_endpoints") )
@@ -359,7 +364,11 @@ $in_sequences.get("$resource.getUriTemplate()").get($uri)
                             #elseif( $endpoint_config.get("production_endpoints") )
         <sequence key="_sandbox_key_error_"/>
                             #elseif( $endpoint_config.get("sandbox_endpoints") )
+                                #if( $resource.getAuthType() == 'None' )
+                                    #draw_endpoint( "sandbox" $endpoint_config )
+                                #else
         <sequence key="_production_key_error_"/>
+                                #end
                             #end
                         #end
     </else>

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/token/InvokeAPIWithVariousEndpointsAndTokensInSandboxEnvTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/token/InvokeAPIWithVariousEndpointsAndTokensInSandboxEnvTestCase.java
@@ -1,0 +1,300 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.am.integration.tests.token;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+import org.wso2.am.integration.clients.publisher.api.v1.dto.APIOperationsDTO;
+import org.wso2.am.integration.clients.store.api.v1.dto.ApplicationDTO;
+import org.wso2.am.integration.clients.store.api.v1.dto.ApplicationKeyDTO;
+import org.wso2.am.integration.clients.store.api.v1.dto.ApplicationKeyGenerateRequestDTO;
+import org.wso2.am.integration.test.utils.base.APIMIntegrationConstants;
+import org.wso2.am.integration.test.utils.bean.APIRequest;
+import org.wso2.am.integration.tests.api.lifecycle.APIManagerLifecycleBaseTest;
+import org.wso2.carbon.apimgt.api.model.APIIdentifier;
+import org.wso2.carbon.automation.engine.FrameworkConstants;
+import org.wso2.carbon.automation.engine.annotations.ExecutionEnvironment;
+import org.wso2.carbon.automation.engine.annotations.SetEnvironment;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.carbon.automation.test.utils.http.client.HttpRequestUtil;
+import org.wso2.carbon.automation.test.utils.http.client.HttpResponse;
+import org.wso2.carbon.integration.common.utils.mgt.ServerConfigurationManager;
+
+import java.io.File;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+@SetEnvironment(executionEnvironments = { ExecutionEnvironment.STANDALONE })
+public class InvokeAPIWithVariousEndpointsAndTokensInSandboxEnvTestCase extends APIManagerLifecycleBaseTest {
+    private ServerConfigurationManager serverConfigurationManager;
+    private static final Log log = LogFactory.getLog(InvokeAPIWithVariousEndpointsAndTokensTestCase.class);
+    private List<APIOperationsDTO> apiOperationsDTOList;
+    private final String apiTier = APIMIntegrationConstants.API_TIER.UNLIMITED;
+    private final String applicationTier = APIMIntegrationConstants.APPLICATION_TIER.UNLIMITED;
+    private final String resourceTier = APIMIntegrationConstants.RESOURCE_TIER.UNLIMITED;
+    private String gatewayUrl;
+    private String providerName;
+    private String apiId1;
+    private String apiId2;
+    private String applicationId;
+    ApplicationKeyDTO applicationKeyProductionDTO;
+    ApplicationKeyDTO applicationKeySandboxDTO;
+    private final String SANDBOX_RESPONSE_BODY = "HelloWSO2 from File 1_Sandbox";
+    private final String PRODUCTION_KEY_FOR_API_WITH_NO_PRODUCTION_ENDPOINT_ERROR = "<error><message>Production Key Provided for Sandbox Gateway</message></error>";
+
+    @DataProvider
+    public static Object[][] userModeDataProvider() {
+        return new Object[][] { new Object[] { TestUserMode.SUPER_TENANT_ADMIN } };
+    }
+
+    @Factory(dataProvider = "userModeDataProvider")
+    public InvokeAPIWithVariousEndpointsAndTokensInSandboxEnvTestCase(TestUserMode userMode) {
+        this.userMode = userMode;
+    }
+
+    @BeforeClass(alwaysRun = true)
+    public void setEnvironment() throws Exception {
+        super.init(userMode);
+        log.info("Test starting user mode: " + userMode);
+
+        serverConfigurationManager = new ServerConfigurationManager(gatewayContextWrk);
+        serverConfigurationManager.applyConfiguration(new File(
+                getAMResourceLocation() + File.separator + "configFiles" + File.separator + "tokenTest" + File.separator + "apiInvokeCombinationsTest" + File.separator + "deployment.toml"));
+
+        // Create an application to subscribe to the APIs
+        String applicationName = "InvokeAPIWithVariousEndpointsAndTokens";
+        String applicationDescription = "Application for Invoke API with various endpoints and tokens";
+        HttpResponse applicationResponse = restAPIStore.createApplication(applicationName, applicationDescription,
+                APIMIntegrationConstants.APPLICATION_TIER.UNLIMITED, ApplicationDTO.TokenTypeEnum.JWT);
+        applicationId = applicationResponse.getData();
+
+        // Generate production and sandbox keys
+        ArrayList<String> grantTypes = new ArrayList<>();
+        grantTypes.add(APIMIntegrationConstants.GRANT_TYPE.PASSWORD);
+        grantTypes.add(APIMIntegrationConstants.GRANT_TYPE.CLIENT_CREDENTIAL);
+        applicationKeyProductionDTO = restAPIStore.generateKeys(applicationId, "3600", "",
+                ApplicationKeyGenerateRequestDTO.KeyTypeEnum.PRODUCTION, null, grantTypes);
+        applicationKeySandboxDTO = restAPIStore.generateKeys(applicationId, "3600", "",
+                ApplicationKeyGenerateRequestDTO.KeyTypeEnum.SANDBOX, null, grantTypes);
+
+        if (gatewayContextWrk.getContextTenant().getDomain().equals(FrameworkConstants.SUPER_TENANT_DOMAIN_NAME)) {
+            gatewayUrl = gatewayUrlsWrk.getWebAppURLNhttp();
+        } else {
+            gatewayUrl = gatewayUrlsWrk.getWebAppURLNhttp() + "t/" + gatewayContextWrk.getContextTenant()
+                    .getDomain() + "/";
+        }
+
+        providerName = publisherContext.getContextTenant().getContextUser().getUserName();
+    }
+
+    @Test(groups = { "wso2.am" }, description = "Invoke API with both sandbox and production endpoints and tokens")
+    public void testInvokeAPIWithBothEndpointsAndTokens() throws Exception {
+        // Create an API
+        String apiName = "InvokeAPIWithBothEndpointsAndTokens";
+        String apiContext = "invokeAPIWithBothEndpointsAndTokens";
+        String apiVersion = "1.0.0";
+        String apiDescription = "This is a test API created by API manager integration test";
+        String endpointUrl = gatewayUrl + apiContext + "/" + apiVersion + "/name";
+        String apiSandboxEndpoint = backEndServerUrl.getWebAppURLHttp() + APIMIntegrationConstants.SANDBOXEP1_WEB_APP_NAME;
+        String apiProductionEndpoint = backEndServerUrl.getWebAppURLHttp() + APIMIntegrationConstants.PRODEP1_WEB_APP_NAME;
+
+        // Add the resource
+        apiOperationsDTOList = new ArrayList<>();
+        APIOperationsDTO apiOperationDTO = new APIOperationsDTO();
+        apiOperationDTO.setTarget("/name");
+        apiOperationDTO.setVerb("GET");
+        apiOperationDTO.authType(
+                APIMIntegrationConstants.ResourceAuthTypes.APPLICATION_AND_APPLICATION_USER.getAuthType());
+        apiOperationDTO.setThrottlingPolicy(resourceTier);
+        apiOperationsDTOList.add(apiOperationDTO);
+
+        APIRequest apiRequest = new APIRequest(apiName, apiContext, new URL(apiProductionEndpoint),
+                new URL(apiSandboxEndpoint));
+        apiRequest.setTiersCollection(apiTier);
+        apiRequest.setTier(apiTier);
+        apiRequest.setVersion(apiVersion);
+        apiRequest.setOperationsDTOS(apiOperationsDTOList);
+        apiRequest.setVisibility("public");
+        apiRequest.setDescription(apiDescription);
+        apiRequest.setProvider(providerName);
+        APIIdentifier apiIdentifier = new APIIdentifier(providerName, apiName, apiVersion);
+
+        apiId1 = createPublishAndSubscribeToAPIUsingRest(apiRequest, restAPIPublisher, restAPIStore, applicationId,
+                applicationTier);
+
+        // Invoke the API with sandbox endpoint and JWT token
+        Map<String, String> requestHeaders = new HashMap<>();
+        assert applicationKeySandboxDTO.getToken() != null;
+        requestHeaders.put("Authorization", "Bearer " + applicationKeySandboxDTO.getToken().getAccessToken());
+        HttpResponse sandboxResponse = HttpRequestUtil.doGet(endpointUrl, requestHeaders);
+        assertEquals(sandboxResponse.getResponseCode(), HTTP_RESPONSE_CODE_OK, "Response code mismatched");
+        assertEquals(sandboxResponse.getData(), SANDBOX_RESPONSE_BODY, "Response body mismatch");
+
+        // Invoke the API with production endpoint and JWT token
+        requestHeaders = new HashMap<>();
+        assert applicationKeyProductionDTO.getToken() != null;
+        requestHeaders.put("Authorization", "Bearer " + applicationKeyProductionDTO.getToken().getAccessToken());
+        HttpResponse productionResponse = HttpRequestUtil.doGet(endpointUrl, requestHeaders);
+        assertEquals(productionResponse.getResponseCode(), HTTP_RESPONSE_CODE_UNAUTHORIZED, "Response code mismatched");
+        assertEquals(productionResponse.getData(), PRODUCTION_KEY_FOR_API_WITH_NO_PRODUCTION_ENDPOINT_ERROR, "Response body mismatch");
+
+        // Update the resource auth type to none
+        apiOperationDTO = apiOperationsDTOList.get(0);
+        apiOperationDTO.authType(APIMIntegrationConstants.ResourceAuthTypes.NONE.getAuthType());
+        apiOperationsDTOList.clear();
+        apiOperationsDTOList.add(apiOperationDTO);
+        apiRequest.setOperationsDTOS(apiOperationsDTOList);
+        HttpResponse updateAPIHTTPResponse = restAPIPublisher.updateAPI(apiRequest, apiId1);
+
+        // Undeploy and Delete API Revisions
+        undeployAndDeleteAPIRevisionsUsingRest(apiId1, restAPIPublisher);
+        // Create Revision and Deploy to Gateway
+        createAPIRevisionAndDeployUsingRest(apiId1, restAPIPublisher);
+
+        waitForAPIDeploymentSync(providerName, apiName, apiVersion, APIMIntegrationConstants.IS_API_EXISTS);
+
+        assertEquals(updateAPIHTTPResponse.getResponseCode(), HTTP_RESPONSE_CODE_OK,
+                "Update API Response Code is invalid. " + getAPIIdentifierString(apiIdentifier));
+        assertNotNull(updateAPIHTTPResponse.getData(),
+                "Error in API Update in " + getAPIIdentifierString(apiIdentifier));
+
+        // Invoke the updated API with sandbox endpoint and JWT token
+        requestHeaders = new HashMap<>();
+        requestHeaders.put("Authorization", "Bearer " + applicationKeySandboxDTO.getToken().getAccessToken());
+        sandboxResponse = HttpRequestUtil.doGet(endpointUrl, requestHeaders);
+        assertEquals(sandboxResponse.getResponseCode(), HTTP_RESPONSE_CODE_OK, "Response code mismatched");
+        assertEquals(sandboxResponse.getData(), SANDBOX_RESPONSE_BODY, "Response body mismatch");
+
+        // Invoke the updated API with production endpoint and JWT token
+        requestHeaders = new HashMap<>();
+        requestHeaders.put("Authorization", "Bearer " + applicationKeyProductionDTO.getToken().getAccessToken());
+        productionResponse = HttpRequestUtil.doGet(endpointUrl, requestHeaders);
+        assertEquals(productionResponse.getResponseCode(), HTTP_RESPONSE_CODE_OK, "Response code mismatched");
+        assertEquals(productionResponse.getData(), SANDBOX_RESPONSE_BODY, "Response body mismatch");
+    }
+
+    @Test(groups = { "wso2.am" }, description = "Invoke API with sandbox endpoint and both tokens")
+    public void testInvokeAPIWithSandboxEndpointAndBothTokens() throws Exception {
+        // Create an API
+        String apiName = "InvokeAPIWithSandboxEndpointAndBothTokens";
+        String apiContext = "invokeAPIWithSandboxEndpointAndBothTokens";
+        String apiVersion = "1.0.0";
+        String apiDescription = "This is a test API created by API manager integration test";
+        String endpointUrl = gatewayUrl + apiContext + "/" + apiVersion + "/name";
+        String apiSandboxEndpoint = backEndServerUrl.getWebAppURLHttp() + APIMIntegrationConstants.SANDBOXEP1_WEB_APP_NAME;
+        List<String> endpointLB = new ArrayList<>();
+        endpointLB.add(apiSandboxEndpoint);
+
+        // Add the resource
+        apiOperationsDTOList = new ArrayList<>();
+        APIOperationsDTO apiOperationDTO = new APIOperationsDTO();
+        apiOperationDTO.setTarget("/name");
+        apiOperationDTO.setVerb("GET");
+        apiOperationDTO.authType(
+                APIMIntegrationConstants.ResourceAuthTypes.APPLICATION_AND_APPLICATION_USER.getAuthType());
+        apiOperationDTO.setThrottlingPolicy(resourceTier);
+        apiOperationsDTOList.add(apiOperationDTO);
+
+        APIRequest apiRequest = new APIRequest(apiName, apiContext, apiVersion, null, endpointLB);
+        apiRequest.setTiersCollection(apiTier);
+        apiRequest.setTier(apiTier);
+        apiRequest.setVersion(apiVersion);
+        apiRequest.setOperationsDTOS(apiOperationsDTOList);
+        apiRequest.setVisibility("public");
+        apiRequest.setDescription(apiDescription);
+        apiRequest.setProvider(providerName);
+        APIIdentifier apiIdentifier = new APIIdentifier(providerName, apiName, apiVersion);
+
+        apiId2 = createPublishAndSubscribeToAPIUsingRest(apiRequest, restAPIPublisher, restAPIStore, applicationId,
+                applicationTier);
+
+        // Invoke the API with sandbox endpoint and JWT token
+        Map<String, String> requestHeaders = new HashMap<>();
+        assert applicationKeySandboxDTO.getToken() != null;
+        requestHeaders.put("Authorization", "Bearer " + applicationKeySandboxDTO.getToken().getAccessToken());
+        HttpResponse sandboxResponse = HttpRequestUtil.doGet(endpointUrl, requestHeaders);
+        assertEquals(sandboxResponse.getResponseCode(), HTTP_RESPONSE_CODE_OK, "Response code mismatched");
+        assertEquals(sandboxResponse.getData(), SANDBOX_RESPONSE_BODY, "Response body mismatch");
+
+        // Invoke the API with production endpoint and JWT token
+        requestHeaders = new HashMap<>();
+        assert applicationKeyProductionDTO.getToken() != null;
+        requestHeaders.put("Authorization", "Bearer " + applicationKeyProductionDTO.getToken().getAccessToken());
+        HttpResponse productionResponse = HttpRequestUtil.doGet(endpointUrl, requestHeaders);
+        assertEquals(productionResponse.getResponseCode(), HTTP_RESPONSE_CODE_UNAUTHORIZED, "Response code mismatched");
+        assertEquals(productionResponse.getData(), PRODUCTION_KEY_FOR_API_WITH_NO_PRODUCTION_ENDPOINT_ERROR,
+                "Response body mismatch");
+
+        // Update the resource auth type to none
+        apiOperationDTO = apiOperationsDTOList.get(0);
+        apiOperationDTO.authType(APIMIntegrationConstants.ResourceAuthTypes.NONE.getAuthType());
+        apiOperationsDTOList.clear();
+        apiOperationsDTOList.add(apiOperationDTO);
+        apiRequest.setOperationsDTOS(apiOperationsDTOList);
+        HttpResponse updateAPIHTTPResponse = restAPIPublisher.updateAPI(apiRequest, apiId2);
+
+        // Undeploy and Delete API Revisions
+        undeployAndDeleteAPIRevisionsUsingRest(apiId2, restAPIPublisher);
+        // Create Revision and Deploy to Gateway
+        createAPIRevisionAndDeployUsingRest(apiId2, restAPIPublisher);
+
+        waitForAPIDeploymentSync(providerName, apiName, apiVersion, APIMIntegrationConstants.IS_API_EXISTS);
+
+        assertEquals(updateAPIHTTPResponse.getResponseCode(), HTTP_RESPONSE_CODE_OK,
+                "Update API Response Code is invalid. " + getAPIIdentifierString(apiIdentifier));
+        assertNotNull(updateAPIHTTPResponse.getData(),
+                "Error in API Update in " + getAPIIdentifierString(apiIdentifier));
+
+        // Invoke the updated API with sandbox endpoint and JWT token
+        requestHeaders = new HashMap<>();
+        requestHeaders.put("Authorization", "Bearer " + applicationKeySandboxDTO.getToken().getAccessToken());
+        sandboxResponse = HttpRequestUtil.doGet(endpointUrl, requestHeaders);
+        assertEquals(sandboxResponse.getResponseCode(), HTTP_RESPONSE_CODE_OK, "Response code mismatched");
+        assertEquals(sandboxResponse.getData(), SANDBOX_RESPONSE_BODY, "Response body mismatch");
+
+        // Invoke the updated API with production endpoint and JWT token
+        requestHeaders = new HashMap<>();
+        requestHeaders.put("Authorization", "Bearer " + applicationKeyProductionDTO.getToken().getAccessToken());
+        productionResponse = HttpRequestUtil.doGet(endpointUrl, requestHeaders);
+        assertEquals(productionResponse.getResponseCode(), HTTP_RESPONSE_CODE_OK, "Response code mismatched");
+        assertEquals(productionResponse.getData(), SANDBOX_RESPONSE_BODY, "Response body mismatch");
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void destroy() throws Exception {
+        restAPIStore.deleteApplication(applicationId);
+        undeployAndDeleteAPIRevisionsUsingRest(apiId1, restAPIPublisher);
+        undeployAndDeleteAPIRevisionsUsingRest(apiId2, restAPIPublisher);
+        restAPIPublisher.deleteAPI(apiId1);
+        restAPIPublisher.deleteAPI(apiId2);
+        serverConfigurationManager.restoreToLastConfiguration();
+        super.cleanUp();
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/token/InvokeAPIWithVariousEndpointsAndTokensTestCase.java
+++ b/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/token/InvokeAPIWithVariousEndpointsAndTokensTestCase.java
@@ -1,0 +1,388 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.am.integration.tests.token;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+
+import org.wso2.am.integration.clients.publisher.api.v1.dto.APIOperationsDTO;
+import org.wso2.am.integration.tests.api.lifecycle.APIManagerLifecycleBaseTest;
+import org.wso2.am.integration.test.utils.bean.APIRequest;
+import org.wso2.carbon.apimgt.api.model.APIIdentifier;
+import org.wso2.carbon.automation.engine.FrameworkConstants;
+import org.wso2.am.integration.test.utils.base.APIMIntegrationConstants;
+import org.wso2.carbon.automation.test.utils.http.client.HttpResponse;
+import org.wso2.am.integration.clients.store.api.v1.dto.ApplicationDTO;
+import org.wso2.carbon.automation.test.utils.http.client.HttpRequestUtil;
+import org.wso2.am.integration.clients.store.api.v1.dto.ApplicationKeyDTO;
+import org.wso2.am.integration.clients.store.api.v1.dto.ApplicationKeyGenerateRequestDTO;
+import org.wso2.carbon.automation.engine.annotations.ExecutionEnvironment;
+import org.wso2.carbon.automation.engine.annotations.SetEnvironment;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+
+import java.util.Map;
+import java.util.HashMap;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+@SetEnvironment(executionEnvironments = { ExecutionEnvironment.STANDALONE })
+public class InvokeAPIWithVariousEndpointsAndTokensTestCase extends APIManagerLifecycleBaseTest {
+
+    private static final Log log = LogFactory.getLog(InvokeAPIWithVariousEndpointsAndTokensTestCase.class);
+    private List<APIOperationsDTO> apiOperationsDTOList;
+    private final String apiTier = APIMIntegrationConstants.API_TIER.UNLIMITED;
+    private final String applicationTier = APIMIntegrationConstants.APPLICATION_TIER.UNLIMITED;
+    private final String resourceTier = APIMIntegrationConstants.RESOURCE_TIER.UNLIMITED;
+    private String gatewayUrl;
+    private String providerName;
+    private String apiId1;
+    private String apiId2;
+    private String apiId3;
+    private String applicationId;
+    ApplicationKeyDTO applicationKeyProductionDTO;
+    ApplicationKeyDTO applicationKeySandboxDTO;
+    private final String SANDBOX_RESPONSE_BODY = "HelloWSO2 from File 1_Sandbox";
+    private final String PRODUCTION_RESPONSE_BODY = "HelloWSO2 from File 1";
+    private final String SANDBOX_KEY_FOR_API_WITH_NO_SANDBOX_ENDPOINT_ERROR = "{\"code\":\"900901\",\"type\":\"Status report\",\"message\":\"Runtime Error\",\"description\":\"Sandbox key offered to the API with no sandbox endpoint\"}";
+    private final String PRODUCTION_KEY_FOR_API_WITH_NO_PRODUCTION_ENDPOINT_ERROR = "{\"code\":\"900901\",\"type\":\"Status report\",\"message\":\"Runtime Error\",\"description\":\"Production key offered to the API with no production endpoint\"}";
+
+    @DataProvider
+    public static Object[][] userModeDataProvider() {
+        return new Object[][] { new Object[] { TestUserMode.SUPER_TENANT_ADMIN },
+                new Object[] { TestUserMode.TENANT_ADMIN }, };
+    }
+
+    @Factory(dataProvider = "userModeDataProvider")
+    public InvokeAPIWithVariousEndpointsAndTokensTestCase(TestUserMode userMode) {
+        this.userMode = userMode;
+    }
+
+    @BeforeClass(alwaysRun = true)
+    public void setEnvironment() throws Exception {
+        super.init(userMode);
+        log.info("Test starting user mode: " + userMode);
+
+        // Create an application to subscribe to the APIs
+        String applicationName = "InvokeAPIWithVariousEndpointsAndTokens";
+        String applicationDescription = "Application for Invoke API with various endpoints and tokens";
+        HttpResponse applicationResponse = restAPIStore.createApplication(applicationName, applicationDescription,
+                APIMIntegrationConstants.APPLICATION_TIER.UNLIMITED, ApplicationDTO.TokenTypeEnum.JWT);
+        applicationId = applicationResponse.getData();
+
+        // Generate production and sandbox keys
+        ArrayList<String> grantTypes = new ArrayList<>();
+        grantTypes.add(APIMIntegrationConstants.GRANT_TYPE.PASSWORD);
+        grantTypes.add(APIMIntegrationConstants.GRANT_TYPE.CLIENT_CREDENTIAL);
+        applicationKeyProductionDTO = restAPIStore.generateKeys(applicationId, "3600", "",
+                ApplicationKeyGenerateRequestDTO.KeyTypeEnum.PRODUCTION, null, grantTypes);
+        applicationKeySandboxDTO = restAPIStore.generateKeys(applicationId, "3600", "",
+                ApplicationKeyGenerateRequestDTO.KeyTypeEnum.SANDBOX, null, grantTypes);
+
+        if (gatewayContextWrk.getContextTenant().getDomain().equals(FrameworkConstants.SUPER_TENANT_DOMAIN_NAME)) {
+            gatewayUrl = gatewayUrlsWrk.getWebAppURLNhttp();
+        } else {
+            gatewayUrl = gatewayUrlsWrk.getWebAppURLNhttp() + "t/" + gatewayContextWrk.getContextTenant()
+                    .getDomain() + "/";
+        }
+
+        providerName = publisherContext.getContextTenant().getContextUser().getUserName();
+    }
+
+    @Test(groups = { "wso2.am" }, description = "Invoke API with both sandbox and production endpoints and tokens")
+    public void testInvokeAPIWithBothEndpointsAndTokens() throws Exception {
+        // Create an API
+        String apiName = "InvokeAPIWithBothEndpointsAndTokens";
+        String apiContext = "invokeAPIWithBothEndpointsAndTokens";
+        String apiVersion = "1.0.0";
+        String apiDescription = "This is a test API created by API manager integration test";
+        String endpointUrl = gatewayUrl + apiContext + "/" + apiVersion + "/name";
+        String apiSandboxEndpoint = backEndServerUrl.getWebAppURLHttp() + APIMIntegrationConstants.SANDBOXEP1_WEB_APP_NAME;
+        String apiProductionEndpoint = backEndServerUrl.getWebAppURLHttp() + APIMIntegrationConstants.PRODEP1_WEB_APP_NAME;
+
+        // Add the resource
+        apiOperationsDTOList = new ArrayList<>();
+        APIOperationsDTO apiOperationDTO = new APIOperationsDTO();
+        apiOperationDTO.setTarget("/name");
+        apiOperationDTO.setVerb("GET");
+        apiOperationDTO.authType(
+                APIMIntegrationConstants.ResourceAuthTypes.APPLICATION_AND_APPLICATION_USER.getAuthType());
+        apiOperationDTO.setThrottlingPolicy(resourceTier);
+        apiOperationsDTOList.add(apiOperationDTO);
+
+        APIRequest apiRequest = new APIRequest(apiName, apiContext, new URL(apiProductionEndpoint),
+                new URL(apiSandboxEndpoint));
+        apiRequest.setTiersCollection(apiTier);
+        apiRequest.setTier(apiTier);
+        apiRequest.setVersion(apiVersion);
+        apiRequest.setOperationsDTOS(apiOperationsDTOList);
+        apiRequest.setVisibility("public");
+        apiRequest.setDescription(apiDescription);
+        apiRequest.setProvider(providerName);
+        APIIdentifier apiIdentifier = new APIIdentifier(providerName, apiName, apiVersion);
+
+        apiId1 = createPublishAndSubscribeToAPIUsingRest(apiRequest, restAPIPublisher, restAPIStore, applicationId,
+                applicationTier);
+
+        // Invoke the API with sandbox endpoint and JWT token
+        Map<String, String> requestHeaders = new HashMap<>();
+        assert applicationKeySandboxDTO.getToken() != null;
+        requestHeaders.put("Authorization", "Bearer " + applicationKeySandboxDTO.getToken().getAccessToken());
+        HttpResponse sandboxResponse = HttpRequestUtil.doGet(endpointUrl, requestHeaders);
+        assertEquals(sandboxResponse.getResponseCode(), HTTP_RESPONSE_CODE_OK, "Response code mismatched");
+        assertEquals(sandboxResponse.getData(), SANDBOX_RESPONSE_BODY, "Response body mismatch");
+
+        // Invoke the API with production endpoint and JWT token
+        requestHeaders = new HashMap<>();
+        assert applicationKeyProductionDTO.getToken() != null;
+        requestHeaders.put("Authorization", "Bearer " + applicationKeyProductionDTO.getToken().getAccessToken());
+        HttpResponse productionResponse = HttpRequestUtil.doGet(endpointUrl, requestHeaders);
+        assertEquals(productionResponse.getResponseCode(), HTTP_RESPONSE_CODE_OK, "Response code mismatched");
+        assertEquals(productionResponse.getData(), PRODUCTION_RESPONSE_BODY, "Response body mismatch");
+
+        // Update the resource auth type to none
+        apiOperationDTO = apiOperationsDTOList.get(0);
+        apiOperationDTO.authType(APIMIntegrationConstants.ResourceAuthTypes.NONE.getAuthType());
+        apiOperationsDTOList.clear();
+        apiOperationsDTOList.add(apiOperationDTO);
+        apiRequest.setOperationsDTOS(apiOperationsDTOList);
+        HttpResponse updateAPIHTTPResponse = restAPIPublisher.updateAPI(apiRequest, apiId1);
+
+        // Undeploy and Delete API Revisions
+        undeployAndDeleteAPIRevisionsUsingRest(apiId1, restAPIPublisher);
+        // Create Revision and Deploy to Gateway
+        createAPIRevisionAndDeployUsingRest(apiId1, restAPIPublisher);
+
+        waitForAPIDeploymentSync(providerName, apiName, apiVersion, APIMIntegrationConstants.IS_API_EXISTS);
+
+        assertEquals(updateAPIHTTPResponse.getResponseCode(), HTTP_RESPONSE_CODE_OK,
+                "Update API Response Code is invalid. " + getAPIIdentifierString(apiIdentifier));
+        assertNotNull(updateAPIHTTPResponse.getData(),
+                "Error in API Update in " + getAPIIdentifierString(apiIdentifier));
+
+        // Invoke the updated API with sandbox endpoint and JWT token
+        requestHeaders = new HashMap<>();
+        requestHeaders.put("Authorization", "Bearer " + applicationKeySandboxDTO.getToken().getAccessToken());
+        sandboxResponse = HttpRequestUtil.doGet(endpointUrl, requestHeaders);
+        assertEquals(sandboxResponse.getResponseCode(), HTTP_RESPONSE_CODE_OK, "Response code mismatched");
+        assertEquals(sandboxResponse.getData(), PRODUCTION_RESPONSE_BODY, "Response body mismatch");
+
+        // Invoke the updated API with production endpoint and JWT token
+        requestHeaders = new HashMap<>();
+        requestHeaders.put("Authorization", "Bearer " + applicationKeyProductionDTO.getToken().getAccessToken());
+        productionResponse = HttpRequestUtil.doGet(endpointUrl, requestHeaders);
+        assertEquals(productionResponse.getResponseCode(), HTTP_RESPONSE_CODE_OK, "Response code mismatched");
+        assertEquals(productionResponse.getData(), PRODUCTION_RESPONSE_BODY, "Response body mismatch");
+    }
+
+    @Test(groups = { "wso2.am" }, description = "Invoke API with production endpoint and both tokens")
+    public void testInvokeAPIWithProductionEndpointAndBothTokens() throws Exception {
+        // Create an API
+        String apiName = "InvokeAPIWithProductionEndpointAndBothTokens";
+        String apiContext = "invokeAPIWithProductionEndpointAndBothTokens";
+        String apiVersion = "1.0.0";
+        String apiDescription = "This is a test API created by API manager integration test";
+        String endpointUrl = gatewayUrl + apiContext + "/" + apiVersion + "/name";
+        String apiProductionEndpoint = backEndServerUrl.getWebAppURLHttp() + APIMIntegrationConstants.PRODEP1_WEB_APP_NAME;
+        List<String> endpointLB = new ArrayList<>();
+        endpointLB.add(apiProductionEndpoint);
+
+        // Add the resource
+        apiOperationsDTOList = new ArrayList<>();
+        APIOperationsDTO apiOperationDTO = new APIOperationsDTO();
+        apiOperationDTO.setTarget("/name");
+        apiOperationDTO.setVerb("GET");
+        apiOperationDTO.authType(
+                APIMIntegrationConstants.ResourceAuthTypes.APPLICATION_AND_APPLICATION_USER.getAuthType());
+        apiOperationDTO.setThrottlingPolicy(resourceTier);
+        apiOperationsDTOList.add(apiOperationDTO);
+
+        APIRequest apiRequest = new APIRequest(apiName, apiContext, apiVersion, endpointLB, null);
+        apiRequest.setTiersCollection(apiTier);
+        apiRequest.setTier(apiTier);
+        apiRequest.setVersion(apiVersion);
+        apiRequest.setOperationsDTOS(apiOperationsDTOList);
+        apiRequest.setVisibility("public");
+        apiRequest.setDescription(apiDescription);
+        apiRequest.setProvider(providerName);
+        APIIdentifier apiIdentifier = new APIIdentifier(providerName, apiName, apiVersion);
+
+        apiId2 = createPublishAndSubscribeToAPIUsingRest(apiRequest, restAPIPublisher, restAPIStore, applicationId,
+                applicationTier);
+
+        // Invoke the API with sandbox endpoint and JWT token
+        Map<String, String> requestHeaders = new HashMap<>();
+        assert applicationKeySandboxDTO.getToken() != null;
+        requestHeaders.put("Authorization", "Bearer " + applicationKeySandboxDTO.getToken().getAccessToken());
+        HttpResponse sandboxResponse = HttpRequestUtil.doGet(endpointUrl, requestHeaders);
+        assertEquals(sandboxResponse.getResponseCode(), HTTP_RESPONSE_CODE_FORBIDDEN, "Response code mismatched");
+        assertEquals(sandboxResponse.getData(), SANDBOX_KEY_FOR_API_WITH_NO_SANDBOX_ENDPOINT_ERROR,
+                "Response body mismatch");
+
+        // Invoke the API with production endpoint and JWT token
+        requestHeaders = new HashMap<>();
+        assert applicationKeyProductionDTO.getToken() != null;
+        requestHeaders.put("Authorization", "Bearer " + applicationKeyProductionDTO.getToken().getAccessToken());
+        HttpResponse productionResponse = HttpRequestUtil.doGet(endpointUrl, requestHeaders);
+        assertEquals(productionResponse.getResponseCode(), HTTP_RESPONSE_CODE_OK, "Response code mismatched");
+        assertEquals(productionResponse.getData(), PRODUCTION_RESPONSE_BODY, "Response body mismatch");
+
+        // Update the resource auth type to none
+        apiOperationDTO = apiOperationsDTOList.get(0);
+        apiOperationDTO.authType(APIMIntegrationConstants.ResourceAuthTypes.NONE.getAuthType());
+        apiOperationsDTOList.clear();
+        apiOperationsDTOList.add(apiOperationDTO);
+        apiRequest.setOperationsDTOS(apiOperationsDTOList);
+        HttpResponse updateAPIHTTPResponse = restAPIPublisher.updateAPI(apiRequest, apiId2);
+
+        // Undeploy and Delete API Revisions
+        undeployAndDeleteAPIRevisionsUsingRest(apiId2, restAPIPublisher);
+        // Create Revision and Deploy to Gateway
+        createAPIRevisionAndDeployUsingRest(apiId2, restAPIPublisher);
+
+        waitForAPIDeploymentSync(providerName, apiName, apiVersion, APIMIntegrationConstants.IS_API_EXISTS);
+
+        assertEquals(updateAPIHTTPResponse.getResponseCode(), HTTP_RESPONSE_CODE_OK,
+                "Update API Response Code is invalid. " + getAPIIdentifierString(apiIdentifier));
+        assertNotNull(updateAPIHTTPResponse.getData(),
+                "Error in API Update in " + getAPIIdentifierString(apiIdentifier));
+
+        // Invoke the updated API with sandbox endpoint and JWT token
+        requestHeaders = new HashMap<>();
+        requestHeaders.put("Authorization", "Bearer " + applicationKeySandboxDTO.getToken().getAccessToken());
+        sandboxResponse = HttpRequestUtil.doGet(endpointUrl, requestHeaders);
+        assertEquals(sandboxResponse.getResponseCode(), HTTP_RESPONSE_CODE_OK, "Response code mismatched");
+        assertEquals(sandboxResponse.getData(), PRODUCTION_RESPONSE_BODY, "Response body mismatch");
+
+        // Invoke the updated API with production endpoint and JWT token
+        requestHeaders = new HashMap<>();
+        requestHeaders.put("Authorization", "Bearer " + applicationKeyProductionDTO.getToken().getAccessToken());
+        productionResponse = HttpRequestUtil.doGet(endpointUrl, requestHeaders);
+        assertEquals(productionResponse.getResponseCode(), HTTP_RESPONSE_CODE_OK, "Response code mismatched");
+        assertEquals(productionResponse.getData(), PRODUCTION_RESPONSE_BODY, "Response body mismatch");
+    }
+
+    @Test(groups = { "wso2.am" }, description = "Invoke API with sandbox endpoint and both tokens")
+    public void testInvokeAPIWithSandboxEndpointAndBothTokens() throws Exception {
+        // Create an API
+        String apiName = "InvokeAPIWithSandboxEndpointAndBothTokens";
+        String apiContext = "invokeAPIWithSandboxEndpointAndBothTokens";
+        String apiVersion = "1.0.0";
+        String apiDescription = "This is a test API created by API manager integration test";
+        String endpointUrl = gatewayUrl + apiContext + "/" + apiVersion + "/name";
+        String apiSandboxEndpoint = backEndServerUrl.getWebAppURLHttp() + APIMIntegrationConstants.SANDBOXEP1_WEB_APP_NAME;
+        List<String> endpointLB = new ArrayList<>();
+        endpointLB.add(apiSandboxEndpoint);
+
+        // Add the resource
+        apiOperationsDTOList = new ArrayList<>();
+        APIOperationsDTO apiOperationDTO = new APIOperationsDTO();
+        apiOperationDTO.setTarget("/name");
+        apiOperationDTO.setVerb("GET");
+        apiOperationDTO.authType(
+                APIMIntegrationConstants.ResourceAuthTypes.APPLICATION_AND_APPLICATION_USER.getAuthType());
+        apiOperationDTO.setThrottlingPolicy(resourceTier);
+        apiOperationsDTOList.add(apiOperationDTO);
+
+        APIRequest apiRequest = new APIRequest(apiName, apiContext, apiVersion, null, endpointLB);
+        apiRequest.setTiersCollection(apiTier);
+        apiRequest.setTier(apiTier);
+        apiRequest.setVersion(apiVersion);
+        apiRequest.setOperationsDTOS(apiOperationsDTOList);
+        apiRequest.setVisibility("public");
+        apiRequest.setDescription(apiDescription);
+        apiRequest.setProvider(providerName);
+        APIIdentifier apiIdentifier = new APIIdentifier(providerName, apiName, apiVersion);
+
+        apiId3 = createPublishAndSubscribeToAPIUsingRest(apiRequest, restAPIPublisher, restAPIStore, applicationId,
+                applicationTier);
+
+        // Invoke the API with sandbox endpoint and JWT token
+        Map<String, String> requestHeaders = new HashMap<>();
+        assert applicationKeySandboxDTO.getToken() != null;
+        requestHeaders.put("Authorization", "Bearer " + applicationKeySandboxDTO.getToken().getAccessToken());
+        HttpResponse sandboxResponse = HttpRequestUtil.doGet(endpointUrl, requestHeaders);
+        assertEquals(sandboxResponse.getResponseCode(), HTTP_RESPONSE_CODE_OK, "Response code mismatched");
+        assertEquals(sandboxResponse.getData(), SANDBOX_RESPONSE_BODY, "Response body mismatch");
+
+        // Invoke the API with production endpoint and JWT token
+        requestHeaders = new HashMap<>();
+        assert applicationKeyProductionDTO.getToken() != null;
+        requestHeaders.put("Authorization", "Bearer " + applicationKeyProductionDTO.getToken().getAccessToken());
+        HttpResponse productionResponse = HttpRequestUtil.doGet(endpointUrl, requestHeaders);
+        assertEquals(productionResponse.getResponseCode(), HTTP_RESPONSE_CODE_FORBIDDEN, "Response code mismatched");
+        assertEquals(productionResponse.getData(), PRODUCTION_KEY_FOR_API_WITH_NO_PRODUCTION_ENDPOINT_ERROR,
+                "Response body mismatch");
+
+        // Update the resource auth type to none
+        apiOperationDTO = apiOperationsDTOList.get(0);
+        apiOperationDTO.authType(APIMIntegrationConstants.ResourceAuthTypes.NONE.getAuthType());
+        apiOperationsDTOList.clear();
+        apiOperationsDTOList.add(apiOperationDTO);
+        apiRequest.setOperationsDTOS(apiOperationsDTOList);
+        HttpResponse updateAPIHTTPResponse = restAPIPublisher.updateAPI(apiRequest, apiId3);
+
+        // Undeploy and Delete API Revisions
+        undeployAndDeleteAPIRevisionsUsingRest(apiId3, restAPIPublisher);
+        // Create Revision and Deploy to Gateway
+        createAPIRevisionAndDeployUsingRest(apiId3, restAPIPublisher);
+
+        waitForAPIDeploymentSync(providerName, apiName, apiVersion, APIMIntegrationConstants.IS_API_EXISTS);
+
+        assertEquals(updateAPIHTTPResponse.getResponseCode(), HTTP_RESPONSE_CODE_OK,
+                "Update API Response Code is invalid. " + getAPIIdentifierString(apiIdentifier));
+        assertNotNull(updateAPIHTTPResponse.getData(),
+                "Error in API Update in " + getAPIIdentifierString(apiIdentifier));
+
+        // Invoke the updated API with sandbox endpoint and JWT token
+        requestHeaders = new HashMap<>();
+        requestHeaders.put("Authorization", "Bearer " + applicationKeySandboxDTO.getToken().getAccessToken());
+        sandboxResponse = HttpRequestUtil.doGet(endpointUrl, requestHeaders);
+        assertEquals(sandboxResponse.getResponseCode(), HTTP_RESPONSE_CODE_OK, "Response code mismatched");
+        assertEquals(sandboxResponse.getData(), SANDBOX_RESPONSE_BODY, "Response body mismatch");
+
+        // Invoke the updated API with production endpoint and JWT token
+        requestHeaders = new HashMap<>();
+        requestHeaders.put("Authorization", "Bearer " + applicationKeyProductionDTO.getToken().getAccessToken());
+        productionResponse = HttpRequestUtil.doGet(endpointUrl, requestHeaders);
+        assertEquals(productionResponse.getResponseCode(), HTTP_RESPONSE_CODE_OK, "Response code mismatched");
+        assertEquals(productionResponse.getData(), SANDBOX_RESPONSE_BODY, "Response body mismatch");
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void destroy() throws Exception {
+        restAPIStore.deleteApplication(applicationId);
+        undeployAndDeleteAPIRevisionsUsingRest(apiId1, restAPIPublisher);
+        undeployAndDeleteAPIRevisionsUsingRest(apiId2, restAPIPublisher);
+        undeployAndDeleteAPIRevisionsUsingRest(apiId3, restAPIPublisher);
+        restAPIPublisher.deleteAPI(apiId1);
+        restAPIPublisher.deleteAPI(apiId2);
+        restAPIPublisher.deleteAPI(apiId3);
+        super.cleanUp();
+    }
+}

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/tokenTest/apiInvokeCombinationsTest/deployment.toml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/tokenTest/apiInvokeCombinationsTest/deployment.toml
@@ -1,0 +1,282 @@
+[server]
+hostname = "localhost"
+#offset=0
+base_path = "${carbon.protocol}://${carbon.host}:${carbon.management.port}"
+server_role = "default"
+enable_shutdown_from_api = true
+enable_restart_from_api = true
+
+[super_admin]
+username = "admin"
+password = "admin"
+create_admin_account = true
+
+[user_store]
+type = "database_unique_id"
+
+[database.apim_db]
+driver = "$env{API_MANAGER_DATABASE_DRIVER}"
+url = "$env{API_MANAGER_DATABASE_URL}"
+username = "$env{API_MANAGER_DATABASE_USERNAME}"
+password = "$env{API_MANAGER_DATABASE_PASSWORD}"
+validationQuery = "$env{API_MANAGER_DATABASE_VALIDATION_QUERY}"
+
+[database.shared_db]
+driver = "$env{SHARED_DATABASE_DRIVER}"
+url = "$env{SHARED_DATABASE_URL}"
+username = "$env{SHARED_DATABASE_USERNAME}"
+password = "$env{SHARED_DATABASE_PASSWORD}"
+validationQuery = "$env{SHARED_DATABASE_VALIDATION_QUERY}"
+
+[keystore.tls]
+file_name =  "wso2carbon.jks"
+type =  "JKS"
+password =  "wso2carbon"
+alias =  "wso2carbon"
+key_password =  "wso2carbon"
+
+[[apim.gateway.environment]]
+name = "Default"
+type = "sandbox"
+provider = "wso2"
+display_in_api_console = true
+description = "This is a hybrid gateway that handles both production and sandbox token traffic."
+show_as_token_endpoint_url = true
+service_url = "https://localhost:${mgt.transport.https.port}/services/"
+username = "admin"
+password = "admin"
+ws_endpoint = "ws://localhost:9099"
+http_endpoint = "http://localhost:${http.nio.port}"
+https_endpoint = "https://localhost:${https.nio.port}"
+
+[[apim.gateway.environment]]
+name = "devportalEnv"
+display_name = "Developer portal Test Environment"
+type = "sandbox"
+display_in_api_console = false
+description = "development api gateway broker"
+provider = "solace"
+service_url = "http://localhost:9960"
+username = "testUser"
+ws_endpoint = "ws://localhost:9960/"
+wss_endpoint = "wss://localhost:9960/"
+http_endpoint = "http://localhost:9960"
+https_endpoint = "https://localhost:9960/"
+password = "testPassword"
+show_as_token_endpoint_url = false
+
+[apim.gateway.environment.properties]
+Organization = "TestWSO2"
+DisplayName = "Developer portal Test Environment"
+DevAccountName = "devPortTestEnv"
+
+#[apim.cache.gateway_token]
+#enable = true
+#expiry_time = "15m"
+
+#[apim.cache.resource]
+#enable = true
+
+#[apim.cache.km_token]
+#enable = false
+#expiry_time = "15m"
+
+#[apim.cache.recent_apis]
+#enable = false
+
+#[apim.cache.scopes]
+#enable = true
+
+#[apim.cache.publisher_roles]
+#enable = true
+
+#[apim.cache.jwt_claim]
+#enable = true
+#expiry_time = "15m"
+
+#[apim.cache.tags]
+#expiry_time = "2m"
+
+#[apim.analytics]
+#enable = false
+#store_api_url = "https://localhost:7444"
+#username = "$ref{super_admin.username}"
+#password = "$ref{super_admin.password}"
+#event_publisher_type = "default"
+#event_publisher_type = "custom"
+#event_publisher_impl = "org.wso2.carbon.apimgt.usage.publisher.APIMgtUsageDataBridgeDataPublisher"
+#publish_response_size = true
+
+#[[apim.analytics.url_group]]
+#analytics_url =["tcp://analytics1:7611","tcp://analytics2:7611"]
+#analytics_auth_url =["ssl://analytics1:7711","ssl://analytics2:7711"]
+#type = "loadbalance"
+
+#[[apim.analytics.url_group]]
+#analytics_url =["tcp://analytics1:7612","tcp://analytics2:7612"]
+#analytics_auth_url =["ssl://analytics1:7712","ssl://analytics2:7712"]
+#type = "failover"
+
+
+#[apim.key_manager]
+#service_url = "https://localhost:${mgt.transport.https.port}/services/"
+#username = "$ref{super_admin.username}"
+#password = "$ref{super_admin.password}"
+#pool.init_idle_capacity = 50
+#pool.max_idle = 100
+#key_validation_handler_type = "default"
+#key_validation_handler_type = "custom"
+#key_validation_handler_impl = "org.wso2.carbon.apimgt.keymgt.handlers.DefaultKeyValidationHandler"
+
+#[apim.jwt]
+#enable = true
+#encoding = "base64" # base64,base64url
+#generator_impl = "org.wso2.carbon.apimgt.keymgt.token.JWTGenerator"
+#claim_dialect = "http://wso2.org/claims"
+#header = "X-JWT-Assertion"
+#signing_algorithm = "SHA256withRSA"
+#enable_user_claims = true
+#claims_extractor_impl = "org.wso2.carbon.apimgt.impl.token.DefaultClaimsRetriever"
+
+#[apim.oauth_config]
+#enable_outbound_auth_header = false
+#auth_header = "Authorization"
+#revoke_endpoint = "https://localhost:${https.nio.port}/revoke"
+#enable_token_encryption = false
+#enable_token_hashing = false
+
+#[apim.devportal]
+#url = "https://localhost:${mgt.transport.https.port}/devportal"
+#enable_application_sharing = false
+#if application_sharing_type, application_sharing_impl both defined priority goes to application_sharing_impl
+#application_sharing_type = "default" #changed type, saml, default #todo: check the new config for rest api
+#application_sharing_impl = "org.wso2.carbon.apimgt.impl.SAMLGroupIDExtractorImpl"
+#display_multiple_versions = false
+#display_deprecated_apis = false
+#enable_comments = true
+#enable_ratings = true
+#enable_forum = true
+
+[apim.cors]
+allow_origins = "*"
+allow_methods = ["GET","PUT","POST","DELETE","PATCH","OPTIONS"]
+allow_headers = ["authorization","Access-Control-Allow-Origin","Content-Type","SOAPAction"]
+allow_credentials = false
+
+#[[apim.throttling.url_group]]
+#analytics_url = ["tcp://localhost:7611","tcp://localhost:7611"]
+#analytics_auth_url = ["ssl://localhost:7711","ssl://localhost:7711"]
+#type = "loadbalance"
+
+#[apim.throttling]
+#enable_data_publishing = true
+#enable_policy_deploy = true
+#enable_blacklist_condition = true
+
+#throttle_decision_endpoints = ["tcp://localhost:5672","tcp://localhost:5672"]
+#
+#enable_persistence = true
+
+#[apim.throttling.blacklist_condition]
+#start_delay = "5m"
+#period = "1h"
+
+#[apim.throttling.jms]
+#start_delay = "5m"
+
+#[apim.throttling.event_sync]
+#hostName = "0.0.0.0"
+#port = 11224
+#
+#[apim.throttling.event_management]
+#hostName = "0.0.0.0"
+#port = 10005
+
+#[[apim.throttling.url_group]]
+#traffic_manager_urls = ["tcp://localhost:9611","tcp://localhost:9611"]
+#traffic_manager_auth_urls = ["ssl://localhost:9711","ssl://localhost:9711"]
+#type = "loadbalance"
+#
+#[[apim.throttling.url_group]]
+#traffic_manager_urls = ["tcp://localhost:9611","tcp://localhost:9611"]
+#traffic_manager_auth_urls = ["ssl://localhost:9711","ssl://localhost:9711"]
+#type = "failover"
+
+#[apim.workflow]
+#enable = false
+#service_url = "https://localhost:9445/bpmn"
+#username = "$ref{super_admin.username}"
+#password = "$ref{super_admin.password}"
+#callback_endpoint = "https://localhost:${mgt.transport.https.port}/api/am/publisher/v0.16/workflows/update-workflow-status"
+#token_endpoint = "https://localhost:${https.nio.port}/token"
+#client_registration_endpoint = "https://localhost:${mgt.transport.https.port}/client-registration/v0.17/register"
+#client_registration_username = "$ref{super_admin.username}"
+#client_registration_password = "$ref{super_admin.password}"
+
+#data bridge config
+#[transport.receiver]
+#type = "binary"
+#worker_threads = 10
+#session_timeout = "30m"
+#keystore.file_name = "$ref{keystore.tls.file_name}"
+#keystore.password = "$ref{keystore.tls.password}"
+#tcp_port = 9611
+#ssl_port = 9711
+#ssl_receiver_thread_pool_size = 100
+#tcp_receiver_thread_pool_size = 100
+#ssl_enabled_protocols = ["TLSv1","TLSv1.1","TLSv1.2"]
+#ciphers = ["SSL_RSA_WITH_RC4_128_MD5","SSL_RSA_WITH_RC4_128_SHA"]
+
+#[apim.notification]
+#from_address = "APIM.com"
+#username = "APIM"
+#password = "APIM+123"
+#hostname = "localhost"
+#port = 3025
+#enable_start_tls = false
+#enable_authentication = true
+
+#[apim.token.revocation]
+#notifier_impl = "org.wso2.carbon.apimgt.keymgt.events.TokenRevocationNotifierImpl"
+#enable_realtime_notifier = true
+#realtime_notifier.ttl = 5000
+#enable_persistent_notifier = true
+#persistent_notifier.hostname = "https://localhost:2379/v2/keys/jti/"
+#persistent_notifier.ttl = 5000
+#persistent_notifier.username = "root"
+#persistent_notifier.password = "root"
+
+[[event_handler]]
+name="userPostSelfRegistration"
+subscriptions=["POST_ADD_USER"]
+
+[transport]
+passthru_https.listener.ssl_profile_interval = 6000
+passthru_https.sender.ssl_profile.interval = 6000
+
+[security_audit]
+api_token="b57973cf-b74c-4ade-921d-ece83251eceb"
+collection_id="f73b8171-4f71-499b-891a-d34aa71f2d45"
+base_url="https://localhost:9943/am-auditApi-sample/api/auditapi"
+global=true
+
+[apim.certificate_reloader]
+period = "1m"
+
+[database.local]
+url = "jdbc:h2:./repository/database/WSO2CARBON_DB;DB_CLOSE_ON_EXIT=FALSE"
+
+[[event_listener]]
+id = "token_revocation"
+type = "org.wso2.carbon.identity.core.handler.AbstractIdentityHandler"
+name = "org.wso2.is.notification.ApimOauthEventInterceptor"
+order = 1
+[event_listener.properties]
+notification_endpoint = "https://localhost:${mgt.transport.https.port}/internal/data/v1/notify"
+username = "${admin.username}"
+password = "${admin.password}"
+'header.X-WSO2-KEY-MANAGER' = "default"
+
+[apim.sync_runtime_artifacts.gateway.skip_list]
+apis = ["admin--git2231head_v1.0.0.xml","admin--PizzaShackAPI_v1.0.0.xml","admin--ScriptMediatorAPI_v1.0.xml",
+    "APIThrottleBackendAPI.xml","BackEndSecurity.xml","DigestAuth_API.xml","git2231.xml","HttpPATCHSupport_API.xml","JWKS-Backend.xml","JWTBackendAPI.xml","multiVSR_v1.0.0.xml","Response_API_1.xml","Response_API_2.xml","Response_Custom_API.xml","Response_Error_API.xml","Response_Loc_API.xml","SpecialCRN_v1.0.0.xml","status_code_204_API.xml","stockquote.xml","XML_API.xml","Version1.xml","Version2.xml","schemaValidationAPI.xml"]

--- a/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -112,6 +112,8 @@
             <class name="org.wso2.am.integration.tests.header.CustomHeaderTestCase"/>
             <!--<class name="org.wso2.am.integration.tests.header.DuplicateHeaderTestCase"/>-->
             <class name="org.wso2.am.integration.tests.token.InvalidTokenTestCase"/>
+            <class name="org.wso2.am.integration.tests.token.InvokeAPIWithVariousEndpointsAndTokensTestCase"/>
+            <class name="org.wso2.am.integration.tests.token.InvokeAPIWithVariousEndpointsAndTokensInSandboxEnvTestCase"/>
             <class name="org.wso2.am.integration.tests.throttling.APIThrottlingTestCase"/>
             <class name="org.wso2.am.integration.tests.throttling.JWTBandwidthThrottlingTestCase"/>
             <class name="org.wso2.am.integration.tests.throttling.BurstControlTestCase"/>


### PR DESCRIPTION
### Purpose

> - Invoking an API resource with security set to 'None' returns a runtime error if the Production endpoint is not configured, even though the request can be routed to the Sandbox endpoint. This PR addresses and resolves this issue.
> - Add tests to validate the flows in Velocity templates when resource security is set to None.
> - Related to: https://github.com/wso2/api-manager/issues/3294

### Approach 

> - Updated the Velocity template to properly handle resources when security is set to 'None'.
> - Tested all possible scenarios across the Hybrid, Sandbox, and Production environments to ensure the fix resolves the issue without impacting other functionalities.
> -  Add two tests for the hybrid gateway environment and the sandbox gateway environment,
>    - In the hybrid gateway environment, the following scenarios are tested:
>       - Both production and sandbox endpoints are available.
>       - Only the production endpoint is available.
>       - Only the sandbox endpoint is available.
>    - In the sandbox gateway environment, the following scenarios are tested:
>       - Both production and sandbox endpoints are available.
>       - Only the sandbox endpoint is available.


