### PR TITLE
Remove transport header removal action in websub api template

### DIFF
--- a/all-in-one-apim/modules/distribution/resources/api_templates/websub_api_template.xml
+++ b/all-in-one-apim/modules/distribution/resources/api_templates/websub_api_template.xml
@@ -38,7 +38,6 @@
                                     <target>
                                         <sequence onError="webhooksFaultSequence">
                                             <class name="org.wso2.carbon.apimgt.gateway.mediators.webhooks.SubscriberInfoLoader"/>
-                                            <property name="TRANSPORT_HEADERS" action="remove" scope="axis2"/>
                                             <property name="REST_URL_POSTFIX" scope="axis2" action="remove"/>
                                             <property name="link" expression="$ctx:SUBSCRIBER_LINK_HEADER" scope="transport"/>
                                             <header name="To" expression="$ctx:SUBSCRIBER_CALLBACK"/>

--- a/api-control-plane/modules/distribution/resources/api_templates/websub_api_template.xml
+++ b/api-control-plane/modules/distribution/resources/api_templates/websub_api_template.xml
@@ -38,7 +38,6 @@
                                     <target>
                                         <sequence onError="webhooksFaultSequence">
                                             <class name="org.wso2.carbon.apimgt.gateway.mediators.webhooks.SubscriberInfoLoader"/>
-                                            <property name="TRANSPORT_HEADERS" action="remove" scope="axis2"/>
                                             <property name="REST_URL_POSTFIX" scope="axis2" action="remove"/>
                                             <property name="link" expression="$ctx:SUBSCRIBER_LINK_HEADER" scope="transport"/>
                                             <header name="To" expression="$ctx:SUBSCRIBER_CALLBACK"/>

--- a/gateway/modules/distribution/resources/api_templates/websub_api_template.xml
+++ b/gateway/modules/distribution/resources/api_templates/websub_api_template.xml
@@ -38,7 +38,6 @@
                                     <target>
                                         <sequence onError="webhooksFaultSequence">
                                             <class name="org.wso2.carbon.apimgt.gateway.mediators.webhooks.SubscriberInfoLoader"/>
-                                            <property name="TRANSPORT_HEADERS" action="remove" scope="axis2"/>
                                             <property name="REST_URL_POSTFIX" scope="axis2" action="remove"/>
                                             <property name="link" expression="$ctx:SUBSCRIBER_LINK_HEADER" scope="transport"/>
                                             <header name="To" expression="$ctx:SUBSCRIBER_CALLBACK"/>

--- a/traffic-manager/modules/distribution/resources/api_templates/websub_api_template.xml
+++ b/traffic-manager/modules/distribution/resources/api_templates/websub_api_template.xml
@@ -38,7 +38,6 @@
                                     <target>
                                         <sequence onError="webhooksFaultSequence">
                                             <class name="org.wso2.carbon.apimgt.gateway.mediators.webhooks.SubscriberInfoLoader"/>
-                                            <property name="TRANSPORT_HEADERS" action="remove" scope="axis2"/>
                                             <property name="REST_URL_POSTFIX" scope="axis2" action="remove"/>
                                             <property name="link" expression="$ctx:SUBSCRIBER_LINK_HEADER" scope="transport"/>
                                             <header name="To" expression="$ctx:SUBSCRIBER_CALLBACK"/>


### PR DESCRIPTION
## Purpose
- When using the webhook apis transport headers are removed in current implementation
- This fix will remove transport header removal action in webhook api template
- Related issue - https://github.com/wso2/api-manager/issues/3560

## Approach
- Remove transport header removal action in websub api template.