### PR TITLE
Add missing J2 mappings

### DIFF
--- a/modules/distribution/product/src/main/resources/conf/default.json
+++ b/modules/distribution/product/src/main/resources/conf/default.json
@@ -267,6 +267,8 @@
   "keystore.ssl_profile.default.servers": "*",
   "keystore.listener_profile.ssl_verify_client" : "optional",
   "keystore.listener_profile.bind_address" : "0.0.0.0",
+  "broker.performance_tuning.delivery.topic_message_delivery_strategy.strategy_name": "DISCARD_NONE",
+  "broker.performance_tuning.delivery.topic_message_delivery_strategy.delivery_timeout": "60",
   "broker.transport.amqp.enabled" : true,
   "broker.transport.amqp.bind_address" : "0.0.0.0",
   "broker.transport.amqp.default_connection.enabled" : true,

--- a/modules/distribution/product/src/main/resources/conf/templates/repository/conf/broker.xml.j2
+++ b/modules/distribution/product/src/main/resources/conf/templates/repository/conf/broker.xml.j2
@@ -385,13 +385,17 @@ This file is ciphertool compliant. Refer PRODUCT_HOME/repository/conf/security/c
                                      sent but ack is not honoured.
             -->
             <topicMessageDeliveryStrategy>
-                <strategyName>DISCARD_NONE</strategyName>
+                {% if broker.performance_tuning.delivery.topic_message_delivery_strategy.strategy_name is defined %}
+                    <strategyName>{{broker.performance_tuning.delivery.topic_message_delivery_strategy.strategy_name}}</strategyName>
+                {% endif %}
                 <!-- If you choose DISCARD_ALLOWED topic message delivery strategy,
                      broker keep messages in memory until ack is done until this timeout.
                      If an ack is not received under this timeout, ack will be simulated
                      internally and real acknowledgement is discarded.
                      deliveryTimeout is in seconds -->
-                <deliveryTimeout>60</deliveryTimeout>
+                {% if broker.performance_tuning.delivery.topic_message_delivery_strategy.delivery_timeout is defined %}
+                    <deliveryTimeout>{{broker.performance_tuning.delivery.topic_message_delivery_strategy.delivery_timeout}}</deliveryTimeout>
+                {% endif %}
             </topicMessageDeliveryStrategy>
         </delivery>
 


### PR DESCRIPTION
### Purpose

- Fix https://github.com/wso2/api-manager/issues/2972
- Add J2 mappings for broker.performance_tuning.delivery.topic_message_delivery_strategy.strategy_name and broker.performance_tuning.delivery.topic_message_delivery_strategy.delivery_timeout