### PR TITLE
Handle the editing of past API revisions

### DIFF
--- a/modules/distribution/product/src/main/resources/conf/templates/repository/conf/registry.xml.j2
+++ b/modules/distribution/product/src/main/resources/conf/templates/repository/conf/registry.xml.j2
@@ -110,7 +110,7 @@
 
 
     <!-- This handler use to index APIs when there change in Api artifact-->
-    <handler class="org.wso2.carbon.registry.indexing.IndexingHandler">
+    <handler class="org.wso2.carbon.apimgt.impl.handlers.APIIndexingHandler">
         <filter class = "org.wso2.carbon.registry.core.jdbc.handlers.filters.MediaTypeMatcher">
             <property name="mediaType">application/vnd.wso2-api+xml</property>
         </filter>

--- a/pom.xml
+++ b/pom.xml
@@ -1288,7 +1288,7 @@
 
         <!-- APIM Component Version -->
 
-        <carbon.apimgt.version>9.30.85</carbon.apimgt.version>
+        <carbon.apimgt.version>9.30.89</carbon.apimgt.version>
 
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 


### PR DESCRIPTION
Changed the Indexing handler from the default Indexing Handler to the API indexing handler to stop the indexing of old API revisions from happening. 

The API Indexing handler is written to carbon-apimgt in this PR. https://github.com/wso2/carbon-apimgt/pull/12725

Changed the carbon-apimgt version.