### PR TITLE
Add Further Governance Integration Tests

### DIFF
--- a/all-in-one-apim/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/Constants.java
+++ b/all-in-one-apim/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/Constants.java
@@ -70,19 +70,29 @@ public class Constants {
         public static final String DEFAULT_RULESET_OWASP = "OWASP Top 10";
         public static final String DEFAULT_POLICY_NAME = "WSO2 API Management Best Practices";
 
+        public static final String TEST_RESOURCE_DIRECTORY = "apim-governance";
         public static final String REST_API_ARTIFACT_TYPE = "REST_API";
+        public static final String ASYNC_API_ARTIFACT_TYPE = "ASYNC_API";
         public static final String API_DEFINITION_RULE_TYPE = "API_DEFINITION";
         public static final String SPECTRAL_RULE_CATEGORY  = "SPECTRAL";
         public static final String ADMIN_PROVIDER = "admin";
 
         public static final String SIMPLE_SPECTRAL_RULESET_FILE_NAME = "simple-spectral-ruleset.yaml";
+        public static final String SIMPLE_SPECTRAL_RULESET_JSON_FILE_NAME = "simple-spectral-ruleset.json";
+        public static final String INVALID_SPECTRAL_RULESET_FILE_NAME = "invalid-spectral-ruleset.yaml";
         public static final String SIMPLE_SPECTRAL_RULESET_NAME = "Simple Spectral Ruleset";
         public static final String SIMPLE_SPECTRAL_RULESET_DESCRIPTION = "This is a sample ruleset description";
-        public static final String RULESET_DOCUMENTATION_LINK = "https://wso2.com";
-        public static final String TEST_RESOURCE_DIRECTORY = "apim-governance";
+        public static final String SIMPLE_SPECTRAL_RULESET_DOCUMENTATION_LINK = "https://wso2.com";
+
+        public static final String UPDATED_SIMPLE_SPECTRAL_RULESET_FILE_NAME = "simple-spectral-ruleset.yaml";
+        public static final String UPDATED_SIMPLE_SPECTRAL_RULESET_NAME = "Simple Spectral Ruleset";
+        public static final String UPDATED_SIMPLE_SPECTRAL_RULESET_DESCRIPTION = "This is a sample ruleset description";
+        public static final String UPDATED_SIMPLE_SPECTRAL_RULESET_DOCUMENTATION_LINK = "https://am.wso2.com";
 
         public static final String TEST_POLICY_NAME = "TestPolicy";
         public static final String TEST_POLICY_DESCRIPTION = "Test Policy Description";
+        public static final String UPDATED_TEST_POLICY_NAME = "UpdatedTestPolicy";
+        public static final String UPDATED_TEST_POLICY_DESCRIPTION = "Updated Test Policy Description";
         public static final String GLOBAL_LABEL = "global";
     }
 }

--- a/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/resources/apim-governance/invalid-spectral-ruleset.yaml
+++ b/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/resources/apim-governance/invalid-spectral-ruleset.yaml
@@ -6,6 +6,8 @@ rules:
     then:
       field: contact
       function: truthy
+      functionOptions:
+        min: 10
 
   operation-summary-required:
     description: "Each operation must have a 'summary' field."
@@ -17,6 +19,7 @@ rules:
 
   operation-description-length:
     description: "Each operation should have a description of at least 10 characters."
+    severity: warn
     given: "$.paths[*][*].description"
     then:
       function: length

--- a/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/resources/apim-governance/simple-spectral-ruleset.json
+++ b/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/resources/apim-governance/simple-spectral-ruleset.json
@@ -1,0 +1,40 @@
+{
+  "rules": {
+    "info-contact-required": {
+      "description": "The 'info' object must have a 'contact' field.",
+      "severity": "error",
+      "given": "$.info",
+      "then": {
+        "field": "contact",
+        "function": "truthy"
+      }
+    },
+    "operation-summary-required": {
+      "description": "Each operation must have a 'summary' field.",
+      "severity": "error",
+      "given": "$.paths[*][*]",
+      "then": {
+        "field": "summary",
+        "function": "truthy"
+      }
+    },
+    "operation-description-length": {
+      "description": "Each operation should have a description of at least 10 characters.",
+      "given": "$.paths[*][*].description",
+      "then": {
+        "function": "length",
+        "functionOptions": {
+          "min": 10
+        }
+      }
+    },
+    "no-empty-parameters": {
+      "description": "Parameters must not be empty.",
+      "severity": "error",
+      "given": "$.paths[*][*].parameters[*]",
+      "then": {
+        "function": "truthy"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Purpose

This pull request includes updates to the APIM Governance Test Constants and enhancements to the Ruleset Management test cases. The changes introduce new constants, improve error handling, and add new test cases to cover various scenarios.

https://github.com/wso2/api-manager/issues/3687

### Constants Update:

* [`all-in-one-apim/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/Constants.java`](diffhunk://#diff-c910a4bc72121aa7f5b18afe087497fc1d05704fcd692aab1beeebd01ded31b8R73-R95): Added new constants for ASYNC API artifact type, JSON ruleset file name, and updated ruleset details.

### Test Case Enhancements:

* [`all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/apimGovernance/RulesetMgtTestCase.java`](diffhunk://#diff-de0574eb82a5f452f7dcac50bf150695cc3c9e66955c95d00b9cb179da6af229R21-R32): Added imports for `Gson`, `ApiException`, and `ErrorDTO`. Added new test cases for invalid ruleset creation, invalid ruleset update, valid ruleset creation with JSON content, and invalid ruleset deletion. Updated existing test cases to depend on new tests and handle new constants. [[1]](diffhunk://#diff-de0574eb82a5f452f7dcac50bf150695cc3c9e66955c95d00b9cb179da6af229R21-R32) [[2]](diffhunk://#diff-de0574eb82a5f452f7dcac50bf150695cc3c9e66955c95d00b9cb179da6af229R54) [[3]](diffhunk://#diff-de0574eb82a5f452f7dcac50bf150695cc3c9e66955c95d00b9cb179da6af229R112-R146) [[4]](diffhunk://#diff-de0574eb82a5f452f7dcac50bf150695cc3c9e66955c95d00b9cb179da6af229L123-R225) [[5]](diffhunk://#diff-de0574eb82a5f452f7dcac50bf150695cc3c9e66955c95d00b9cb179da6af229R240-R297)

### Resource Files:

* [`all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/resources/apim-governance/invalid-spectral-ruleset.yaml`](diffhunk://#diff-267f20cb3070abf1ae3de56da0a845aa887b05492ee2eb6508ce8198cedbcaf0R1-R34): Added a new invalid spectral ruleset YAML file for testing purposes.
* [`all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/resources/apim-governance/simple-spectral-ruleset.json`](diffhunk://#diff-bd0512640a9ca099253b174b25e154b2ca712f0c2302c1280de81879511b5c9cR1-R40): Added a new JSON ruleset file for testing valid ruleset creation with JSON content.

### Minor Changes:

* [`all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/resources/apim-governance/simple-spectral-ruleset.yaml`](diffhunk://#diff-ccd072b09700c7e520f48a6aff1eb844e238db155bc10edadd2e41e1f3e21e1fL20): Removed the severity level from the operation description length rule.