### PR TITLE
Enable AsyncWebhookEventPublishers in TM seperated setups

### DIFF
--- a/all-in-one-apim/modules/distribution/product/src/main/resources/conf/templates/repository/deployment/server/eventpublishers/asyncWebhooksEventPublisher2.xml.j2
+++ b/all-in-one-apim/modules/distribution/product/src/main/resources/conf/templates/repository/deployment/server/eventpublishers/asyncWebhooksEventPublisher2.xml.j2
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-{% if apim.throttling.event_duplicate_url is defined %}
+{% if apim.event_hub.event_duplicate_url is defined || apim.throttling.event_duplicate_url is defined %}
 	<eventPublisher name="asyncWebhooksEventPublisher2" statistics="disable"
 {% else %}
 	<eventPublisher name="asyncWebhooksEventPublisher2" statistics="disable" processing="disable"

--- a/all-in-one-apim/modules/distribution/product/src/main/resources/conf/templates/repository/deployment/server/eventpublishers/asyncWebhooksEventPublisher_1.0.0_2.xml.j2
+++ b/all-in-one-apim/modules/distribution/product/src/main/resources/conf/templates/repository/deployment/server/eventpublishers/asyncWebhooksEventPublisher_1.0.0_2.xml.j2
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-{% if apim.throttling.event_duplicate_url is defined %}
+{% if apim.event_hub.event_duplicate_url is defined || apim.throttling.event_duplicate_url is defined %}
         <eventPublisher name="asyncWebhooksEventPublisher-1.0.0-2" statistics="disable"
 {% else %}
         <eventPublisher name="asyncWebhooksEventPublisher-1.0.0-2" statistics="disable" processing="disable"


### PR DESCRIPTION
Update the J2 mappings to enable the asynchronous webhook event publishers to be triggered on the `apim.event_hub.event_duplicate_url`, ensuring that events are properly synchronized between the brokers of both CP nodes.

Fix: https://github.com/wso2/api-manager/issues/3807