### PR TITLE
Add test for subscribing to websub API from multiple applications.

### DIFF
--- a/all-in-one-apim/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/RestAPIInternalImpl.java
+++ b/all-in-one-apim/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/RestAPIInternalImpl.java
@@ -2,19 +2,21 @@ package org.wso2.am.integration.test;
 
 import org.wso2.am.integration.clients.internal.ApiClient;
 import org.wso2.am.integration.clients.internal.ApiException;
+import org.wso2.am.integration.clients.internal.api.RetrievingWebhooksSubscriptionsApi;
 import org.wso2.am.integration.clients.internal.api.RevokeJwt_Api;
 import org.wso2.am.integration.clients.internal.api.dto.RevokedEventsDTO;
-import org.wso2.am.integration.clients.internal.api.dto.RevokedJWTListDTO;
+import org.wso2.am.integration.clients.internal.api.dto.WebhooksSubscriptionsListDTO;
 
 import javax.xml.bind.DatatypeConverter;
 import java.nio.charset.StandardCharsets;
-import java.util.List;
 
 public class RestAPIInternalImpl {
     RevokeJwt_Api revokedListAPI = new RevokeJwt_Api();
+    ApiClient apiClient = new ApiClient();
+    RetrievingWebhooksSubscriptionsApi webhooksSubscriptionsApi = new RetrievingWebhooksSubscriptionsApi();
+    String tenantDomain;
 
     public RestAPIInternalImpl(String username, String password, String tenantDomain) {
-        ApiClient apiClient = new ApiClient();
         String basicEncoded =
                 DatatypeConverter.printBase64Binary((username + ':' + password).getBytes(StandardCharsets.UTF_8));
         apiClient.addDefaultHeader("Authorization", "Basic " + basicEncoded);
@@ -24,10 +26,15 @@ public class RestAPIInternalImpl {
         apiClient.setConnectTimeout(600000);
         apiClient.setWriteTimeout(600000);
         revokedListAPI.setApiClient(apiClient);
+        this.tenantDomain = tenantDomain;
+        webhooksSubscriptionsApi.setApiClient(apiClient);
     }
 
     public RevokedEventsDTO retrieveRevokedList() throws ApiException {
         return revokedListAPI.revokedjwtGet();
+    }
 
+    public WebhooksSubscriptionsListDTO retrieveWebhooksSubscriptions() throws ApiException {
+        return webhooksSubscriptionsApi.webhooksSubscriptionsGet(tenantDomain);
     }
 }

--- a/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/streamingapis/websub/WebSubAPITestCase.java
+++ b/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/streamingapis/websub/WebSubAPITestCase.java
@@ -35,6 +35,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
+import org.wso2.am.integration.clients.internal.api.dto.WebhooksSubscriptionsListDTO;
 import org.wso2.am.integration.clients.publisher.api.v1.dto.APIDTO;
 import org.wso2.am.integration.clients.publisher.api.v1.dto.APIListDTO;
 import org.wso2.am.integration.clients.publisher.api.v1.dto.WebsubSubscriptionConfigurationDTO;
@@ -286,6 +287,82 @@ public class WebSubAPITestCase extends APIMIntegrationBaseTest {
         Assert.assertEquals(sent, received, "Callback server did not receive all the content distribution requests");
     }
 
+    @Test(description = "Test invoke WebSub API with multiple subscriptions and check subscription count",
+            dependsOnMethods = "testInvokeWebSubApi")
+    public void testMultipleSubscriptions() throws Exception {
+        String callbackUrl = "http://" + serverHost + ":" + callbackReceiverPort + "/receiver";
+        ArrayList grantTypes = new ArrayList();
+        grantTypes.add(APIMIntegrationConstants.GRANT_TYPE.PASSWORD);
+        grantTypes.add(APIMIntegrationConstants.GRANT_TYPE.REFRESH_CODE);
+        grantTypes.add(APIMIntegrationConstants.GRANT_TYPE.CLIENT_CREDENTIAL);
+
+        int initialSubscriptionCount = restAPIInternal.retrieveWebhooksSubscriptions().getList().size();
+
+        // Create 3 applications and subscribe to the API and subscribe to the topic
+        String application1Name = applicationName + "1";
+        HttpResponse application1Response = restAPIStore.createApplication(application1Name,
+                "", APIMIntegrationConstants.API_TIER.UNLIMITED, ApplicationDTO.TokenTypeEnum.OAUTH);
+        String app1Id = application1Response.getData();
+        restAPIStore.subscribeToAPI(apiId, app1Id,
+                APIMIntegrationConstants.API_TIER.ASYNC_WH_UNLIMITED);
+        ApplicationKeyDTO application1KeyDTO = restAPIStore.generateKeys(app1Id, "3600", null,
+                ApplicationKeyGenerateRequestDTO.KeyTypeEnum.PRODUCTION,
+                null, grantTypes);
+        String accessToken1 = application1KeyDTO.getToken().getAccessToken();
+        handleCallbackSubscriptionWithFormUrlEncoded(SUBSCRIBE, apiEndpoint, callbackUrl,
+                DEFAULT_TOPIC, topicSecret, "50000000",
+                accessToken1);
+        Thread.sleep(5000);
+
+        String application2Name = applicationName + "2";
+        HttpResponse application2Response = restAPIStore.createApplication(application2Name,
+                "", APIMIntegrationConstants.API_TIER.UNLIMITED, ApplicationDTO.TokenTypeEnum.OAUTH);
+        String app2Id = application2Response.getData();
+        restAPIStore.subscribeToAPI(apiId, app2Id,
+                APIMIntegrationConstants.API_TIER.ASYNC_WH_UNLIMITED);
+        ApplicationKeyDTO application2KeyDTO = restAPIStore.generateKeys(app2Id, "3600", null,
+                ApplicationKeyGenerateRequestDTO.KeyTypeEnum.PRODUCTION,
+                null, grantTypes);
+        String accessToken2 = application2KeyDTO.getToken().getAccessToken();
+        handleCallbackSubscriptionWithFormUrlEncoded(SUBSCRIBE, apiEndpoint, callbackUrl,
+                DEFAULT_TOPIC, topicSecret, "50000000",
+                accessToken2);
+        Thread.sleep(5000);
+
+        String application3Name = applicationName + "3";
+        HttpResponse application3Response = restAPIStore.createApplication(application3Name,
+                "", APIMIntegrationConstants.API_TIER.UNLIMITED, ApplicationDTO.TokenTypeEnum.OAUTH);
+        String app3Id = application3Response.getData();
+        restAPIStore.subscribeToAPI(apiId, app3Id,
+                APIMIntegrationConstants.API_TIER.ASYNC_WH_UNLIMITED);
+        ApplicationKeyDTO application3KeyDTO = restAPIStore.generateKeys(app3Id, "3600", null,
+                ApplicationKeyGenerateRequestDTO.KeyTypeEnum.PRODUCTION,
+                null, grantTypes);
+        String accessToken3 = application3KeyDTO.getToken().getAccessToken();
+        // Subscribe to topic with infinite expiry time
+        handleCallbackSubscriptionWithFormUrlEncoded(SUBSCRIBE, apiEndpoint, callbackUrl,
+                DEFAULT_TOPIC, topicSecret, accessToken3);
+        Thread.sleep(5000);
+
+        WebhooksSubscriptionsListDTO webhooksSubscriptionsListDTO = restAPIInternal.retrieveWebhooksSubscriptions();
+        Assert.assertEquals(webhooksSubscriptionsListDTO.getList().size(), initialSubscriptionCount + 3,
+                "Expected number of subscriptions not found in the database");
+
+        // Unsubscribe from the topic
+        HttpResponse unSubResponse1 = handleCallbackSubscriptionWithFormUrlEncoded(UNSUBSCRIBE, apiEndpoint, callbackUrl,
+                DEFAULT_TOPIC, topicSecret,
+                "50000000", accessToken1);
+        HttpResponse unSubResponse2 = handleCallbackSubscriptionWithFormUrlEncoded(UNSUBSCRIBE, apiEndpoint, callbackUrl,
+                DEFAULT_TOPIC, topicSecret,
+                "50000000", accessToken2);
+        HttpResponse unSubResponse3 = handleCallbackSubscriptionWithFormUrlEncoded(UNSUBSCRIBE, apiEndpoint, callbackUrl,
+                DEFAULT_TOPIC, topicSecret, accessToken3);
+        Thread.sleep(5000);
+        WebhooksSubscriptionsListDTO webhooksSubscriptionsListDTOAfterUnsubscribing = restAPIInternal.retrieveWebhooksSubscriptions();
+        Assert.assertEquals(webhooksSubscriptionsListDTOAfterUnsubscribing.getList().size(), initialSubscriptionCount,
+                "Expected number of subscriptions not found in the database");
+    }
+
     @Test(description = "Check availability of mandatory parameters",
             dependsOnMethods = "testInvokeWebSubApi")
     public void testMandatoryParameters() throws Exception {
@@ -430,6 +507,21 @@ public class WebSubAPITestCase extends APIMIntegrationBaseTest {
         String encodedUrl = URLEncoder.encode(callbackUrl, StandardCharsets.UTF_8.toString());
         String body = "hub.callback=" + encodedUrl + "&hub.mode=" + hubMode + "&hub.secret=" + hubSecret
                 + "&hub.lease_seconds=" + hubLeaseSeconds + "&hub.topic=" + hubTopic;
+        Map<String, String> headers = new HashMap<>();
+        headers.put(HttpHeaders.AUTHORIZATION, "Bearer " + bearerToken);
+        headers.put(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED);
+        return HttpRequestUtil.doPost(new URL(url), body, headers);
+    }
+
+    // Subscribe to topic without an expiry time (infinite expiry time)
+    private static HttpResponse handleCallbackSubscriptionWithFormUrlEncoded(String hubMode, String url,
+                                                                             String callbackUrl, String hubTopic,
+                                                                             String hubSecret,
+                                                                             String bearerToken)
+            throws UnsupportedEncodingException, MalformedURLException, AutomationFrameworkException {
+        String encodedUrl = URLEncoder.encode(callbackUrl, StandardCharsets.UTF_8.toString());
+        String body = "hub.callback=" + encodedUrl + "&hub.mode=" + hubMode + "&hub.secret=" + hubSecret
+                + "&hub.topic=" + hubTopic;
         Map<String, String> headers = new HashMap<>();
         headers.put(HttpHeaders.AUTHORIZATION, "Bearer " + bearerToken);
         headers.put(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED);

--- a/all-in-one-apim/pom.xml
+++ b/all-in-one-apim/pom.xml
@@ -1293,7 +1293,7 @@
 
         <!-- APIM Component Version -->
 
-        <carbon.apimgt.version>9.31.94</carbon.apimgt.version>
+        <carbon.apimgt.version>9.31.110</carbon.apimgt.version>
 
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 

--- a/api-control-plane/pom.xml
+++ b/api-control-plane/pom.xml
@@ -1284,7 +1284,7 @@
 
         <!-- APIM Component Version -->
 
-        <carbon.apimgt.version>9.31.94</carbon.apimgt.version>
+        <carbon.apimgt.version>9.31.110</carbon.apimgt.version>
 
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -1284,7 +1284,7 @@
 
         <!-- APIM Component Version -->
 
-        <carbon.apimgt.version>9.31.94</carbon.apimgt.version>
+        <carbon.apimgt.version>9.31.110</carbon.apimgt.version>
 
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 

--- a/traffic-manager/pom.xml
+++ b/traffic-manager/pom.xml
@@ -1284,7 +1284,7 @@
 
         <!-- APIM Component Version -->
 
-        <carbon.apimgt.version>9.31.94</carbon.apimgt.version>
+        <carbon.apimgt.version>9.31.110</carbon.apimgt.version>
 
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 


### PR DESCRIPTION
Related issue: https://github.com/wso2/api-manager/issues/3809

- Add test for subscribing to websub API from multiple applications and checking subscription count from internal API.
- Also tests whether topic subscriptions created without providing `hubLeaseSeconds` are retrieved from the same internal API.
- Bump carbon apimgt version