### PR TITLE
Move APISecurityTestCase to apim-integration-tests-api-lifecycle Tests

### DIFF
--- a/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -106,6 +106,7 @@
             <class name="org.wso2.am.integration.tests.api.lifecycle.APIEndpointCertificateUsageTestCase"/>
             <class name="org.wso2.am.integration.tests.api.lifecycle.UpdateAPINullPointerTestCase"/>
             <class name="org.wso2.am.integration.tests.api.lifecycle.AudienceValidationTestCase"/>
+            <class name="org.wso2.am.integration.tests.api.lifecycle.APISecurityTestCase" />
         </classes>
     </test>
 
@@ -129,7 +130,6 @@
             <class name="org.wso2.am.integration.tests.operationPolicy.OperationPolicyTestCase"/>
             <class name="org.wso2.am.integration.tests.other.APICreationForTenantsTestCase" />
             <class name="org.wso2.am.integration.tests.operationPolicy.JWTClaimBasedAccessValidatorPolicyTestCase"/>
-            <class name="org.wso2.am.integration.tests.api.lifecycle.APISecurityTestCase" />
         </classes>
     </test>
 


### PR DESCRIPTION
### Purpose
- Move APISecurityTestCase to apim-integration-tests-api-lifecycle tests to solve the git action test failure of carbon-apimgt repo