### PR TITLE
Update cors_request_handler sequence to send only the necessary cors-headers values in non-preflight response calls

### DIFF
--- a/all-in-one-apim/modules/distribution/product/src/main/conf/synapse-configs/default/sequences/_cors_request_handler_.xml
+++ b/all-in-one-apim/modules/distribution/product/src/main/conf/synapse-configs/default/sequences/_cors_request_handler_.xml
@@ -6,12 +6,12 @@
                <property name="Access-Control-Allow-Origin" expression="$ctx:Access-Control-Allow-Origin"  scope="transport" type="STRING"/>
             </then>
          </filter>
-         <filter source="boolean($trp:Access-Control-Allow-Methods)" regex="false">
+         <filter source="boolean($trp:Access-Control-Allow-Methods) = false and $ctx:api.ut.HTTP_METHOD = 'OPTIONS'" regex="true">
             <then>
                <property name="Access-Control-Allow-Methods" expression="$ctx:Access-Control-Allow-Methods" scope="transport" type="STRING"/>
             </then>
          </filter>
-         <filter source="boolean($trp:Access-Control-Allow-Headers)" regex="false">
+         <filter source="boolean($trp:Access-Control-Allow-Headers) = false and $ctx:api.ut.HTTP_METHOD = 'OPTIONS'" regex="true">
             <then>
                <property name="Access-Control-Allow-Headers" expression="$ctx:Access-Control-Allow-Headers" scope="transport" type="STRING"/>
             </then>
@@ -25,7 +25,7 @@
                </filter>
             </then>
          </filter>
-         <filter source="boolean($trp:Access-Control-Expose-Headers)" regex="false">
+         <filter source="boolean($trp:Access-Control-Expose-Headers) = false and $ctx:api.ut.HTTP_METHOD = 'OPTIONS'" regex="true">
             <then>
                <property name="Access-Control-Expose-Headers" expression="$ctx:Access-Control-Expose-Headers" scope="transport" type="STRING"/>
             </then>

--- a/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/header/CORSHeadersTestCase.java
+++ b/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/header/CORSHeadersTestCase.java
@@ -205,16 +205,6 @@ public class CORSHeadersTestCase extends APIManagerLifecycleBaseTest {
         assertEquals(header.getValue(), ACCESS_CONTROL_ALLOW_ORIGIN_HEADER_VALUE,
                      ACCESS_CONTROL_ALLOW_ORIGIN_HEADER + " header value mismatch.");
 
-        header = pickHeader(responseHeaders, ACCESS_CONTROL_ALLOW_METHODS_HEADER);
-        assertNotNull(header, ACCESS_CONTROL_ALLOW_METHODS_HEADER + " header is not available in the response.");
-             assertTrue(ACCESS_CONTROL_ALLOW_METHODS_HEADER_VALUE.contains(header.getValue()),
-                     ACCESS_CONTROL_ALLOW_METHODS_HEADER + " header value mismatch.");
-
-        header = pickHeader(responseHeaders, ACCESS_CONTROL_ALLOW_HEADERS_HEADER);
-        assertNotNull(header, ACCESS_CONTROL_ALLOW_HEADERS_HEADER + " header is not available in the response.");
-        assertEquals(header.getValue(), ACCESS_CONTROL_ALLOW_HEADERS_HEADER_VALUE,
-                     ACCESS_CONTROL_ALLOW_HEADERS_HEADER + " header value mismatch.");
-
         assertNull(pickHeader(responseHeaders, ACCESS_CONTROL_ALLOW_CREDENTIALS_HEADER),
                    ACCESS_CONTROL_ALLOW_CREDENTIALS_HEADER + " header is available in the response, " +
                    "but it should not be.");

--- a/gateway/modules/distribution/product/src/main/conf/synapse-configs/default/sequences/_cors_request_handler_.xml
+++ b/gateway/modules/distribution/product/src/main/conf/synapse-configs/default/sequences/_cors_request_handler_.xml
@@ -6,12 +6,12 @@
                <property name="Access-Control-Allow-Origin" expression="$ctx:Access-Control-Allow-Origin"  scope="transport" type="STRING"/>
             </then>
          </filter>
-         <filter source="boolean($trp:Access-Control-Allow-Methods)" regex="false">
+         <filter source="boolean($trp:Access-Control-Allow-Methods) = false and $ctx:api.ut.HTTP_METHOD = 'OPTIONS'" regex="true">
             <then>
                <property name="Access-Control-Allow-Methods" expression="$ctx:Access-Control-Allow-Methods" scope="transport" type="STRING"/>
             </then>
          </filter>
-         <filter source="boolean($trp:Access-Control-Allow-Headers)" regex="false">
+         <filter source="boolean($trp:Access-Control-Allow-Headers) = false and $ctx:api.ut.HTTP_METHOD = 'OPTIONS'" regex="true">
             <then>
                <property name="Access-Control-Allow-Headers" expression="$ctx:Access-Control-Allow-Headers" scope="transport" type="STRING"/>
             </then>
@@ -25,7 +25,7 @@
                </filter>
             </then>
          </filter>
-         <filter source="boolean($trp:Access-Control-Expose-Headers)" regex="false">
+         <filter source="boolean($trp:Access-Control-Expose-Headers) = false and $ctx:api.ut.HTTP_METHOD = 'OPTIONS'" regex="true">
             <then>
                <property name="Access-Control-Expose-Headers" expression="$ctx:Access-Control-Expose-Headers" scope="transport" type="STRING"/>
             </then>


### PR DESCRIPTION
Fixes https://github.com/wso2/api-manager/issues/3547