### PR TITLE
Update websocket_endpoint macro to accept endpoint as parameter

### DIFF
--- a/all-in-one-apim/modules/distribution/resources/api_templates/endpoint_template.xml
+++ b/all-in-one-apim/modules/distribution/resources/api_templates/endpoint_template.xml
@@ -46,6 +46,8 @@
 
 
         #macro ( timeout $config $dynamicTimeout)
+        ## No timeout config for WS endpoints
+        #if( $endpointClass != "ws" )
         #if( $config.get("actionSelect") == "neverTimeout" )
         ## print nothing.
         #elseif($config.get("actionDuration")|| $config.get("actionSelect"))
@@ -53,7 +55,7 @@
 #print_if_exist_only("duration" $config.get("actionDuration"))
 #print_if_exist_only("responseAction" $config.get("actionSelect"))
 </timeout>
-#elseif( $endpointClass != "ws" )
+#else
         ##add default timeout config for non WS endpoints
 <timeout>
     #if( $dynamicTimeout )
@@ -61,6 +63,7 @@
     #end
      <responseAction>fault</responseAction>
 </timeout>
+        #end
         #end
 
         #if( $config.get("suspendDuration") == 0)
@@ -80,11 +83,14 @@
 #print_if_exist_only("maximumDuration" $config.get("suspendMaxDuration"))
 <progressionFactor>#print_if_exist( $config.get("factor") 1.0)</progressionFactor>
 </suspendOnFailure>
+## No markForSuspension config for WS endpoints
+#if( $endpointClass != "ws" )
 <markForSuspension>
 #print_list("errorCodes" $config.get("retryErroCode"))
 <retriesBeforeSuspension>#print_if_exist( $config.get("retryTimeOut") 0)</retriesBeforeSuspension>
 <retryDelay>#print_if_exist( $config.get("retryDelay") 0)</retryDelay>
 </markForSuspension>
+#end
         #end
 #end
 
@@ -178,7 +184,7 @@
         #end
 
         ##macro for websocket endpoints
-        #macro ( websocket_endpoint $name )
+        #macro ( websocket_endpoint $name $ep )
 <endpoint xmlns="http://ws.apache.org/ns/synapse" name="${name}_${websocketResourceKey}">
 <property name="OUT_ONLY" value="true"/>
 <http uri-template="$util.escapeXml($endpointUrl)">
@@ -233,7 +239,7 @@ optimize="$advance_ep.get("optimize")"
         #elseif( $endpointClass == "http" )
             #http_endpoint( $ep_key $endpoints false)
         #elseif( $endpointClass == "ws" )
-            #websocket_endpoint( $ep_key )
+            #websocket_endpoint( $ep_key $endpoints )
         #elseif( $endpointClass == "address" )
             #address_endpoint( $ep_key $endpoints )
         #elseif( $endpointClass == "failover" )

--- a/api-control-plane/modules/distribution/resources/api_templates/endpoint_template.xml
+++ b/api-control-plane/modules/distribution/resources/api_templates/endpoint_template.xml
@@ -46,6 +46,8 @@
 
 
         #macro ( timeout $config $dynamicTimeout)
+        ## No timeout config for WS endpoints
+        #if( $endpointClass != "ws" )
         #if( $config.get("actionSelect") == "neverTimeout" )
         ## print nothing.
         #elseif($config.get("actionDuration")|| $config.get("actionSelect"))
@@ -53,7 +55,7 @@
 #print_if_exist_only("duration" $config.get("actionDuration"))
 #print_if_exist_only("responseAction" $config.get("actionSelect"))
 </timeout>
-#elseif( $endpointClass != "ws" )
+#else
         ##add default timeout config for non WS endpoints
 <timeout>
     #if( $dynamicTimeout )
@@ -61,6 +63,7 @@
     #end
      <responseAction>fault</responseAction>
 </timeout>
+        #end
         #end
 
         #if( $config.get("suspendDuration") == 0)
@@ -80,11 +83,14 @@
 #print_if_exist_only("maximumDuration" $config.get("suspendMaxDuration"))
 <progressionFactor>#print_if_exist( $config.get("factor") 1.0)</progressionFactor>
 </suspendOnFailure>
+## No markForSuspension config for WS endpoints
+#if( $endpointClass != "ws" )
 <markForSuspension>
 #print_list("errorCodes" $config.get("retryErroCode"))
 <retriesBeforeSuspension>#print_if_exist( $config.get("retryTimeOut") 0)</retriesBeforeSuspension>
 <retryDelay>#print_if_exist( $config.get("retryDelay") 0)</retryDelay>
 </markForSuspension>
+#end
         #end
 #end
 
@@ -178,7 +184,7 @@
         #end
 
         ##macro for websocket endpoints
-        #macro ( websocket_endpoint $name )
+        #macro ( websocket_endpoint $name $ep )
 <endpoint xmlns="http://ws.apache.org/ns/synapse" name="${name}_${websocketResourceKey}">
 <property name="OUT_ONLY" value="true"/>
 <http uri-template="$util.escapeXml($endpointUrl)">
@@ -233,7 +239,7 @@ optimize="$advance_ep.get("optimize")"
         #elseif( $endpointClass == "http" )
             #http_endpoint( $ep_key $endpoints false)
         #elseif( $endpointClass == "ws" )
-            #websocket_endpoint( $ep_key )
+            #websocket_endpoint( $ep_key $endpoints )
         #elseif( $endpointClass == "address" )
             #address_endpoint( $ep_key $endpoints )
         #elseif( $endpointClass == "failover" )

--- a/gateway/modules/distribution/resources/api_templates/endpoint_template.xml
+++ b/gateway/modules/distribution/resources/api_templates/endpoint_template.xml
@@ -46,6 +46,8 @@
 
 
         #macro ( timeout $config)
+        ## No timeout config for WS endpoints
+        #if( $endpointClass != "ws" )
         #if( $config.get("actionSelect") == "neverTimeout" )
         ## print nothing.
         #elseif($config.get("actionDuration")|| $config.get("actionSelect"))
@@ -53,11 +55,12 @@
 #print_if_exist_only("duration" $config.get("actionDuration"))
 #print_if_exist_only("responseAction" $config.get("actionSelect"))
 </timeout>
-#elseif( $endpointClass != "ws" )
+#else
         ##add default timeout config for non WS endpoints
 <timeout>
      <responseAction>fault</responseAction>
 </timeout>
+        #end
         #end
 
         #if( $config.get("suspendDuration") == 0)
@@ -77,11 +80,14 @@
 #print_if_exist_only("maximumDuration" $config.get("suspendMaxDuration"))
 <progressionFactor>#print_if_exist( $config.get("factor") 1.0)</progressionFactor>
 </suspendOnFailure>
+## No markForSuspension config for WS endpoints
+#if( $endpointClass != "ws" )
 <markForSuspension>
 #print_list("errorCodes" $config.get("retryErroCode"))
 <retriesBeforeSuspension>#print_if_exist( $config.get("retryTimeOut") 0)</retriesBeforeSuspension>
 <retryDelay>#print_if_exist( $config.get("retryDelay") 0)</retryDelay>
 </markForSuspension>
+#end
         #end
 #end
 
@@ -175,7 +181,7 @@
         #end
 
         ##macro for websocket endpoints
-        #macro ( websocket_endpoint $name )
+        #macro ( websocket_endpoint $name $ep )
 <endpoint xmlns="http://ws.apache.org/ns/synapse" name="${name}_${websocketResourceKey}">
 <property name="OUT_ONLY" value="true"/>
 <http uri-template="$util.escapeXml($endpointUrl)">
@@ -231,7 +237,7 @@ optimize="$advance_ep.get("optimize")"
         #if( $endpointClass == "http" )
             #http_endpoint( $ep_key $endpoints )
         #elseif( $endpointClass == "ws" )
-            #websocket_endpoint( $ep_key )
+            #websocket_endpoint( $ep_key $endpoints )
         #elseif( $endpointClass == "address" )
             #address_endpoint( $ep_key $endpoints )
         #elseif( $endpointClass == "failover" )

--- a/traffic-manager/modules/distribution/resources/api_templates/endpoint_template.xml
+++ b/traffic-manager/modules/distribution/resources/api_templates/endpoint_template.xml
@@ -46,6 +46,8 @@
 
 
         #macro ( timeout $config)
+        ## No timeout config for WS endpoints
+        #if( $endpointClass != "ws" )
         #if( $config.get("actionSelect") == "neverTimeout" )
         ## print nothing.
         #elseif($config.get("actionDuration")|| $config.get("actionSelect"))
@@ -53,11 +55,12 @@
 #print_if_exist_only("duration" $config.get("actionDuration"))
 #print_if_exist_only("responseAction" $config.get("actionSelect"))
 </timeout>
-#elseif( $endpointClass != "ws" )
+#else
         ##add default timeout config for non WS endpoints
 <timeout>
      <responseAction>fault</responseAction>
 </timeout>
+        #end
         #end
 
         #if( $config.get("suspendDuration") == 0)
@@ -77,11 +80,14 @@
 #print_if_exist_only("maximumDuration" $config.get("suspendMaxDuration"))
 <progressionFactor>#print_if_exist( $config.get("factor") 1.0)</progressionFactor>
 </suspendOnFailure>
+## No markForSuspension config for WS endpoints
+#if( $endpointClass != "ws" )
 <markForSuspension>
 #print_list("errorCodes" $config.get("retryErroCode"))
 <retriesBeforeSuspension>#print_if_exist( $config.get("retryTimeOut") 0)</retriesBeforeSuspension>
 <retryDelay>#print_if_exist( $config.get("retryDelay") 0)</retryDelay>
 </markForSuspension>
+#end
         #end
 #end
 
@@ -175,7 +181,7 @@
         #end
 
         ##macro for websocket endpoints
-        #macro ( websocket_endpoint $name )
+        #macro ( websocket_endpoint $name $ep )
 <endpoint xmlns="http://ws.apache.org/ns/synapse" name="${name}_${websocketResourceKey}">
 <property name="OUT_ONLY" value="true"/>
 <http uri-template="$util.escapeXml($endpointUrl)">
@@ -227,7 +233,7 @@ optimize="$advance_ep.get("optimize")"
         #if( $endpointClass == "http" )
             #http_endpoint( $ep_key $endpoints )
         #elseif( $endpointClass == "ws" )
-            #websocket_endpoint( $ep_key )
+            #websocket_endpoint( $ep_key $endpoints )
         #elseif( $endpointClass == "address" )
             #address_endpoint( $ep_key $endpoints )
         #elseif( $endpointClass == "failover" )


### PR DESCRIPTION
## Purpose
Purpose of this PR is to fix https://github.com/wso2/api-manager/issues/3993

## Approach
Updated the `websocket_endpoint` macro in `endpoint_template` to accept the endpoint as a parameter, so the Synapse artifact for the WebSocket API will include the timeout and suspension-related configurations.