### PR TITLE
Fix MSSQL test failure by updating API names in DenyPolicySearchTestCase

### DIFF
--- a/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/restapi/admin/throttlingpolicy/DenyPolicySearchTestCase.java
+++ b/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/restapi/admin/throttlingpolicy/DenyPolicySearchTestCase.java
@@ -40,10 +40,10 @@ import java.net.URL;
 
 public class DenyPolicySearchTestCase extends APIMIntegrationBaseTest {
 
-    private final String API1_NAME = "TestAPI1";
+    private final String API1_NAME = "DenyPolicyTestAPI1";
     private final String API1_CONTEXT = "test";
     private final String API1_VERSION = "1.0.0";
-    private final String API2_NAME = "TestAPI2";
+    private final String API2_NAME = "DenyPolicyTestAPI2";
     private final String API2_CONTEXT = "test/abc";
     private final String API2_VERSION = "2.0.0";
     private final String API_END_POINT_POSTFIX_URL = "jaxrs_basic/services/customers/customerservice/";


### PR DESCRIPTION
### Purpose

Rename test API names in DenyPolicySearchTestCase to fix the MSSQL test failure.

Issue: https://github.com/wso2-enterprise/wso2-apim-internal/issues/9300