### PR TITLE
Add Governance Audit Log Configs

### DIFF
--- a/all-in-one-apim/modules/distribution/product/src/main/conf/log4j2.properties
+++ b/all-in-one-apim/modules/distribution/product/src/main/conf/log4j2.properties
@@ -1,6 +1,6 @@
 # list of all appenders
 #add entry "syslog" to use the syslog appender
-appenders=CARBON_CONSOLE, APIM_METRICS_APPENDER, CARBON_LOGFILE, AUDIT_LOGFILE, ATOMIKOS_LOGFILE, CARBON_TRACE_LOGFILE, ERROR_LOGFILE, OPEN_TRACING,SERVICE_APPENDER, TRACE_APPENDER, osgi, CORRELATION, BOTDATA_APPENDER, API_LOGFILE, APIM_GATEWAY_ACCESS_APPENDER
+appenders=CARBON_CONSOLE, APIM_METRICS_APPENDER, CARBON_LOGFILE, AUDIT_LOGFILE, ATOMIKOS_LOGFILE, CARBON_TRACE_LOGFILE, ERROR_LOGFILE, OPEN_TRACING,SERVICE_APPENDER, TRACE_APPENDER, osgi, CORRELATION, BOTDATA_APPENDER, API_LOGFILE, APIM_GATEWAY_ACCESS_APPENDER, APIM_GOV_AUDIT_LOGFILE
 #, syslog
 
 # CARBON_CONSOLE is set to be a ConsoleAppender using a PatternLayout.
@@ -213,11 +213,29 @@ appender.APIM_GATEWAY_ACCESS_APPENDER.strategy.max = 10
 appender.APIM_GATEWAY_ACCESS_APPENDER.filter.threshold.type = ThresholdFilter
 appender.APIM_GATEWAY_ACCESS_APPENDER.filter.threshold.level = DEBUG
 
+# Appender config to APIM_GOV_AUDIT_LOGFILE
+appender.APIM_GOV_AUDIT_LOGFILE.type = RollingFile
+appender.APIM_GOV_AUDIT_LOGFILE.name = APIM_GOV_AUDIT_LOGFILE
+appender.APIM_GOV_AUDIT_LOGFILE.fileName = ${sys:carbon.home}/repository/logs/apim_governance_audit.log
+appender.APIM_GOV_AUDIT_LOGFILE.filePattern = ${sys:carbon.home}/repository/logs/apim_governance_audit-%d{MM-dd-yyyy}.log
+appender.APIM_GOV_AUDIT_LOGFILE.layout.type = PatternLayout
+appender.APIM_GOV_AUDIT_LOGFILE.layout.pattern = ThreadID: [%T] TenantID: [%tenantId] [%d] %5p {%c} - %m%ex%n
+appender.APIM_GOV_AUDIT_LOGFILE.policies.type = Policies
+appender.APIM_GOV_AUDIT_LOGFILE.policies.time.type = TimeBasedTriggeringPolicy
+appender.APIM_GOV_AUDIT_LOGFILE.policies.time.interval = 1
+appender.APIM_GOV_AUDIT_LOGFILE.policies.time.modulate = true
+appender.APIM_GOV_AUDIT_LOGFILE.policies.size.type = SizeBasedTriggeringPolicy
+appender.APIM_GOV_AUDIT_LOGFILE.policies.size.size = 10MB
+appender.APIM_GOV_AUDIT_LOGFILE.strategy.type = DefaultRolloverStrategy
+appender.APIM_GOV_AUDIT_LOGFILE.strategy.max = 20
+appender.APIM_GOV_AUDIT_LOGFILE.filter.threshold.type = ThresholdFilter
+appender.APIM_GOV_AUDIT_LOGFILE.filter.threshold.level = INFO
+
 appender.osgi.type = PaxOsgi
 appender.osgi.name = PaxOsgi
 appender.osgi.filter = *
 
-loggers = AUDIT_LOG, reporter, trace-messages, org-apache-coyote, com-hazelcast, Owasp-CsrfGuard, org-apache-axis2-wsdl-codegen-writer-PrettyPrinter, org-apache-axis2-clustering, org-apache-catalina, org-apache-tomcat, org-wso2-carbon-apacheds, org-apache-directory-server-ldap, org-apache-directory-server-core-event, com-atomikos, org-quartz, org-apache-jackrabbit-webdav, org-apache-juddi, org-apache-commons-digester-Digester, org-apache-jasper-compiler-TldLocationsCache, org-apache-qpid, org-apache-qpid-server-Main, qpid-message, qpid-message-broker-listening, org-apache-tiles, org-apache-commons-httpclient, org-apache-solr, me-prettyprint-cassandra-hector-TimingLogger, org-apache-axis-enterprise, org-apache-directory-shared-ldap, org-apache-directory-server-ldap-handlers, org-apache-directory-shared-ldap-entry-DefaultServerAttribute, org-apache-directory-server-core-DefaultDirectoryService, org-apache-directory-shared-ldap-ldif-LdifReader, org-apache-directory-server-ldap-LdapProtocolHandler, org-apache-directory-server-core, org-apache-directory-server-ldap-LdapSession, DataNucleus, Datastore, Datastore-Schema, JPOX-Datastore, JPOX-Plugin, JPOX-MetaData, JPOX-Query, JPOX-General, JPOX-Enhancer, org-apache-hadoop-hive, hive, ExecMapper, ExecReducer, net-sf-ehcache-config-ConfigurationFactory, axis2Deployment, equinox, tomcat2, StAXDialectDetector, trace, synapse, synapse_transport, axis2, axis2_transport, org-wso2-carbon, hunsicker, thrift-publisher, service_logger, trace_logger, org-wso2-carbon-apimgt-gateway-mediators-BotDetectionMediator, correlation, API_LOG, GatewayAccessLogger
+loggers = AUDIT_LOG, APIM_GOV_AUDIT_LOG, reporter, trace-messages, org-apache-coyote, com-hazelcast, Owasp-CsrfGuard, org-apache-axis2-wsdl-codegen-writer-PrettyPrinter, org-apache-axis2-clustering, org-apache-catalina, org-apache-tomcat, org-wso2-carbon-apacheds, org-apache-directory-server-ldap, org-apache-directory-server-core-event, com-atomikos, org-quartz, org-apache-jackrabbit-webdav, org-apache-juddi, org-apache-commons-digester-Digester, org-apache-jasper-compiler-TldLocationsCache, org-apache-qpid, org-apache-qpid-server-Main, qpid-message, qpid-message-broker-listening, org-apache-tiles, org-apache-commons-httpclient, org-apache-solr, me-prettyprint-cassandra-hector-TimingLogger, org-apache-axis-enterprise, org-apache-directory-shared-ldap, org-apache-directory-server-ldap-handlers, org-apache-directory-shared-ldap-entry-DefaultServerAttribute, org-apache-directory-server-core-DefaultDirectoryService, org-apache-directory-shared-ldap-ldif-LdifReader, org-apache-directory-server-ldap-LdapProtocolHandler, org-apache-directory-server-core, org-apache-directory-server-ldap-LdapSession, DataNucleus, Datastore, Datastore-Schema, JPOX-Datastore, JPOX-Plugin, JPOX-MetaData, JPOX-Query, JPOX-General, JPOX-Enhancer, org-apache-hadoop-hive, hive, ExecMapper, ExecReducer, net-sf-ehcache-config-ConfigurationFactory, axis2Deployment, equinox, tomcat2, StAXDialectDetector, trace, synapse, synapse_transport, axis2, axis2_transport, org-wso2-carbon, hunsicker, thrift-publisher, service_logger, trace_logger, org-wso2-carbon-apimgt-gateway-mediators-BotDetectionMediator, correlation, API_LOG, GatewayAccessLogger
 
 logger.API_LOG.name = API_LOG
 logger.API_LOG.level = INFO
@@ -233,6 +251,11 @@ logger.AUDIT_LOG.name = AUDIT_LOG
 logger.AUDIT_LOG.level = INFO
 logger.AUDIT_LOG.appenderRef.AUDIT_LOGFILE.ref = AUDIT_LOGFILE
 logger.AUDIT_LOG.additivity = false
+
+logger.APIM_GOV_AUDIT_LOG.name = APIM_GOV_AUDIT_LOG
+logger.APIM_GOV_AUDIT_LOG.level = INFO
+logger.APIM_GOV_AUDIT_LOG.appenderRef.APIM_GOV_AUDIT_LOGFILE.ref = APIM_GOV_AUDIT_LOGFILE
+logger.APIM_GOV_AUDIT_LOG.additivity = false
 
 logger.trace-messages.name = trace.messages
 logger.trace-messages.level = TRACE

--- a/api-control-plane/modules/distribution/product/src/main/conf/log4j2.properties
+++ b/api-control-plane/modules/distribution/product/src/main/conf/log4j2.properties
@@ -1,6 +1,6 @@
 # list of all appenders
 #add entry "syslog" to use the syslog appender
-appenders=CARBON_CONSOLE, APIM_METRICS_APPENDER, CARBON_LOGFILE, AUDIT_LOGFILE, ATOMIKOS_LOGFILE, CARBON_TRACE_LOGFILE, ERROR_LOGFILE, OPEN_TRACING,SERVICE_APPENDER, TRACE_APPENDER, osgi, CORRELATION, BOTDATA_APPENDER, API_LOGFILE, APIM_GATEWAY_ACCESS_APPENDER
+appenders=CARBON_CONSOLE, APIM_METRICS_APPENDER, CARBON_LOGFILE, AUDIT_LOGFILE, ATOMIKOS_LOGFILE, CARBON_TRACE_LOGFILE, ERROR_LOGFILE, OPEN_TRACING,SERVICE_APPENDER, TRACE_APPENDER, osgi, CORRELATION, BOTDATA_APPENDER, API_LOGFILE, APIM_GATEWAY_ACCESS_APPENDER, APIM_GOV_AUDIT_LOGFILE
 #, syslog
 
 # CARBON_CONSOLE is set to be a ConsoleAppender using a PatternLayout.
@@ -213,11 +213,29 @@ appender.APIM_GATEWAY_ACCESS_APPENDER.strategy.max = 10
 appender.APIM_GATEWAY_ACCESS_APPENDER.filter.threshold.type = ThresholdFilter
 appender.APIM_GATEWAY_ACCESS_APPENDER.filter.threshold.level = DEBUG
 
+# Appender config to APIM_GOV_AUDIT_LOGFILE
+appender.APIM_GOV_AUDIT_LOGFILE.type = RollingFile
+appender.APIM_GOV_AUDIT_LOGFILE.name = APIM_GOV_AUDIT_LOGFILE
+appender.APIM_GOV_AUDIT_LOGFILE.fileName = ${sys:carbon.home}/repository/logs/apim_governance_audit.log
+appender.APIM_GOV_AUDIT_LOGFILE.filePattern = ${sys:carbon.home}/repository/logs/apim_governance_audit-%d{MM-dd-yyyy}.log
+appender.APIM_GOV_AUDIT_LOGFILE.layout.type = PatternLayout
+appender.APIM_GOV_AUDIT_LOGFILE.layout.pattern = ThreadID: [%T] TenantID: [%tenantId] [%d] %5p {%c} - %m%ex%n
+appender.APIM_GOV_AUDIT_LOGFILE.policies.type = Policies
+appender.APIM_GOV_AUDIT_LOGFILE.policies.time.type = TimeBasedTriggeringPolicy
+appender.APIM_GOV_AUDIT_LOGFILE.policies.time.interval = 1
+appender.APIM_GOV_AUDIT_LOGFILE.policies.time.modulate = true
+appender.APIM_GOV_AUDIT_LOGFILE.policies.size.type = SizeBasedTriggeringPolicy
+appender.APIM_GOV_AUDIT_LOGFILE.policies.size.size = 10MB
+appender.APIM_GOV_AUDIT_LOGFILE.strategy.type = DefaultRolloverStrategy
+appender.APIM_GOV_AUDIT_LOGFILE.strategy.max = 20
+appender.APIM_GOV_AUDIT_LOGFILE.filter.threshold.type = ThresholdFilter
+appender.APIM_GOV_AUDIT_LOGFILE.filter.threshold.level = INFO
+
 appender.osgi.type = PaxOsgi
 appender.osgi.name = PaxOsgi
 appender.osgi.filter = *
 
-loggers = AUDIT_LOG, reporter, trace-messages, org-apache-coyote, com-hazelcast, Owasp-CsrfGuard, org-apache-axis2-wsdl-codegen-writer-PrettyPrinter, org-apache-axis2-clustering, org-apache-catalina, org-apache-tomcat, org-wso2-carbon-apacheds, org-apache-directory-server-ldap, org-apache-directory-server-core-event, com-atomikos, org-quartz, org-apache-jackrabbit-webdav, org-apache-juddi, org-apache-commons-digester-Digester, org-apache-jasper-compiler-TldLocationsCache, org-apache-qpid, org-apache-qpid-server-Main, qpid-message, qpid-message-broker-listening, org-apache-tiles, org-apache-commons-httpclient, org-apache-solr, me-prettyprint-cassandra-hector-TimingLogger, org-apache-axis-enterprise, org-apache-directory-shared-ldap, org-apache-directory-server-ldap-handlers, org-apache-directory-shared-ldap-entry-DefaultServerAttribute, org-apache-directory-server-core-DefaultDirectoryService, org-apache-directory-shared-ldap-ldif-LdifReader, org-apache-directory-server-ldap-LdapProtocolHandler, org-apache-directory-server-core, org-apache-directory-server-ldap-LdapSession, DataNucleus, Datastore, Datastore-Schema, JPOX-Datastore, JPOX-Plugin, JPOX-MetaData, JPOX-Query, JPOX-General, JPOX-Enhancer, org-apache-hadoop-hive, hive, ExecMapper, ExecReducer, net-sf-ehcache-config-ConfigurationFactory, axis2Deployment, equinox, tomcat2, StAXDialectDetector, trace, synapse, synapse_transport, axis2, axis2_transport, org-wso2-carbon, hunsicker, thrift-publisher, service_logger, trace_logger, org-wso2-carbon-apimgt-gateway-mediators-BotDetectionMediator, correlation, API_LOG, GatewayAccessLogger
+loggers = AUDIT_LOG, APIM_GOV_AUDIT_LOG, reporter, trace-messages, org-apache-coyote, com-hazelcast, Owasp-CsrfGuard, org-apache-axis2-wsdl-codegen-writer-PrettyPrinter, org-apache-axis2-clustering, org-apache-catalina, org-apache-tomcat, org-wso2-carbon-apacheds, org-apache-directory-server-ldap, org-apache-directory-server-core-event, com-atomikos, org-quartz, org-apache-jackrabbit-webdav, org-apache-juddi, org-apache-commons-digester-Digester, org-apache-jasper-compiler-TldLocationsCache, org-apache-qpid, org-apache-qpid-server-Main, qpid-message, qpid-message-broker-listening, org-apache-tiles, org-apache-commons-httpclient, org-apache-solr, me-prettyprint-cassandra-hector-TimingLogger, org-apache-axis-enterprise, org-apache-directory-shared-ldap, org-apache-directory-server-ldap-handlers, org-apache-directory-shared-ldap-entry-DefaultServerAttribute, org-apache-directory-server-core-DefaultDirectoryService, org-apache-directory-shared-ldap-ldif-LdifReader, org-apache-directory-server-ldap-LdapProtocolHandler, org-apache-directory-server-core, org-apache-directory-server-ldap-LdapSession, DataNucleus, Datastore, Datastore-Schema, JPOX-Datastore, JPOX-Plugin, JPOX-MetaData, JPOX-Query, JPOX-General, JPOX-Enhancer, org-apache-hadoop-hive, hive, ExecMapper, ExecReducer, net-sf-ehcache-config-ConfigurationFactory, axis2Deployment, equinox, tomcat2, StAXDialectDetector, trace, synapse, synapse_transport, axis2, axis2_transport, org-wso2-carbon, hunsicker, thrift-publisher, service_logger, trace_logger, org-wso2-carbon-apimgt-gateway-mediators-BotDetectionMediator, correlation, API_LOG, GatewayAccessLogger
 
 logger.API_LOG.name = API_LOG
 logger.API_LOG.level = INFO
@@ -233,6 +251,11 @@ logger.AUDIT_LOG.name = AUDIT_LOG
 logger.AUDIT_LOG.level = INFO
 logger.AUDIT_LOG.appenderRef.AUDIT_LOGFILE.ref = AUDIT_LOGFILE
 logger.AUDIT_LOG.additivity = false
+
+logger.APIM_GOV_AUDIT_LOG.name = APIM_GOV_AUDIT_LOG
+logger.APIM_GOV_AUDIT_LOG.level = INFO
+logger.APIM_GOV_AUDIT_LOG.appenderRef.APIM_GOV_AUDIT_LOGFILE.ref = APIM_GOV_AUDIT_LOGFILE
+logger.APIM_GOV_AUDIT_LOG.additivity = false
 
 logger.trace-messages.name = trace.messages
 logger.trace-messages.level = TRACE


### PR DESCRIPTION
## Purpose
This pull request includes updates to the logging configuration in two different modules. The changes primarily focus on adding a new appender and logger for APIM governance audit logs.

### Logging Configuration Updates:

* Added `APIM_GOV_AUDIT_LOGFILE` appender to the `appenders` list in `log4j2.properties` for both `all-in-one-apim` and `api-control-plane` modules.
* Configured the `APIM_GOV_AUDIT_LOGFILE` appender with rolling file settings, including file pattern, layout, and policies.
* Updated the `loggers` list to include `APIM_GOV_AUDIT_LOG` in `log4j2.properties` for both `all-in-one-apim` and `api-control-plane` modules.
* Added `APIM_GOV_AUDIT_LOG` logger configuration, specifying its name, level, appender reference, and additivity setting.