### PR TITLE
Enhance security by encoding username in basicauth.jsp and usernameIdentifier in login.jsp

### DIFF
--- a/all-in-one-apim/modules/distribution/product/src/main/extensions/basicauth.jsp
+++ b/all-in-one-apim/modules/distribution/product/src/main/extensions/basicauth.jsp
@@ -337,7 +337,7 @@
             </div>
         </div>
     <% } else { %>
-        <input id="username" name="username" type="hidden" data-testid="login-page-username-input" value="<%=username%>">
+        <input id="username" name="username" type="hidden" data-testid="login-page-username-input" value="<%=Encode.forHtmlAttribute(username)%>">
     <% } %>
         <div class="field">
             <div class="ui fluid left icon input addon-wrapper">

--- a/all-in-one-apim/modules/distribution/product/src/main/extensions/login.jsp
+++ b/all-in-one-apim/modules/distribution/product/src/main/extensions/login.jsp
@@ -226,7 +226,7 @@
                 <h3 class="ui header ellipsis">
                     <% if (isIdentifierFirstLogin(inputType)) { %>
                         <div class="display-inline"><%=AuthenticationEndpointUtil.i18n(resourceBundle, "welcome") + " "%></div>
-                        <div id="user-name-label" class="display-inline" data-position="top left" data-variation="inverted" data-content="<%=usernameIdentifier%>"><%=usernameIdentifier%></div>
+                        <div id="user-name-label" class="display-inline" data-position="top left" data-variation="inverted" data-content="<%=Encode.forHtmlAttribute(usernameIdentifier)%>"><%=Encode.forHtmlContent(usernameIdentifier)%></div>
                     <% } else { %>
                         <%=AuthenticationEndpointUtil.i18n(resourceBundle, "login")%>
                     <% } %>

--- a/api-control-plane/modules/distribution/product/src/main/extensions/basicauth.jsp
+++ b/api-control-plane/modules/distribution/product/src/main/extensions/basicauth.jsp
@@ -337,7 +337,7 @@
             </div>
         </div>
     <% } else { %>
-        <input id="username" name="username" type="hidden" data-testid="login-page-username-input" value="<%=username%>">
+        <input id="username" name="username" type="hidden" data-testid="login-page-username-input" value="<%=Encode.forHtmlAttribute(username)%>">
     <% } %>
         <div class="field">
             <div class="ui fluid left icon input addon-wrapper">

--- a/api-control-plane/modules/distribution/product/src/main/extensions/login.jsp
+++ b/api-control-plane/modules/distribution/product/src/main/extensions/login.jsp
@@ -226,7 +226,7 @@
                 <h3 class="ui header ellipsis">
                     <% if (isIdentifierFirstLogin(inputType)) { %>
                         <div class="display-inline"><%=AuthenticationEndpointUtil.i18n(resourceBundle, "welcome") + " "%></div>
-                        <div id="user-name-label" class="display-inline" data-position="top left" data-variation="inverted" data-content="<%=usernameIdentifier%>"><%=usernameIdentifier%></div>
+                        <div id="user-name-label" class="display-inline" data-position="top left" data-variation="inverted" data-content="<%=Encode.forHtmlAttribute(usernameIdentifier)%>"><%=Encode.forHtmlContent(usernameIdentifier)%></div>
                     <% } else { %>
                         <%=AuthenticationEndpointUtil.i18n(resourceBundle, "login")%>
                     <% } %>


### PR DESCRIPTION
## Purpose

To mitigate a reflected Cross-Site Scripting (XSS) vulnerability on the login page by ensuring that user-supplied input passed via the `username` query parameters is safely rendered in the HTML without executing unintended scripts.

## Goals

- Prevent execution of malicious scripts injected through URL parameters.
- Prevent HTML injection or malformed DOM behavior caused by unencoded special characters.
- Preserve backend functionality including login and organization resolution.

## Approach

The fix involves encoding the `username` and `userIdentifier` parameters at the point of rendering, ensuring frontend safety while preserving the raw input for backend logic.

- `Encode.forHtmlAttribute(...)` is used for rendering values inside attribute contexts, such as the `value` of hidden `<input>` fields.
- `Encode.forHtmlContent(...)` is applied where values are inserted into the HTML body.
- This fix targets `login.jsp` and `basicauth.jsp` pages where the username is echoed, protecting against injection into both body and attribute contexts.

## Conclusion

Although this issue is not reproducible, due to how the `username` is retrieved using `parameters.get("username")`—where characters like `<`, `"`, `'`, and `&` are treated as literal strings rather than being interpreted as HTML—the fix was still applied as a preventive measure to ensure proper output encoding and maintain long-term security consistency.
