### PR TITLE
Improved webhook delivery traceability through detailed fault and debug logging

### DIFF
--- a/all-in-one-apim/modules/distribution/product/src/main/conf/synapse-configs/default/sequences/webhooksFaultSequence.xml
+++ b/all-in-one-apim/modules/distribution/product/src/main/conf/synapse-configs/default/sequences/webhooksFaultSequence.xml
@@ -18,6 +18,14 @@
   -->
 <sequence xmlns="http://ws.apache.org/ns/synapse" name="webhooksFaultSequence">
     <class name="org.wso2.carbon.apimgt.gateway.mediators.webhooks.DeliveryStatusUpdater"/>
+    <log level="custom">
+        <property name="STATUS" value="Executing default 'webhooksFaultSequence' sequence"/>
+        <property name="CALLBACK" expression="$ctx:SUBSCRIBER_CALLBACK"/>
+        <property name="ERROR_CODE" expression="get-property('ERROR_CODE')"/>
+        <property name="ERROR_MESSAGE" expression="get-property('ERROR_MESSAGE')"/>
+        <property name="API_UUID" expression="get-property('apiUUID')"/>
+        <property name="API_NAME" expression="get-property('apiName')"/>
+    </log>
     <payloadFactory media-type="json">
         <format>{"error":"$1"}</format>
         <args>

--- a/gateway/modules/distribution/product/src/main/conf/synapse-configs/default/sequences/webhooksFaultSequence.xml
+++ b/gateway/modules/distribution/product/src/main/conf/synapse-configs/default/sequences/webhooksFaultSequence.xml
@@ -18,6 +18,14 @@
   -->
 <sequence xmlns="http://ws.apache.org/ns/synapse" name="webhooksFaultSequence">
     <class name="org.wso2.carbon.apimgt.gateway.mediators.webhooks.DeliveryStatusUpdater"/>
+    <log level="custom">
+        <property name="STATUS" value="Executing default 'webhooksFaultSequence' sequence"/>
+        <property name="CALLBACK" expression="$ctx:SUBSCRIBER_CALLBACK"/>
+        <property name="ERROR_CODE" expression="get-property('ERROR_CODE')"/>
+        <property name="ERROR_MESSAGE" expression="get-property('ERROR_MESSAGE')"/>
+        <property name="API_UUID" expression="get-property('apiUUID')"/>
+        <property name="API_NAME" expression="get-property('apiName')"/>
+    </log>
     <payloadFactory media-type="json">
         <format>{"error":"$1"}</format>
         <args>


### PR DESCRIPTION
## Summary

Improves WebSub delivery traceability in the WSO2 API Manager gateway by introducing detailed logging for both successful and failed delivery attempts. These enhancements support better troubleshooting and issue correlation.

---

## Key Changes

### Java Mediator Logging
- Added debug logs in `DeliveryStatusUpdater`.
- Captures status, HTTP code, callback URL, topic, tenant domain, app ID, API UUID, and API name.
- Logs are shown when debug is enabled.

### Synapse Fault Sequence Logging
- Added always-on `<log>` mediator in `webhooksFaultSequence.xml`.
- Logs failed deliveries with key metadata regardless of log level.

---

## Related Issue

Fixes: [#3874](https://github.com/wso2/api-manager/issues/3874) – WebSub delivery logging and traceability improvements