### PR TITLE
Intra-vendor model routing support for AI APIs

### DIFF
--- a/all-in-one-apim/modules/distribution/resources/operation_policies/definitions/modelFailover_v1.j2
+++ b/all-in-one-apim/modules/distribution/resources/operation_policies/definitions/modelFailover_v1.j2
@@ -1,0 +1,1 @@
+<property action="set" name="failoverConfigs" value="{{failoverConfigs}}" scope="transport" />

--- a/all-in-one-apim/modules/distribution/resources/operation_policies/definitions/modelRoundRobin_v1.j2
+++ b/all-in-one-apim/modules/distribution/resources/operation_policies/definitions/modelRoundRobin_v1.j2
@@ -1,0 +1,1 @@
+<property action="set" name="roundRobinConfigs" value="{{roundRobinConfigs}}" scope="transport" />

--- a/all-in-one-apim/modules/distribution/resources/operation_policies/definitions/modelWeightedRoundRobin_v1.j2
+++ b/all-in-one-apim/modules/distribution/resources/operation_policies/definitions/modelWeightedRoundRobin_v1.j2
@@ -1,0 +1,1 @@
+<property action="set" name="weightedRoundRobinConfigs" value="{{weightedRoundRobinConfigs}}" scope="transport" />

--- a/all-in-one-apim/modules/distribution/resources/operation_policies/specifications/modelFailover_v1.json
+++ b/all-in-one-apim/modules/distribution/resources/operation_policies/specifications/modelFailover_v1.json
@@ -1,0 +1,26 @@
+{
+  "category": "Mediation",
+  "name": "modelFailover",
+  "version": "v1",
+  "displayName": "Model Failover",
+  "description": "This policy allows you to route traffic to a different model(s) when the primary model fails",
+  "policyAttributes": [
+    {
+      "name": "failoverConfigs",
+      "displayName": "Failover Configurations",
+      "description": "Configurations for the failover policy",
+      "validationRegex": "^.+$",
+      "type": "String",
+      "required": true
+    }
+  ],
+  "applicableFlows": [
+    "request"
+  ],
+  "supportedGateways": [
+    "Synapse"
+  ],
+  "supportedApiTypes": [
+    "HTTP"
+  ]
+}

--- a/all-in-one-apim/modules/distribution/resources/operation_policies/specifications/modelRoundRobin_v1.json
+++ b/all-in-one-apim/modules/distribution/resources/operation_policies/specifications/modelRoundRobin_v1.json
@@ -1,0 +1,26 @@
+{
+  "category": "Mediation",
+  "name": "modelRoundRobin",
+  "version": "v1",
+  "displayName": "Model Round Robin",
+  "description": "This policy allows you to route traffic to different models within the same AI/LLM vendor in a round robin fashion",
+  "policyAttributes": [
+    {
+      "name": "roundRobinConfigs",
+      "displayName": "Round Robin Configurations",
+      "description": "Configurations for the round robin policy",
+      "validationRegex": "^.+$",
+      "type": "String",
+      "required": true
+    }
+  ],
+  "applicableFlows": [
+    "request"
+  ],
+  "supportedGateways": [
+    "Synapse"
+  ],
+  "supportedApiTypes": [
+    "HTTP"
+  ]
+}

--- a/all-in-one-apim/modules/distribution/resources/operation_policies/specifications/modelWeightedRoundRobin_v1.json
+++ b/all-in-one-apim/modules/distribution/resources/operation_policies/specifications/modelWeightedRoundRobin_v1.json
@@ -1,0 +1,26 @@
+{
+  "category": "Mediation",
+  "name": "modelWeightedRoundRobin",
+  "version": "v1",
+  "displayName": "Model Weighted Round Robin",
+  "description": "This policy allows you to route traffic to different models within the same AI/LLM vendor in a weighted round robin fashion",
+  "policyAttributes": [
+    {
+      "name": "weightedRoundRobinConfigs",
+      "displayName": "Weighted Round Robin Configurations",
+      "description": "Configurations for the weighted round robin policy",
+      "validationRegex": "^.+$",
+      "type": "String",
+      "required": true
+    }
+  ],
+  "applicableFlows": [
+    "request"
+  ],
+  "supportedGateways": [
+    "Synapse"
+  ],
+  "supportedApiTypes": [
+    "HTTP"
+  ]
+}


### PR DESCRIPTION
This PR onboards the following default AI policies to support intra-vendor model routing capabilities:
- Model Round Robin
- Model Weighted Round Robin
- Model Failover
