### PR TITLE
Add improvements to the ACP, GW and TM components

### DIFF
--- a/api-control-plane/modules/distribution/product/src/main/conf/deployment.toml
+++ b/api-control-plane/modules/distribution/product/src/main/conf/deployment.toml
@@ -49,21 +49,21 @@ key_password =  "wso2carbon"
 [apim]
 gateway_type = "Regular,APK,AWS"
 
-[[apim.gateway.environment]]
-name = "Default"
-type = "hybrid"
-gateway_type = "Regular"
-provider = "wso2"
-display_in_api_console = true
-description = "This is a hybrid gateway that handles both production and sandbox token traffic."
-show_as_token_endpoint_url = true
-service_url = "https://localhost:${mgt.transport.https.port}/services/"
-username= "${admin.username}"
-password= "${admin.password}"
-ws_endpoint = "ws://localhost:9099"
-wss_endpoint = "wss://localhost:8099"
-http_endpoint = "http://localhost:${http.nio.port}"
-https_endpoint = "https://localhost:${https.nio.port}"
+#[[apim.gateway.environment]]
+#name = "Default"
+#type = "hybrid"
+#gateway_type = "Regular"
+#provider = "wso2"
+#display_in_api_console = true
+#description = "This is a hybrid gateway that handles both production and sandbox token traffic."
+#show_as_token_endpoint_url = true
+#service_url = "https://localhost:9444/services/"
+#username= "${admin.username}"
+#password= "${admin.password}"
+#ws_endpoint = "ws://localhost:9100"
+#wss_endpoint = "wss://localhost:8100"
+#http_endpoint = "http://localhost:8281"
+#https_endpoint = "https://localhost:8244"
 
 #[apim.cache.gateway_token]
 #enable = true
@@ -138,7 +138,6 @@ allow_credentials = false
 #enable_persistence = true
 #throttle_decision_endpoints = ["tcp://localhost:5672","tcp://localhost:5672"]
 
-
 #[[apim.throttling.url_group]]
 #traffic_manager_urls = ["tcp://localhost:9611"]
 #traffic_manager_auth_urls = ["ssl://localhost:9711"]
@@ -147,50 +146,6 @@ allow_credentials = false
 #traffic_manager_urls = ["tcp://localhost:9611","tcp://localhost:9611"]
 #traffic_manager_auth_urls = ["ssl://localhost:9711","ssl://localhost:9711"]
 #type = "failover"
-
-#[apim.workflow]
-#enable = false
-#service_url = "https://localhost:9445/bpmn"
-#username = "$ref{super_admin.username}"
-#password = "$ref{super_admin.password}"
-#callback_endpoint = "https://localhost:${mgt.transport.https.port}/api/am/admin/v0.17/workflows/update-workflow-status"
-#token_endpoint = "https://localhost:${https.nio.port}/token"
-#client_registration_endpoint = "https://localhost:${mgt.transport.https.port}/client-registration/v0.17/register"
-#client_registration_username = "$ref{super_admin.username}"
-#client_registration_password = "$ref{super_admin.password}"
-
-#data bridge config
-#[transport.receiver]
-#type = "binary"
-#worker_threads = 10
-#session_timeout = "30m"
-#keystore.file_name = "$ref{keystore.tls.file_name}"
-#keystore.password = "$ref{keystore.tls.password}"
-#tcp_port = 9611
-#ssl_port = 9711
-#ssl_receiver_thread_pool_size = 100
-#tcp_receiver_thread_pool_size = 100
-#ssl_enabled_protocols = ["TLSv1","TLSv1.1","TLSv1.2"]
-#ciphers = ["SSL_RSA_WITH_RC4_128_MD5","SSL_RSA_WITH_RC4_128_SHA"]
-
-#[apim.notification]
-#from_address = "APIM.com"
-#username = "APIM"
-#password = "APIM+123"
-#hostname = "localhost"
-#port = 3025
-#enable_start_tls = false
-#enable_authentication = true
-
-#[apim.token.revocation]
-#notifier_impl = "org.wso2.carbon.apimgt.keymgt.events.TokenRevocationNotifierImpl"
-#enable_realtime_notifier = true
-#realtime_notifier.ttl = 5000
-#enable_persistent_notifier = true
-#persistent_notifier.hostname = "https://localhost:2379/v2/keys/jti/"
-#persistent_notifier.ttl = 5000
-#persistent_notifier.username = "root"
-#persistent_notifier.password = "root"
 
 [[event_handler]]
 name="userPostSelfRegistration"
@@ -207,6 +162,7 @@ id = "token_revocation"
 type = "org.wso2.carbon.identity.core.handler.AbstractIdentityHandler"
 name = "org.wso2.is.notification.ApimOauthEventInterceptor"
 order = 1
+
 [event_listener.properties]
 notification_endpoint = "https://localhost:${mgt.transport.https.port}/internal/data/v1/notify"
 username = "${admin.username}"

--- a/api-control-plane/modules/distribution/product/src/main/conf/deployment.toml
+++ b/api-control-plane/modules/distribution/product/src/main/conf/deployment.toml
@@ -57,13 +57,13 @@ gateway_type = "Regular,APK,AWS"
 #display_in_api_console = true
 #description = "This is a hybrid gateway that handles both production and sandbox token traffic."
 #show_as_token_endpoint_url = true
-#service_url = "https://localhost:9444/services/"
+#service_url = "https://localhost:${mgt.transport.https.port}/services/"
 #username= "${admin.username}"
 #password= "${admin.password}"
-#ws_endpoint = "ws://localhost:9100"
-#wss_endpoint = "wss://localhost:8100"
-#http_endpoint = "http://localhost:8281"
-#https_endpoint = "https://localhost:8244"
+#ws_endpoint = "ws://localhost:9099"
+#wss_endpoint = "wss://localhost:8099"
+#http_endpoint = "http://localhost:${http.nio.port}"
+#https_endpoint = "https://localhost:${https.nio.port}"
 
 #[apim.cache.gateway_token]
 #enable = true

--- a/gateway/modules/distribution/product/src/main/conf/deployment.toml
+++ b/gateway/modules/distribution/product/src/main/conf/deployment.toml
@@ -1,7 +1,6 @@
 [server]
 hostname = "localhost"
 server_role = "default"
-offset = 1
 
 [user_store]
 type = "database_unique_id"
@@ -58,11 +57,11 @@ password = "wso2carbon"
 gateway_labels =["Default"]
 
 #[apim.throttling]
-#throttle_decision_endpoints = ["tcp://localhost:5674"]
+#throttle_decision_endpoints = ["tcp://localhost:5672"]
 
 #[[apim.throttling.url_group]]
-#traffic_manager_urls = ["tcp://localhost:9613"]
-#traffic_manager_auth_urls = ["ssl://localhost:9713"]
+#traffic_manager_urls = ["tcp://localhost:9611"]
+#traffic_manager_auth_urls = ["ssl://localhost:9711"]
 
 [apim.analytics]
 enable = false

--- a/gateway/modules/distribution/product/src/main/conf/deployment.toml
+++ b/gateway/modules/distribution/product/src/main/conf/deployment.toml
@@ -30,39 +30,39 @@ type = "JKS"
 password = "wso2carbon"
 
 # key manager implementation
-[apim.key_manager]
-service_url = "https://localhost:9443/services/"
-username= "$ref{super_admin.username}"
-password= "$ref{super_admin.password}"
+#[apim.key_manager]
+#service_url = "https://localhost:9443/services/"
+#username= "$ref{super_admin.username}"
+#password= "$ref{super_admin.password}"
 
 # Event Hub configurations
-[apim.event_hub]
-enable = true
-username = "$ref{super_admin.username}"
-password = "$ref{super_admin.password}"
-service_url = "https://localhost:9443/services/"
-event_listening_endpoints = ["tcp://localhost:5672"]
+#[apim.event_hub]
+#enable = true
+#username = "$ref{super_admin.username}"
+#password = "$ref{super_admin.password}"
+#service_url = "https://localhost:9443/services/"
+#event_listening_endpoints = ["tcp://localhost:5672"]
 
 # JWT Generation
-[apim.jwt]
-enable = true
-encoding = "base64" # base64,base64url
+#[apim.jwt]
+#enable = true
+#encoding = "base64" # base64,base64url
 #generator_impl = "org.wso2.carbon.apimgt.keymgt.token.JWTGenerator"
-claim_dialect = "http://wso2.org/claims"
-header = "X-JWT-Assertion"
-signing_algorithm = "SHA256withRSA"
+#claim_dialect = "http://wso2.org/claims"
+#header = "X-JWT-Assertion"
+#signing_algorithm = "SHA256withRSA"
 #enable_user_claims = true
 #claims_extractor_impl = "org.wso2.carbon.apimgt.impl.token.DefaultClaimsRetriever"
 
 [apim.sync_runtime_artifacts.gateway]
 gateway_labels =["Default"]
 
-[apim.throttling]
-throttle_decision_endpoints = ["tcp://localhost:5674"]
+#[apim.throttling]
+#throttle_decision_endpoints = ["tcp://localhost:5674"]
 
-[[apim.throttling.url_group]]
-traffic_manager_urls = ["tcp://localhost:9613"]
-traffic_manager_auth_urls = ["ssl://localhost:9713"]
+#[[apim.throttling.url_group]]
+#traffic_manager_urls = ["tcp://localhost:9613"]
+#traffic_manager_auth_urls = ["ssl://localhost:9713"]
 
 [apim.analytics]
 enable = false

--- a/gateway/modules/distribution/product/src/main/conf/deployment.toml
+++ b/gateway/modules/distribution/product/src/main/conf/deployment.toml
@@ -1,6 +1,7 @@
 [server]
-#hostname = "gw.wso2.com"
+hostname = "localhost"
 server_role = "default"
+offset = 1
 
 [user_store]
 type = "database_unique_id"
@@ -11,12 +12,10 @@ password = "admin"
 create_admin_account = true
 
 [database.shared_db]
-type = "mysql"
-hostname = "shared_db.mysql"
-name = "shared_db"
-port = "3306"
-username = "shareduser"
-password = "shareduser"
+type = "h2"
+url = "jdbc:h2:./repository/database/WSO2SHARED_DB;DB_CLOSE_ON_EXIT=FALSE"
+username = "wso2carbon"
+password = "wso2carbon"
 
 [keystore.tls]
 file_name =  "wso2carbon.jks"
@@ -32,9 +31,17 @@ password = "wso2carbon"
 
 # key manager implementation
 [apim.key_manager]
-service_url = "https://km.wso2.com:443/services/"
+service_url = "https://localhost:9443/services/"
 username= "$ref{super_admin.username}"
 password= "$ref{super_admin.password}"
+
+# Event Hub configurations
+[apim.event_hub]
+enable = true
+username = "$ref{super_admin.username}"
+password = "$ref{super_admin.password}"
+service_url = "https://localhost:9443/services/"
+event_listening_endpoints = ["tcp://localhost:5672"]
 
 # JWT Generation
 [apim.jwt]
@@ -50,25 +57,12 @@ signing_algorithm = "SHA256withRSA"
 [apim.sync_runtime_artifacts.gateway]
 gateway_labels =["Default"]
 
-# Traffic Manager configurations
 [apim.throttling]
-username= "$ref{super_admin.username}"
-password= "$ref{super_admin.password}"
-service_url = "https://tm.wso2.com:443/services/"
-throttle_decision_endpoints = ["tcp://tm1.local:5672","tcp://tm2.local:5672"]
-enable_unlimited_tier = true
-enable_header_based_throttling = false
-enable_jwt_claim_based_throttling = false
-enable_query_param_based_throttling = false
-
+throttle_decision_endpoints = ["tcp://localhost:5674"]
 
 [[apim.throttling.url_group]]
-traffic_manager_urls=["tcp://tm1.local:9611"]
-traffic_manager_auth_urls=["ssl://tm1.local:9711"]
-
-[[apim.throttling.url_group]]
-traffic_manager_urls=["tcp://tm2.local:9611"]
-traffic_manager_auth_urls=["ssl://tm2.local:9711"]
+traffic_manager_urls = ["tcp://localhost:9613"]
+traffic_manager_auth_urls = ["ssl://localhost:9713"]
 
 [apim.analytics]
 enable = false

--- a/gateway/modules/styles/product/src/main/resources/META-INF/component.xml
+++ b/gateway/modules/styles/product/src/main/resources/META-INF/component.xml
@@ -18,17 +18,5 @@
 <component xmlns="http://products.wso2.org/carbon">
 
     <contexts>
-<!--        <context>-->
-<!--            <context-id>default-context</context-id>-->
-<!--            <context-name>publisher</context-name>-->
-<!--            <protocol>https</protocol>-->
-<!--            <description>API Publisher Default Context</description>-->
-<!--        </context>-->
-<!--        <context>-->
-<!--            <context-id>default-additional-context</context-id>-->
-<!--            <context-name>devportal</context-name>-->
-<!--            <protocol>https</protocol>-->
-<!--            <description>API Developer Portal Default Context</description>-->
-<!--        </context>-->
     </contexts>
 </component>

--- a/gateway/modules/styles/product/src/main/resources/META-INF/component.xml
+++ b/gateway/modules/styles/product/src/main/resources/META-INF/component.xml
@@ -18,17 +18,17 @@
 <component xmlns="http://products.wso2.org/carbon">
 
     <contexts>
-        <context>
-            <context-id>default-context</context-id>
-            <context-name>publisher</context-name>
-            <protocol>https</protocol>
-            <description>API Publisher Default Context</description>
-        </context>
-        <context>
-            <context-id>default-additional-context</context-id>
-            <context-name>devportal</context-name>
-            <protocol>https</protocol>
-            <description>API Developer Portal Default Context</description>
-        </context>
+<!--        <context>-->
+<!--            <context-id>default-context</context-id>-->
+<!--            <context-name>publisher</context-name>-->
+<!--            <protocol>https</protocol>-->
+<!--            <description>API Publisher Default Context</description>-->
+<!--        </context>-->
+<!--        <context>-->
+<!--            <context-id>default-additional-context</context-id>-->
+<!--            <context-name>devportal</context-name>-->
+<!--            <protocol>https</protocol>-->
+<!--            <description>API Developer Portal Default Context</description>-->
+<!--        </context>-->
     </contexts>
 </component>

--- a/traffic-manager/modules/distribution/product/src/main/conf/deployment.toml
+++ b/traffic-manager/modules/distribution/product/src/main/conf/deployment.toml
@@ -1,7 +1,6 @@
 [server]
 hostname = "localhost"
 server_role = "default"
-offset = 2
 
 [user_store]
 type = "database_unique_id"

--- a/traffic-manager/modules/distribution/product/src/main/conf/deployment.toml
+++ b/traffic-manager/modules/distribution/product/src/main/conf/deployment.toml
@@ -1,6 +1,7 @@
 [server]
-#hostname = "tm.wso2.com"
+hostname = "localhost"
 server_role = "default"
+offset = 2
 
 [user_store]
 type = "database_unique_id"
@@ -10,21 +11,17 @@ username = "admin"
 password = "admin"
 create_admin_account = true
 
-[database.shared_db]
-type = "mysql"
-hostname = "shared_db.mysql"
-name = "shared_db"
-port = "3306"
-username = "shareduser"
-password = "shareduser"
-
 [database.apim_db]
-type = "mysql"
-hostname = "apim.mysql"
-name = "apimgt_db"
-port = "3306"
-username = "apimuser"
-password = "apimuser"
+type = "h2"
+url = "jdbc:h2:./repository/database/WSO2AM_DB;DB_CLOSE_ON_EXIT=FALSE"
+username = "wso2carbon"
+password = "wso2carbon"
+
+[database.shared_db]
+type = "h2"
+url = "jdbc:h2:./repository/database/WSO2SHARED_DB;DB_CLOSE_ON_EXIT=FALSE"
+username = "wso2carbon"
+password = "wso2carbon"
 
 [keystore.tls]
 file_name =  "wso2carbon.jks"
@@ -38,11 +35,10 @@ file_name = "client-truststore.jks"
 type = "JKS"
 password = "wso2carbon"
 
-# key manager implementation
-[apim.key_manager]
-service_url = "https://km.wso2.com:443/services/"
-
-[apim.oauth_config]
-revoke_endpoint = "https://km.wso2.com:9443/oauth2/revoke"
-enable_token_encryption = false
-enable_token_hashing = false
+# Event Hub configurations
+[apim.event_hub]
+enable = true
+username = "$ref{super_admin.username}"
+password = "$ref{super_admin.password}"
+service_url = "https://localhost:9443/services/"
+event_listening_endpoints = ["tcp://localhost:5672"]

--- a/traffic-manager/modules/distribution/product/src/main/conf/deployment.toml
+++ b/traffic-manager/modules/distribution/product/src/main/conf/deployment.toml
@@ -36,9 +36,9 @@ type = "JKS"
 password = "wso2carbon"
 
 # Event Hub configurations
-[apim.event_hub]
-enable = true
-username = "$ref{super_admin.username}"
-password = "$ref{super_admin.password}"
-service_url = "https://localhost:9443/services/"
-event_listening_endpoints = ["tcp://localhost:5672"]
+#[apim.event_hub]
+#enable = true
+#username = "$ref{super_admin.username}"
+#password = "$ref{super_admin.password}"
+#service_url = "https://localhost:9443/services/"
+#event_listening_endpoints = ["tcp://localhost:5672"]

--- a/traffic-manager/modules/styles/product/src/main/resources/META-INF/component.xml
+++ b/traffic-manager/modules/styles/product/src/main/resources/META-INF/component.xml
@@ -18,17 +18,5 @@
 <component xmlns="http://products.wso2.org/carbon">
 
     <contexts>
-<!--        <context>-->
-<!--            <context-id>default-context</context-id>-->
-<!--            <context-name>publisher</context-name>-->
-<!--            <protocol>https</protocol>-->
-<!--            <description>API Publisher Default Context</description>-->
-<!--        </context>-->
-<!--        <context>-->
-<!--            <context-id>default-additional-context</context-id>-->
-<!--            <context-name>devportal</context-name>-->
-<!--            <protocol>https</protocol>-->
-<!--            <description>API Developer Portal Default Context</description>-->
-<!--        </context>-->
     </contexts>
 </component>

--- a/traffic-manager/modules/styles/product/src/main/resources/META-INF/component.xml
+++ b/traffic-manager/modules/styles/product/src/main/resources/META-INF/component.xml
@@ -18,17 +18,17 @@
 <component xmlns="http://products.wso2.org/carbon">
 
     <contexts>
-        <context>
-            <context-id>default-context</context-id>
-            <context-name>publisher</context-name>
-            <protocol>https</protocol>
-            <description>API Publisher Default Context</description>
-        </context>
-        <context>
-            <context-id>default-additional-context</context-id>
-            <context-name>devportal</context-name>
-            <protocol>https</protocol>
-            <description>API Developer Portal Default Context</description>
-        </context>
+<!--        <context>-->
+<!--            <context-id>default-context</context-id>-->
+<!--            <context-name>publisher</context-name>-->
+<!--            <protocol>https</protocol>-->
+<!--            <description>API Publisher Default Context</description>-->
+<!--        </context>-->
+<!--        <context>-->
+<!--            <context-id>default-additional-context</context-id>-->
+<!--            <context-name>devportal</context-name>-->
+<!--            <protocol>https</protocol>-->
+<!--            <description>API Developer Portal Default Context</description>-->
+<!--        </context>-->
     </contexts>
 </component>


### PR DESCRIPTION
This PR adds the following improvements to the ACP, GW and TM components.

1. Modify the default deployment.toml files of each distribution so that it starts without errors such as unable to resolve `${http.nio.port}` and mysql configs for the DBs.
2. Remove the `/publisher` and `/devportal` urls from the GW and TM startup.