### PR TITLE
Bump AWS Agent Version for the Gateway Federation Feature

### DIFF
--- a/all-in-one-apim/pom.xml
+++ b/all-in-one-apim/pom.xml
@@ -1503,7 +1503,7 @@
         <identity.branding.preference.management.version>1.0.17</identity.branding.preference.management.version>
 
         <!-- External Gateway Agent Versions -->
-        <aws.gwmanager.feature.version>0.9.0</aws.gwmanager.feature.version>
+        <aws.gwmanager.feature.version>0.9.1</aws.gwmanager.feature.version>
     </properties>
 
 </project>

--- a/api-control-plane/pom.xml
+++ b/api-control-plane/pom.xml
@@ -1499,7 +1499,7 @@
         <identity.branding.preference.management.version>1.0.17</identity.branding.preference.management.version>
 
         <!-- External Gateway Agent Versions -->
-        <aws.gwmanager.feature.version>0.9.0</aws.gwmanager.feature.version>
+        <aws.gwmanager.feature.version>0.9.1</aws.gwmanager.feature.version>
     </properties>
 
 </project>


### PR DESCRIPTION
### Description
Bump the AWS Gateway client version to 0.9.1 for the APIM 4.5.0 beta 