### PR TITLE
Fix additional file scanning issue that increases the server startup time

### DIFF
--- a/modules/distribution/product/src/main/startup-scripts/api-manager.bat
+++ b/modules/distribution/product/src/main/startup-scripts/api-manager.bat
@@ -63,9 +63,19 @@ rem ----- update classpath -----------------------------------------------------
 :updateClasspath
 cd %CARBON_HOME%
 set CARBON_CLASSPATH=
-FOR %%C in ("%CARBON_HOME%\bin\*.jar") DO set CARBON_CLASSPATH=!CARBON_CLASSPATH!;".\bin\%%~nC%%~xC"
+FOR %%C in ("%CARBON_HOME%\bin\*.jar") DO (
+	if "!CARBON_CLASSPATH!"=="" (
+		set CARBON_CLASSPATH=".\bin\%%~nC%%~xC"
+    ) else (
+        set CARBON_CLASSPATH=!CARBON_CLASSPATH!;".\bin\%%~nC%%~xC"
+    )
+)
 
-set CARBON_CLASSPATH="%JAVA_HOME%\lib\tools.jar";%CARBON_CLASSPATH%;
+if "!CARBON_CLASSPATH!"=="" (
+	set CARBON_CLASSPATH="%JAVA_HOME%\lib\tools.jar"
+) else (
+	set CARBON_CLASSPATH="%JAVA_HOME%\lib\tools.jar";%CARBON_CLASSPATH%
+)
 
 FOR %%D in ("%CARBON_HOME%\lib\commons-lang*.jar") DO set CARBON_CLASSPATH=!CARBON_CLASSPATH!;".\lib\%%~nD%%~xD"
 

--- a/modules/distribution/product/src/main/startup-scripts/api-manager.sh
+++ b/modules/distribution/product/src/main/startup-scripts/api-manager.sh
@@ -256,16 +256,28 @@ fi
 for f in "$CARBON_HOME"/bin/*.jar
 do
     if [ "$f" != "$CARBON_HOME/bin/*.jar" ];then
-        CARBON_CLASSPATH="$CARBON_CLASSPATH":$f
+        if [ -n "$CARBON_CLASSPATH" ]; then
+            CARBON_CLASSPATH="$CARBON_CLASSPATH:$f"
+        else
+            CARBON_CLASSPATH="$f"
+        fi
     fi
 done
 for t in "$CARBON_HOME"/lib/*.jar
 do
-    CARBON_CLASSPATH="$CARBON_CLASSPATH":$t
+    if [ -n "$CARBON_CLASSPATH" ]; then
+        CARBON_CLASSPATH="$CARBON_CLASSPATH:$t"
+    else
+        CARBON_CLASSPATH="$t"
+    fi
 done
 for t in "$CARBON_HOME"/lib/endorsed/*.jar
 do
-    CARBON_CLASSPATH="$CARBON_CLASSPATH":$t
+    if [ -n "$CARBON_CLASSPATH" ]; then
+        CARBON_CLASSPATH="$CARBON_CLASSPATH:$t"
+    else
+        CARBON_CLASSPATH="$t"
+    fi
 done
 
 


### PR DESCRIPTION
Fix https://github.com/wso2/api-manager/issues/3452

**Current Behavior:** The server startup time has increased due to unnecessary file scanning performed by Tomcat. This is caused by invalid characters in the CARBON_CLASSPATH.
- For example, in Linux, a ':' appears at the beginning of the classpath.
- In Windows, multiple occurrences of ';;' are present within the classpath.

**Fix:** This PR resolves the issue by properly processing the CARBON_CLASSPATH to remove invalid characters, optimizing the server startup time.