### PR TITLE
Upgrade netty version

### DIFF
--- a/all-in-one-apim/pom.xml
+++ b/all-in-one-apim/pom.xml
@@ -1288,7 +1288,7 @@
 
         <!-- APIM Component Version -->
 
-        <carbon.apimgt.version>9.31.47-SNAPSHOT</carbon.apimgt.version>
+        <carbon.apimgt.version>9.31.45</carbon.apimgt.version>
 
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 

--- a/all-in-one-apim/pom.xml
+++ b/all-in-one-apim/pom.xml
@@ -1281,14 +1281,14 @@
 
         <project.scm.id>scm-server</project.scm.id>
 
-        <carbon.analytics.common.version>5.3.17</carbon.analytics.common.version>
+        <carbon.analytics.common.version><LATEST_RELEASE_VERSION></carbon.analytics.common.version>
 
         <!-- APIM Portals Component Version -->
         <carbon.apimgt.ui.version>9.2.40</carbon.apimgt.ui.version>
 
         <!-- APIM Component Version -->
 
-        <carbon.apimgt.version>9.31.45</carbon.apimgt.version>
+        <carbon.apimgt.version><LATEST_RELEASE_VERSION></carbon.apimgt.version>
 
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 
@@ -1310,17 +1310,17 @@
         <carbon.kernel.imp.pkg.version>[4.5.0, 5.0.0)</carbon.kernel.imp.pkg.version>
 
         <!-- carbon mediation -->
-        <carbon.mediation.version>4.7.244</carbon.mediation.version>
+        <carbon.mediation.version><LATEST_RELEASE_VERSION></carbon.mediation.version>
 
         <!-- carbon identity -->
-        <carbon.identity.version>5.25.722</carbon.identity.version>
+        <carbon.identity.version><LATEST_RELEASE_VERSION></carbon.identity.version>
         <carbon.identity.governance.version>1.8.108</carbon.identity.governance.version>
         <carbon.identity.event.handler.account.lock.version>1.8.14</carbon.identity.event.handler.account.lock.version>
         <carbon.identity.event.handler.notification.version>1.7.33</carbon.identity.event.handler.notification.version>
-        <carbon.identity-inbound-auth-oauth.version>6.13.25</carbon.identity-inbound-auth-oauth.version>
+        <carbon.identity-inbound-auth-oauth.version><LATEST_RELEASE_VERSION></carbon.identity-inbound-auth-oauth.version>
         <carbon.identity-data-publisher-oauth.version>1.6.10</carbon.identity-data-publisher-oauth.version>
         <carbon.identity-user-ws.version>5.7.5</carbon.identity-user-ws.version>
-        <carbon.identity-inbound-auth-openid.version>5.9.10</carbon.identity-inbound-auth-openid.version>
+        <carbon.identity-inbound-auth-openid.version><LATEST_RELEASE_VERSION></carbon.identity-inbound-auth-openid.version>
         <org.wso2.carbon.identity.local.auth.api.version>2.5.13</org.wso2.carbon.identity.local.auth.api.version>
         <carbon.identity-local-auth-basicauth.version>6.7.32</carbon.identity-local-auth-basicauth.version>
         <carbon.identity-outbound-auth-samlsso.version>5.8.13</carbon.identity-outbound-auth-samlsso.version>
@@ -1354,7 +1354,7 @@
         <opencsv.version>1.8</opencsv.version>
         <poi.version>3.0-FINAL</poi.version>
         <woden.version>1.0.0.M8-wso2v1</woden.version>
-        <synapse.version>4.0.0-wso2v216</synapse.version>
+        <synapse.version><LATEST_RELEASE_VERSION></synapse.version>
         <passthru.transport.patch.version>1.0.2</passthru.transport.patch.version>
         <axis2.wso2.version>1.6.1-wso2v102</axis2.wso2.version>
         <axiom.wso2.version>1.2.11-wso2v29</axiom.wso2.version>
@@ -1465,10 +1465,10 @@
         <diagnostics.tool.version>1.0.17</diagnostics.tool.version>
 
         <!-- Authenticator Properties -->
-        <identity.outbound.auth.oidc.version>5.11.35</identity.outbound.auth.oidc.version>
+        <identity.outbound.auth.oidc.version><LATEST_RELEASE_VERSION></identity.outbound.auth.oidc.version>
         <swagger-parser-version>2.0.14</swagger-parser-version>
         <nimbus.jwt.version>7.3.0.wso2v1</nimbus.jwt.version>
-        <json-smart.version>2.5.0</json-smart.version>
+        <json-smart.version>2.5.2</json-smart.version>
 
         <maven.javadoc.plugin.version>3.4.1</maven.javadoc.plugin.version>
 

--- a/all-in-one-apim/pom.xml
+++ b/all-in-one-apim/pom.xml
@@ -1281,14 +1281,14 @@
 
         <project.scm.id>scm-server</project.scm.id>
 
-        <carbon.analytics.common.version><LATEST_RELEASE_VERSION></carbon.analytics.common.version>
+        <carbon.analytics.common.version>5.3.19</carbon.analytics.common.version>
 
         <!-- APIM Portals Component Version -->
         <carbon.apimgt.ui.version>9.2.40</carbon.apimgt.ui.version>
 
         <!-- APIM Component Version -->
 
-        <carbon.apimgt.version><LATEST_RELEASE_VERSION></carbon.apimgt.version>
+        <carbon.apimgt.version>9.31.47-SNAPSHOT</carbon.apimgt.version>
 
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 
@@ -1310,17 +1310,17 @@
         <carbon.kernel.imp.pkg.version>[4.5.0, 5.0.0)</carbon.kernel.imp.pkg.version>
 
         <!-- carbon mediation -->
-        <carbon.mediation.version><LATEST_RELEASE_VERSION></carbon.mediation.version>
+        <carbon.mediation.version>4.7.245</carbon.mediation.version>
 
         <!-- carbon identity -->
-        <carbon.identity.version><LATEST_RELEASE_VERSION></carbon.identity.version>
+        <carbon.identity.version>5.25.723</carbon.identity.version>
         <carbon.identity.governance.version>1.8.108</carbon.identity.governance.version>
         <carbon.identity.event.handler.account.lock.version>1.8.14</carbon.identity.event.handler.account.lock.version>
         <carbon.identity.event.handler.notification.version>1.7.33</carbon.identity.event.handler.notification.version>
-        <carbon.identity-inbound-auth-oauth.version><LATEST_RELEASE_VERSION></carbon.identity-inbound-auth-oauth.version>
+        <carbon.identity-inbound-auth-oauth.version>6.13.26</carbon.identity-inbound-auth-oauth.version>
         <carbon.identity-data-publisher-oauth.version>1.6.10</carbon.identity-data-publisher-oauth.version>
         <carbon.identity-user-ws.version>5.7.5</carbon.identity-user-ws.version>
-        <carbon.identity-inbound-auth-openid.version><LATEST_RELEASE_VERSION></carbon.identity-inbound-auth-openid.version>
+        <carbon.identity-inbound-auth-openid.version>5.9.11</carbon.identity-inbound-auth-openid.version>
         <org.wso2.carbon.identity.local.auth.api.version>2.5.13</org.wso2.carbon.identity.local.auth.api.version>
         <carbon.identity-local-auth-basicauth.version>6.7.32</carbon.identity-local-auth-basicauth.version>
         <carbon.identity-outbound-auth-samlsso.version>5.8.13</carbon.identity-outbound-auth-samlsso.version>
@@ -1354,7 +1354,7 @@
         <opencsv.version>1.8</opencsv.version>
         <poi.version>3.0-FINAL</poi.version>
         <woden.version>1.0.0.M8-wso2v1</woden.version>
-        <synapse.version><LATEST_RELEASE_VERSION></synapse.version>
+        <synapse.version>4.0.0-wso2v218</synapse.version>
         <passthru.transport.patch.version>1.0.2</passthru.transport.patch.version>
         <axis2.wso2.version>1.6.1-wso2v102</axis2.wso2.version>
         <axiom.wso2.version>1.2.11-wso2v29</axiom.wso2.version>
@@ -1465,7 +1465,7 @@
         <diagnostics.tool.version>1.0.17</diagnostics.tool.version>
 
         <!-- Authenticator Properties -->
-        <identity.outbound.auth.oidc.version><LATEST_RELEASE_VERSION></identity.outbound.auth.oidc.version>
+        <identity.outbound.auth.oidc.version>5.11.36</identity.outbound.auth.oidc.version>
         <swagger-parser-version>2.0.14</swagger-parser-version>
         <nimbus.jwt.version>7.3.0.wso2v1</nimbus.jwt.version>
         <json-smart.version>2.5.2</json-smart.version>

--- a/all-in-one-apim/pom.xml
+++ b/all-in-one-apim/pom.xml
@@ -1310,7 +1310,7 @@
         <carbon.kernel.imp.pkg.version>[4.5.0, 5.0.0)</carbon.kernel.imp.pkg.version>
 
         <!-- carbon mediation -->
-        <carbon.mediation.version>4.7.228</carbon.mediation.version>
+        <carbon.mediation.version>4.7.244</carbon.mediation.version>
 
         <!-- carbon identity -->
         <carbon.identity.version>5.25.722</carbon.identity.version>
@@ -1354,7 +1354,7 @@
         <opencsv.version>1.8</opencsv.version>
         <poi.version>3.0-FINAL</poi.version>
         <woden.version>1.0.0.M8-wso2v1</woden.version>
-        <synapse.version>4.0.0-wso2v186</synapse.version>
+        <synapse.version>4.0.0-wso2v216</synapse.version>
         <passthru.transport.patch.version>1.0.2</passthru.transport.patch.version>
         <axis2.wso2.version>1.6.1-wso2v102</axis2.wso2.version>
         <axiom.wso2.version>1.2.11-wso2v29</axiom.wso2.version>
@@ -1388,7 +1388,7 @@
         <waffle-jna.version>1.6.wso2v6</waffle-jna.version>
         <version.org.wso2.orbit.javax.xml.bind>2.3.1.wso2v1</version.org.wso2.orbit.javax.xml.bind>
         <opensaml2.wso2.version>3.3.1.wso2v14</opensaml2.wso2.version>
-        <transport.http.netty.version>6.3.52</transport.http.netty.version>
+        <transport.http.netty.version>6.3.53</transport.http.netty.version>
 
         <imp.pkg.version.javax.servlet>[2.6.0, 3.0.0)</imp.pkg.version.javax.servlet>
 

--- a/api-control-plane/pom.xml
+++ b/api-control-plane/pom.xml
@@ -1306,7 +1306,7 @@
         <carbon.kernel.imp.pkg.version>[4.5.0, 5.0.0)</carbon.kernel.imp.pkg.version>
 
         <!-- carbon mediation -->
-        <carbon.mediation.version>4.7.228</carbon.mediation.version>
+        <carbon.mediation.version>4.7.244</carbon.mediation.version>
 
         <!-- carbon identity -->
         <carbon.identity.version>5.25.722</carbon.identity.version>
@@ -1350,7 +1350,7 @@
         <opencsv.version>1.8</opencsv.version>
         <poi.version>3.0-FINAL</poi.version>
         <woden.version>1.0.0.M8-wso2v1</woden.version>
-        <synapse.version>4.0.0-wso2v186</synapse.version>
+        <synapse.version>4.0.0-wso2v216</synapse.version>
         <passthru.transport.patch.version>1.0.2</passthru.transport.patch.version>
         <axis2.wso2.version>1.6.1-wso2v102</axis2.wso2.version>
         <axiom.wso2.version>1.2.11-wso2v29</axiom.wso2.version>
@@ -1384,7 +1384,7 @@
         <waffle-jna.version>1.6.wso2v6</waffle-jna.version>
         <version.org.wso2.orbit.javax.xml.bind>2.3.1.wso2v1</version.org.wso2.orbit.javax.xml.bind>
         <opensaml2.wso2.version>3.3.1.wso2v14</opensaml2.wso2.version>
-        <transport.http.netty.version>6.3.52</transport.http.netty.version>
+        <transport.http.netty.version>6.3.53</transport.http.netty.version>
 
         <imp.pkg.version.javax.servlet>[2.6.0, 3.0.0)</imp.pkg.version.javax.servlet>
 

--- a/api-control-plane/pom.xml
+++ b/api-control-plane/pom.xml
@@ -1284,7 +1284,7 @@
 
         <!-- APIM Component Version -->
 
-        <carbon.apimgt.version>9.31.47-SNAPSHOT</carbon.apimgt.version>
+        <carbon.apimgt.version>9.31.45</carbon.apimgt.version>
 
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 

--- a/api-control-plane/pom.xml
+++ b/api-control-plane/pom.xml
@@ -1277,14 +1277,14 @@
 
         <project.scm.id>scm-server</project.scm.id>
 
-        <carbon.analytics.common.version>5.3.17</carbon.analytics.common.version>
+        <carbon.analytics.common.version><LATEST_RELEASE_VERSION></carbon.analytics.common.version>
 
         <!-- APIM Portals Component Version -->
         <carbon.apimgt.ui.version>9.2.40</carbon.apimgt.ui.version>
 
         <!-- APIM Component Version -->
 
-        <carbon.apimgt.version>9.31.45</carbon.apimgt.version>
+        <carbon.apimgt.version><LATEST_RELEASE_VERSION></carbon.apimgt.version>
 
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 
@@ -1306,17 +1306,17 @@
         <carbon.kernel.imp.pkg.version>[4.5.0, 5.0.0)</carbon.kernel.imp.pkg.version>
 
         <!-- carbon mediation -->
-        <carbon.mediation.version>4.7.244</carbon.mediation.version>
+        <carbon.mediation.version><LATEST_RELEASE_VERSION></carbon.mediation.version>
 
         <!-- carbon identity -->
-        <carbon.identity.version>5.25.722</carbon.identity.version>
+        <carbon.identity.version><LATEST_RELEASE_VERSION></carbon.identity.version>
         <carbon.identity.governance.version>1.8.108</carbon.identity.governance.version>
         <carbon.identity.event.handler.account.lock.version>1.8.14</carbon.identity.event.handler.account.lock.version>
         <carbon.identity.event.handler.notification.version>1.7.33</carbon.identity.event.handler.notification.version>
-        <carbon.identity-inbound-auth-oauth.version>6.13.25</carbon.identity-inbound-auth-oauth.version>
+        <carbon.identity-inbound-auth-oauth.version><LATEST_RELEASE_VERSION></carbon.identity-inbound-auth-oauth.version>
         <carbon.identity-data-publisher-oauth.version>1.6.10</carbon.identity-data-publisher-oauth.version>
         <carbon.identity-user-ws.version>5.7.5</carbon.identity-user-ws.version>
-        <carbon.identity-inbound-auth-openid.version>5.9.10</carbon.identity-inbound-auth-openid.version>
+        <carbon.identity-inbound-auth-openid.version><LATEST_RELEASE_VERSION></carbon.identity-inbound-auth-openid.version>
         <org.wso2.carbon.identity.local.auth.api.version>2.5.13</org.wso2.carbon.identity.local.auth.api.version>
         <carbon.identity-local-auth-basicauth.version>6.7.32</carbon.identity-local-auth-basicauth.version>
         <carbon.identity-outbound-auth-samlsso.version>5.8.13</carbon.identity-outbound-auth-samlsso.version>
@@ -1350,7 +1350,7 @@
         <opencsv.version>1.8</opencsv.version>
         <poi.version>3.0-FINAL</poi.version>
         <woden.version>1.0.0.M8-wso2v1</woden.version>
-        <synapse.version>4.0.0-wso2v216</synapse.version>
+        <synapse.version><LATEST_RELEASE_VERSION></synapse.version>
         <passthru.transport.patch.version>1.0.2</passthru.transport.patch.version>
         <axis2.wso2.version>1.6.1-wso2v102</axis2.wso2.version>
         <axiom.wso2.version>1.2.11-wso2v29</axiom.wso2.version>
@@ -1461,10 +1461,10 @@
         <diagnostics.tool.version>1.0.17</diagnostics.tool.version>
 
         <!-- Authenticator Properties -->
-        <identity.outbound.auth.oidc.version>5.11.34</identity.outbound.auth.oidc.version>
+        <identity.outbound.auth.oidc.version><LATEST_RELEASE_VERSION></identity.outbound.auth.oidc.version>
         <swagger-parser-version>2.0.14</swagger-parser-version>
         <nimbus.jwt.version>7.3.0.wso2v1</nimbus.jwt.version>
-        <json-smart.version>2.5.0</json-smart.version>
+        <json-smart.version>2.5.2</json-smart.version>
 
         <maven.javadoc.plugin.version>3.4.1</maven.javadoc.plugin.version>
 

--- a/api-control-plane/pom.xml
+++ b/api-control-plane/pom.xml
@@ -1277,14 +1277,14 @@
 
         <project.scm.id>scm-server</project.scm.id>
 
-        <carbon.analytics.common.version><LATEST_RELEASE_VERSION></carbon.analytics.common.version>
+        <carbon.analytics.common.version>5.3.19</carbon.analytics.common.version>
 
         <!-- APIM Portals Component Version -->
         <carbon.apimgt.ui.version>9.2.40</carbon.apimgt.ui.version>
 
         <!-- APIM Component Version -->
 
-        <carbon.apimgt.version><LATEST_RELEASE_VERSION></carbon.apimgt.version>
+        <carbon.apimgt.version>9.31.47-SNAPSHOT</carbon.apimgt.version>
 
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 
@@ -1306,17 +1306,17 @@
         <carbon.kernel.imp.pkg.version>[4.5.0, 5.0.0)</carbon.kernel.imp.pkg.version>
 
         <!-- carbon mediation -->
-        <carbon.mediation.version><LATEST_RELEASE_VERSION></carbon.mediation.version>
+        <carbon.mediation.version>4.7.245</carbon.mediation.version>
 
         <!-- carbon identity -->
-        <carbon.identity.version><LATEST_RELEASE_VERSION></carbon.identity.version>
+        <carbon.identity.version>5.25.723</carbon.identity.version>
         <carbon.identity.governance.version>1.8.108</carbon.identity.governance.version>
         <carbon.identity.event.handler.account.lock.version>1.8.14</carbon.identity.event.handler.account.lock.version>
         <carbon.identity.event.handler.notification.version>1.7.33</carbon.identity.event.handler.notification.version>
-        <carbon.identity-inbound-auth-oauth.version><LATEST_RELEASE_VERSION></carbon.identity-inbound-auth-oauth.version>
+        <carbon.identity-inbound-auth-oauth.version>6.13.26</carbon.identity-inbound-auth-oauth.version>
         <carbon.identity-data-publisher-oauth.version>1.6.10</carbon.identity-data-publisher-oauth.version>
         <carbon.identity-user-ws.version>5.7.5</carbon.identity-user-ws.version>
-        <carbon.identity-inbound-auth-openid.version><LATEST_RELEASE_VERSION></carbon.identity-inbound-auth-openid.version>
+        <carbon.identity-inbound-auth-openid.version>5.9.11</carbon.identity-inbound-auth-openid.version>
         <org.wso2.carbon.identity.local.auth.api.version>2.5.13</org.wso2.carbon.identity.local.auth.api.version>
         <carbon.identity-local-auth-basicauth.version>6.7.32</carbon.identity-local-auth-basicauth.version>
         <carbon.identity-outbound-auth-samlsso.version>5.8.13</carbon.identity-outbound-auth-samlsso.version>
@@ -1350,7 +1350,7 @@
         <opencsv.version>1.8</opencsv.version>
         <poi.version>3.0-FINAL</poi.version>
         <woden.version>1.0.0.M8-wso2v1</woden.version>
-        <synapse.version><LATEST_RELEASE_VERSION></synapse.version>
+        <synapse.version>4.0.0-wso2v218</synapse.version>
         <passthru.transport.patch.version>1.0.2</passthru.transport.patch.version>
         <axis2.wso2.version>1.6.1-wso2v102</axis2.wso2.version>
         <axiom.wso2.version>1.2.11-wso2v29</axiom.wso2.version>
@@ -1461,7 +1461,7 @@
         <diagnostics.tool.version>1.0.17</diagnostics.tool.version>
 
         <!-- Authenticator Properties -->
-        <identity.outbound.auth.oidc.version><LATEST_RELEASE_VERSION></identity.outbound.auth.oidc.version>
+        <identity.outbound.auth.oidc.version>5.11.36</identity.outbound.auth.oidc.version>
         <swagger-parser-version>2.0.14</swagger-parser-version>
         <nimbus.jwt.version>7.3.0.wso2v1</nimbus.jwt.version>
         <json-smart.version>2.5.2</json-smart.version>

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -1306,7 +1306,7 @@
         <carbon.kernel.imp.pkg.version>[4.5.0, 5.0.0)</carbon.kernel.imp.pkg.version>
 
         <!-- carbon mediation -->
-        <carbon.mediation.version>4.7.228</carbon.mediation.version>
+        <carbon.mediation.version>4.7.244</carbon.mediation.version>
 
         <!-- carbon identity -->
         <carbon.identity.version>5.25.722</carbon.identity.version>
@@ -1350,7 +1350,7 @@
         <opencsv.version>1.8</opencsv.version>
         <poi.version>3.0-FINAL</poi.version>
         <woden.version>1.0.0.M8-wso2v1</woden.version>
-        <synapse.version>4.0.0-wso2v186</synapse.version>
+        <synapse.version>4.0.0-wso2v216</synapse.version>
         <passthru.transport.patch.version>1.0.2</passthru.transport.patch.version>
         <axis2.wso2.version>1.6.1-wso2v102</axis2.wso2.version>
         <axiom.wso2.version>1.2.11-wso2v29</axiom.wso2.version>
@@ -1384,7 +1384,7 @@
         <waffle-jna.version>1.6.wso2v6</waffle-jna.version>
         <version.org.wso2.orbit.javax.xml.bind>2.3.1.wso2v1</version.org.wso2.orbit.javax.xml.bind>
         <opensaml2.wso2.version>3.3.1.wso2v14</opensaml2.wso2.version>
-        <transport.http.netty.version>6.3.52</transport.http.netty.version>
+        <transport.http.netty.version>6.3.53</transport.http.netty.version>
 
         <imp.pkg.version.javax.servlet>[2.6.0, 3.0.0)</imp.pkg.version.javax.servlet>
 

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -1284,7 +1284,7 @@
 
         <!-- APIM Component Version -->
 
-        <carbon.apimgt.version>9.31.47-SNAPSHOT</carbon.apimgt.version>
+        <carbon.apimgt.version>9.31.45</carbon.apimgt.version>
 
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -1277,14 +1277,14 @@
 
         <project.scm.id>scm-server</project.scm.id>
 
-        <carbon.analytics.common.version>5.3.17</carbon.analytics.common.version>
+        <carbon.analytics.common.version><LATEST_RELEASE_VERSION></carbon.analytics.common.version>
 
         <!-- APIM Portals Component Version -->
         <carbon.apimgt.ui.version>9.2.40</carbon.apimgt.ui.version>
 
         <!-- APIM Component Version -->
 
-        <carbon.apimgt.version>9.31.45</carbon.apimgt.version>
+        <carbon.apimgt.version><LATEST_RELEASE_VERSION></carbon.apimgt.version>
 
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 
@@ -1306,17 +1306,17 @@
         <carbon.kernel.imp.pkg.version>[4.5.0, 5.0.0)</carbon.kernel.imp.pkg.version>
 
         <!-- carbon mediation -->
-        <carbon.mediation.version>4.7.244</carbon.mediation.version>
+        <carbon.mediation.version><LATEST_RELEASE_VERSION></carbon.mediation.version>
 
         <!-- carbon identity -->
-        <carbon.identity.version>5.25.722</carbon.identity.version>
+        <carbon.identity.version><LATEST_RELEASE_VERSION></carbon.identity.version>
         <carbon.identity.governance.version>1.8.108</carbon.identity.governance.version>
         <carbon.identity.event.handler.account.lock.version>1.8.14</carbon.identity.event.handler.account.lock.version>
         <carbon.identity.event.handler.notification.version>1.7.33</carbon.identity.event.handler.notification.version>
-        <carbon.identity-inbound-auth-oauth.version>6.13.25</carbon.identity-inbound-auth-oauth.version>
+        <carbon.identity-inbound-auth-oauth.version><LATEST_RELEASE_VERSION></carbon.identity-inbound-auth-oauth.version>
         <carbon.identity-data-publisher-oauth.version>1.6.10</carbon.identity-data-publisher-oauth.version>
         <carbon.identity-user-ws.version>5.7.5</carbon.identity-user-ws.version>
-        <carbon.identity-inbound-auth-openid.version>5.9.10</carbon.identity-inbound-auth-openid.version>
+        <carbon.identity-inbound-auth-openid.version><LATEST_RELEASE_VERSION></carbon.identity-inbound-auth-openid.version>
         <org.wso2.carbon.identity.local.auth.api.version>2.5.13</org.wso2.carbon.identity.local.auth.api.version>
         <carbon.identity-local-auth-basicauth.version>6.7.32</carbon.identity-local-auth-basicauth.version>
         <carbon.identity-outbound-auth-samlsso.version>5.8.13</carbon.identity-outbound-auth-samlsso.version>
@@ -1350,7 +1350,7 @@
         <opencsv.version>1.8</opencsv.version>
         <poi.version>3.0-FINAL</poi.version>
         <woden.version>1.0.0.M8-wso2v1</woden.version>
-        <synapse.version>4.0.0-wso2v216</synapse.version>
+        <synapse.version><LATEST_RELEASE_VERSION></synapse.version>
         <passthru.transport.patch.version>1.0.2</passthru.transport.patch.version>
         <axis2.wso2.version>1.6.1-wso2v102</axis2.wso2.version>
         <axiom.wso2.version>1.2.11-wso2v29</axiom.wso2.version>
@@ -1461,10 +1461,10 @@
         <diagnostics.tool.version>1.0.17</diagnostics.tool.version>
 
         <!-- Authenticator Properties -->
-        <identity.outbound.auth.oidc.version>5.11.34</identity.outbound.auth.oidc.version>
+        <identity.outbound.auth.oidc.version><LATEST_RELEASE_VERSION></identity.outbound.auth.oidc.version>
         <swagger-parser-version>2.0.14</swagger-parser-version>
         <nimbus.jwt.version>7.3.0.wso2v1</nimbus.jwt.version>
-        <json-smart.version>2.5.0</json-smart.version>
+        <json-smart.version>2.5.2</json-smart.version>
 
         <maven.javadoc.plugin.version>3.4.1</maven.javadoc.plugin.version>
 

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -1277,14 +1277,14 @@
 
         <project.scm.id>scm-server</project.scm.id>
 
-        <carbon.analytics.common.version><LATEST_RELEASE_VERSION></carbon.analytics.common.version>
+        <carbon.analytics.common.version>5.3.19</carbon.analytics.common.version>
 
         <!-- APIM Portals Component Version -->
         <carbon.apimgt.ui.version>9.2.40</carbon.apimgt.ui.version>
 
         <!-- APIM Component Version -->
 
-        <carbon.apimgt.version><LATEST_RELEASE_VERSION></carbon.apimgt.version>
+        <carbon.apimgt.version>9.31.47-SNAPSHOT</carbon.apimgt.version>
 
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 
@@ -1306,17 +1306,17 @@
         <carbon.kernel.imp.pkg.version>[4.5.0, 5.0.0)</carbon.kernel.imp.pkg.version>
 
         <!-- carbon mediation -->
-        <carbon.mediation.version><LATEST_RELEASE_VERSION></carbon.mediation.version>
+        <carbon.mediation.version>4.7.245</carbon.mediation.version>
 
         <!-- carbon identity -->
-        <carbon.identity.version><LATEST_RELEASE_VERSION></carbon.identity.version>
+        <carbon.identity.version>5.25.723</carbon.identity.version>
         <carbon.identity.governance.version>1.8.108</carbon.identity.governance.version>
         <carbon.identity.event.handler.account.lock.version>1.8.14</carbon.identity.event.handler.account.lock.version>
         <carbon.identity.event.handler.notification.version>1.7.33</carbon.identity.event.handler.notification.version>
-        <carbon.identity-inbound-auth-oauth.version><LATEST_RELEASE_VERSION></carbon.identity-inbound-auth-oauth.version>
+        <carbon.identity-inbound-auth-oauth.version>6.13.26</carbon.identity-inbound-auth-oauth.version>
         <carbon.identity-data-publisher-oauth.version>1.6.10</carbon.identity-data-publisher-oauth.version>
         <carbon.identity-user-ws.version>5.7.5</carbon.identity-user-ws.version>
-        <carbon.identity-inbound-auth-openid.version><LATEST_RELEASE_VERSION></carbon.identity-inbound-auth-openid.version>
+        <carbon.identity-inbound-auth-openid.version>5.9.11</carbon.identity-inbound-auth-openid.version>
         <org.wso2.carbon.identity.local.auth.api.version>2.5.13</org.wso2.carbon.identity.local.auth.api.version>
         <carbon.identity-local-auth-basicauth.version>6.7.32</carbon.identity-local-auth-basicauth.version>
         <carbon.identity-outbound-auth-samlsso.version>5.8.13</carbon.identity-outbound-auth-samlsso.version>
@@ -1350,7 +1350,7 @@
         <opencsv.version>1.8</opencsv.version>
         <poi.version>3.0-FINAL</poi.version>
         <woden.version>1.0.0.M8-wso2v1</woden.version>
-        <synapse.version><LATEST_RELEASE_VERSION></synapse.version>
+        <synapse.version>4.0.0-wso2v218</synapse.version>
         <passthru.transport.patch.version>1.0.2</passthru.transport.patch.version>
         <axis2.wso2.version>1.6.1-wso2v102</axis2.wso2.version>
         <axiom.wso2.version>1.2.11-wso2v29</axiom.wso2.version>
@@ -1461,7 +1461,7 @@
         <diagnostics.tool.version>1.0.17</diagnostics.tool.version>
 
         <!-- Authenticator Properties -->
-        <identity.outbound.auth.oidc.version><LATEST_RELEASE_VERSION></identity.outbound.auth.oidc.version>
+        <identity.outbound.auth.oidc.version>5.11.36</identity.outbound.auth.oidc.version>
         <swagger-parser-version>2.0.14</swagger-parser-version>
         <nimbus.jwt.version>7.3.0.wso2v1</nimbus.jwt.version>
         <json-smart.version>2.5.2</json-smart.version>

--- a/traffic-manager/pom.xml
+++ b/traffic-manager/pom.xml
@@ -1306,7 +1306,7 @@
         <carbon.kernel.imp.pkg.version>[4.5.0, 5.0.0)</carbon.kernel.imp.pkg.version>
 
         <!-- carbon mediation -->
-        <carbon.mediation.version>4.7.228</carbon.mediation.version>
+        <carbon.mediation.version>4.7.244</carbon.mediation.version>
 
         <!-- carbon identity -->
         <carbon.identity.version>5.25.722</carbon.identity.version>
@@ -1350,7 +1350,7 @@
         <opencsv.version>1.8</opencsv.version>
         <poi.version>3.0-FINAL</poi.version>
         <woden.version>1.0.0.M8-wso2v1</woden.version>
-        <synapse.version>4.0.0-wso2v186</synapse.version>
+        <synapse.version>4.0.0-wso2v216</synapse.version>
         <passthru.transport.patch.version>1.0.2</passthru.transport.patch.version>
         <axis2.wso2.version>1.6.1-wso2v102</axis2.wso2.version>
         <axiom.wso2.version>1.2.11-wso2v29</axiom.wso2.version>
@@ -1384,7 +1384,7 @@
         <waffle-jna.version>1.6.wso2v6</waffle-jna.version>
         <version.org.wso2.orbit.javax.xml.bind>2.3.1.wso2v1</version.org.wso2.orbit.javax.xml.bind>
         <opensaml2.wso2.version>3.3.1.wso2v14</opensaml2.wso2.version>
-        <transport.http.netty.version>6.3.52</transport.http.netty.version>
+        <transport.http.netty.version>6.3.53</transport.http.netty.version>
 
         <imp.pkg.version.javax.servlet>[2.6.0, 3.0.0)</imp.pkg.version.javax.servlet>
 

--- a/traffic-manager/pom.xml
+++ b/traffic-manager/pom.xml
@@ -1284,7 +1284,7 @@
 
         <!-- APIM Component Version -->
 
-        <carbon.apimgt.version>9.31.47-SNAPSHOT</carbon.apimgt.version>
+        <carbon.apimgt.version>9.31.45</carbon.apimgt.version>
 
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 

--- a/traffic-manager/pom.xml
+++ b/traffic-manager/pom.xml
@@ -1277,14 +1277,14 @@
 
         <project.scm.id>scm-server</project.scm.id>
 
-        <carbon.analytics.common.version>5.3.17</carbon.analytics.common.version>
+        <carbon.analytics.common.version><LATEST_RELEASE_VERSION></carbon.analytics.common.version>
 
         <!-- APIM Portals Component Version -->
         <carbon.apimgt.ui.version>9.2.40</carbon.apimgt.ui.version>
 
         <!-- APIM Component Version -->
 
-        <carbon.apimgt.version>9.31.45</carbon.apimgt.version>
+        <carbon.apimgt.version><LATEST_RELEASE_VERSION></carbon.apimgt.version>
 
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 
@@ -1306,17 +1306,17 @@
         <carbon.kernel.imp.pkg.version>[4.5.0, 5.0.0)</carbon.kernel.imp.pkg.version>
 
         <!-- carbon mediation -->
-        <carbon.mediation.version>4.7.244</carbon.mediation.version>
+        <carbon.mediation.version><LATEST_RELEASE_VERSION></carbon.mediation.version>
 
         <!-- carbon identity -->
-        <carbon.identity.version>5.25.722</carbon.identity.version>
+        <carbon.identity.version><LATEST_RELEASE_VERSION></carbon.identity.version>
         <carbon.identity.governance.version>1.8.108</carbon.identity.governance.version>
         <carbon.identity.event.handler.account.lock.version>1.8.14</carbon.identity.event.handler.account.lock.version>
         <carbon.identity.event.handler.notification.version>1.7.33</carbon.identity.event.handler.notification.version>
-        <carbon.identity-inbound-auth-oauth.version>6.13.25</carbon.identity-inbound-auth-oauth.version>
+        <carbon.identity-inbound-auth-oauth.version><LATEST_RELEASE_VERSION></carbon.identity-inbound-auth-oauth.version>
         <carbon.identity-data-publisher-oauth.version>1.6.10</carbon.identity-data-publisher-oauth.version>
         <carbon.identity-user-ws.version>5.7.5</carbon.identity-user-ws.version>
-        <carbon.identity-inbound-auth-openid.version>5.9.10</carbon.identity-inbound-auth-openid.version>
+        <carbon.identity-inbound-auth-openid.version><LATEST_RELEASE_VERSION></carbon.identity-inbound-auth-openid.version>
         <org.wso2.carbon.identity.local.auth.api.version>2.5.13</org.wso2.carbon.identity.local.auth.api.version>
         <carbon.identity-local-auth-basicauth.version>6.7.32</carbon.identity-local-auth-basicauth.version>
         <carbon.identity-outbound-auth-samlsso.version>5.8.13</carbon.identity-outbound-auth-samlsso.version>
@@ -1350,7 +1350,7 @@
         <opencsv.version>1.8</opencsv.version>
         <poi.version>3.0-FINAL</poi.version>
         <woden.version>1.0.0.M8-wso2v1</woden.version>
-        <synapse.version>4.0.0-wso2v216</synapse.version>
+        <synapse.version><LATEST_RELEASE_VERSION></synapse.version>
         <passthru.transport.patch.version>1.0.2</passthru.transport.patch.version>
         <axis2.wso2.version>1.6.1-wso2v102</axis2.wso2.version>
         <axiom.wso2.version>1.2.11-wso2v29</axiom.wso2.version>
@@ -1461,10 +1461,10 @@
         <diagnostics.tool.version>1.0.17</diagnostics.tool.version>
 
         <!-- Authenticator Properties -->
-        <identity.outbound.auth.oidc.version>5.11.34</identity.outbound.auth.oidc.version>
+        <identity.outbound.auth.oidc.version><LATEST_RELEASE_VERSION></identity.outbound.auth.oidc.version>
         <swagger-parser-version>2.0.14</swagger-parser-version>
         <nimbus.jwt.version>7.3.0.wso2v1</nimbus.jwt.version>
-        <json-smart.version>2.5.0</json-smart.version>
+        <json-smart.version>2.5.2</json-smart.version>
 
         <maven.javadoc.plugin.version>3.4.1</maven.javadoc.plugin.version>
 

--- a/traffic-manager/pom.xml
+++ b/traffic-manager/pom.xml
@@ -1277,14 +1277,14 @@
 
         <project.scm.id>scm-server</project.scm.id>
 
-        <carbon.analytics.common.version><LATEST_RELEASE_VERSION></carbon.analytics.common.version>
+        <carbon.analytics.common.version>5.3.19</carbon.analytics.common.version>
 
         <!-- APIM Portals Component Version -->
         <carbon.apimgt.ui.version>9.2.40</carbon.apimgt.ui.version>
 
         <!-- APIM Component Version -->
 
-        <carbon.apimgt.version><LATEST_RELEASE_VERSION></carbon.apimgt.version>
+        <carbon.apimgt.version>9.31.47-SNAPSHOT</carbon.apimgt.version>
 
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 
@@ -1306,17 +1306,17 @@
         <carbon.kernel.imp.pkg.version>[4.5.0, 5.0.0)</carbon.kernel.imp.pkg.version>
 
         <!-- carbon mediation -->
-        <carbon.mediation.version><LATEST_RELEASE_VERSION></carbon.mediation.version>
+        <carbon.mediation.version>4.7.245</carbon.mediation.version>
 
         <!-- carbon identity -->
-        <carbon.identity.version><LATEST_RELEASE_VERSION></carbon.identity.version>
+        <carbon.identity.version>5.25.723</carbon.identity.version>
         <carbon.identity.governance.version>1.8.108</carbon.identity.governance.version>
         <carbon.identity.event.handler.account.lock.version>1.8.14</carbon.identity.event.handler.account.lock.version>
         <carbon.identity.event.handler.notification.version>1.7.33</carbon.identity.event.handler.notification.version>
-        <carbon.identity-inbound-auth-oauth.version><LATEST_RELEASE_VERSION></carbon.identity-inbound-auth-oauth.version>
+        <carbon.identity-inbound-auth-oauth.version>6.13.26</carbon.identity-inbound-auth-oauth.version>
         <carbon.identity-data-publisher-oauth.version>1.6.10</carbon.identity-data-publisher-oauth.version>
         <carbon.identity-user-ws.version>5.7.5</carbon.identity-user-ws.version>
-        <carbon.identity-inbound-auth-openid.version><LATEST_RELEASE_VERSION></carbon.identity-inbound-auth-openid.version>
+        <carbon.identity-inbound-auth-openid.version>5.9.11</carbon.identity-inbound-auth-openid.version>
         <org.wso2.carbon.identity.local.auth.api.version>2.5.13</org.wso2.carbon.identity.local.auth.api.version>
         <carbon.identity-local-auth-basicauth.version>6.7.32</carbon.identity-local-auth-basicauth.version>
         <carbon.identity-outbound-auth-samlsso.version>5.8.13</carbon.identity-outbound-auth-samlsso.version>
@@ -1350,7 +1350,7 @@
         <opencsv.version>1.8</opencsv.version>
         <poi.version>3.0-FINAL</poi.version>
         <woden.version>1.0.0.M8-wso2v1</woden.version>
-        <synapse.version><LATEST_RELEASE_VERSION></synapse.version>
+        <synapse.version>4.0.0-wso2v218</synapse.version>
         <passthru.transport.patch.version>1.0.2</passthru.transport.patch.version>
         <axis2.wso2.version>1.6.1-wso2v102</axis2.wso2.version>
         <axiom.wso2.version>1.2.11-wso2v29</axiom.wso2.version>
@@ -1461,7 +1461,7 @@
         <diagnostics.tool.version>1.0.17</diagnostics.tool.version>
 
         <!-- Authenticator Properties -->
-        <identity.outbound.auth.oidc.version><LATEST_RELEASE_VERSION></identity.outbound.auth.oidc.version>
+        <identity.outbound.auth.oidc.version>5.11.36</identity.outbound.auth.oidc.version>
         <swagger-parser-version>2.0.14</swagger-parser-version>
         <nimbus.jwt.version>7.3.0.wso2v1</nimbus.jwt.version>
         <json-smart.version>2.5.2</json-smart.version>


### PR DESCRIPTION
## io.netty Upgrade
### Purpose
Upgrades carbon mediation and synapse versions to bump the io.netty version from 4.1.117.Final to non-vulnerable 4.1.118.Final.

#### Related PRs:
transport-http: https://github.com/wso2/transport-http/pull/475
synapse: https://github.com/wso2/wso2-synapse/pull/2333
carbon-mediation: https://github.com/wso2/carbon-mediation/pull/1763
carbon-apimgt: https://github.com/wso2/carbon-apimgt/pull/12953

## Json-smart Upgrade

### Purpose
To upgrade json-smart version from 2.5.0 to the non-vulnerable 2.5.2 version.

#### Related PRs:

Identity-inbound-auth-oauth: https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2730
Carbon-identity-framework: https://github.com/wso2/carbon-identity-framework/pull/6543
Identity-inbound-auth-openid: https://github.com/wso2-extensions/identity-inbound-auth-openid/pull/109
Identity-outbound-auth-oidc: https://github.com/wso2-extensions/identity-outbound-auth-oidc/pull/199
Carbon-mediation: https://github.com/wso2/carbon-mediation/pull/1767
Carbon-analytics-common: https://github.com/wso2/carbon-analytics-common/pull/862
Carbon-apimgt: https://github.com/wso2/carbon-apimgt/pull/12953
