### PR TITLE
Bump AWS Agent Version for the Gateway Federation Feature

### DIFF
--- a/all-in-one-apim/pom.xml
+++ b/all-in-one-apim/pom.xml
@@ -1508,7 +1508,7 @@
         <identity.branding.preference.management.version>1.0.17</identity.branding.preference.management.version>
 
         <!-- External Gateway Agent Versions -->
-        <aws.gwmanager.feature.version>0.9.2</aws.gwmanager.feature.version>
+        <aws.gwmanager.feature.version>1.0.0</aws.gwmanager.feature.version>
     </properties>
 
 </project>


### PR DESCRIPTION
### Description
Bump the AWS Gateway client version to 1.0.0 for the APIM 4.5.0 RC1