### PR TITLE
Add Governance Configs to `default.json`

### DIFF
--- a/all-in-one-apim/modules/distribution/product/src/main/resources/conf/default.json
+++ b/all-in-one-apim/modules/distribution/product/src/main/resources/conf/default.json
@@ -550,5 +550,10 @@
     }
   ],
   "service_provider.use_username_as_sub_claim": false,
-  "apim.ai.llm_provider_events_enabled": true
+  "apim.ai.llm_provider_events_enabled": true,
+  "apim.governance.datasource.name": "jdbc/WSO2AM_DB",
+  "apim.governance.scheduler.thread_pool_size": "20",
+  "apim.governance.scheduler.queue_size": "20",
+  "apim.governance.scheduler.task_check_interval_minutes": "2",
+  "apim.governance.scheduler.task_cleanup_interval_minutes": "30"
 }

--- a/api-control-plane/modules/distribution/product/src/main/resources/conf/default.json
+++ b/api-control-plane/modules/distribution/product/src/main/resources/conf/default.json
@@ -550,5 +550,10 @@
     }
   ],
   "service_provider.use_username_as_sub_claim": false,
-  "apim.ai.llm_provider_events_enabled": true
+  "apim.ai.llm_provider_events_enabled": true,
+  "apim.governance.datasource.name": "jdbc/WSO2AM_DB",
+  "apim.governance.scheduler.thread_pool_size": "20",
+  "apim.governance.scheduler.queue_size": "20",
+  "apim.governance.scheduler.task_check_interval_minutes": "2",
+  "apim.governance.scheduler.task_cleanup_interval_minutes": "30"
 }


### PR DESCRIPTION
## Purpose

This pull request includes updates to the configuration files to add new properties related to governance scheduling. The changes ensure that the governance scheduler is properly configured with appropriate settings for the data source, thread pool size, queue size, task check interval, and task cleanup interval.

Configuration updates:

* [`all-in-one-apim/modules/distribution/product/src/main/resources/conf/default.json`](diffhunk://#diff-e0b9f3bc583f6fefd5cfb6086273a9f520c432f64d58d6efc57c45ba3f79a2d5L553-R558): Added properties for governance scheduler configuration including data source name, thread pool size, queue size, task check interval, and task cleanup interval.
* [`api-control-plane/modules/distribution/product/src/main/resources/conf/default.json`](diffhunk://#diff-e0b9f3bc583f6fefd5cfb6086273a9f520c432f64d58d6efc57c45ba3f79a2d5L553-R558): Added properties for governance scheduler configuration including data source name, thread pool size, queue size, task check interval, and task cleanup interval.