### PR TITLE
Update fault sequence to return 500 on response schema validation failure

### DIFF
--- a/all-in-one-apim/modules/distribution/product/src/main/conf/synapse-configs/default/sequences/_threat_fault_.xml
+++ b/all-in-one-apim/modules/distribution/product/src/main/conf/synapse-configs/default/sequences/_threat_fault_.xml
@@ -38,7 +38,14 @@
     <property name="Host" scope="transport" action="remove"/>
     <property name="Accept" scope="transport" action="remove"/>
     <property name="X-JWT-Assertion" scope="transport" action="remove"/>
-    <property name="HTTP_SC" scope="axis2" type="STRING" value="400"/>
+    <filter xpath="string-length(normalize-space(get-property('THREAT_CODE'))) > 0">
+        <then>
+            <property name="HTTP_SC" scope="axis2" type="STRING" expression="get-property('THREAT_CODE')"/>
+        </then>
+        <else>
+            <property name="HTTP_SC" scope="axis2" type="STRING" value="400"/>
+        </else>
+    </filter>
     <sequence key="_cors_request_handler_"/>
     <send/>
     <drop/>

--- a/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/schemaValidation/SchemaValidationTestCase.java
+++ b/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/schemaValidation/SchemaValidationTestCase.java
@@ -143,7 +143,7 @@ public class SchemaValidationTestCase extends APIManagerLifecycleBaseTest {
         HttpResponse serviceResponse = HTTPSClientUtils.doGet(invokeURL + "/pets/123",
                 requestHeaders);
         //Schema validation fails as the response body does not match the defined schema
-        Assert.assertEquals(serviceResponse.getResponseCode(), 400);
+        Assert.assertEquals(serviceResponse.getResponseCode(), 500);
         Assert.assertEquals(serviceResponse.getData().contains("Schema validation failed in the Response:"), true);
         //Clean the custom request body
     }

--- a/gateway/modules/distribution/product/src/main/conf/synapse-configs/default/sequences/_threat_fault_.xml
+++ b/gateway/modules/distribution/product/src/main/conf/synapse-configs/default/sequences/_threat_fault_.xml
@@ -38,7 +38,14 @@
     <property name="Host" scope="transport" action="remove"/>
     <property name="Accept" scope="transport" action="remove"/>
     <property name="X-JWT-Assertion" scope="transport" action="remove"/>
-    <property name="HTTP_SC" scope="axis2" type="STRING" value="400"/>
+    <filter xpath="string-length(normalize-space(get-property('THREAT_CODE'))) > 0">
+        <then>
+            <property name="HTTP_SC" scope="axis2" type="STRING" expression="get-property('THREAT_CODE')"/>
+        </then>
+        <else>
+            <property name="HTTP_SC" scope="axis2" type="STRING" value="400"/>
+        </else>
+    </filter>
     <sequence key="_cors_request_handler_"/>
     <send/>
     <drop/>


### PR DESCRIPTION
## Description

This PR updates the default fault sequence (`_threat_fault_.xml`) to correctly return a **500 Internal Server Error** when the response payload from the backend fails schema validation, instead of the current **400 Bad Request**.

Returning 500 aligns with standard HTTP semantics and accurately reflects that the backend response is invalid—not the client's request.

## Approach

- Replaced the `HTTP_SC` property (400) in `_threat_fault_.xml` with a **conditional check**.
- Introduced a `filter` mediator to check if the `THREAT_CODE` property is set and non-empty.
  - If `THREAT_CODE` is present, its value is used as the HTTP status code.
  - If not, it defaults to `400`, preserving existing behavior for other threat scenarios.
- This ensures that **response schema validation failures** now result in `500`, as expected.

## Testing

Tested and verified both all-in-one and distributed setups now return `500` upon response schema validation failures, when schema validation is enabled.

## Related Issue
Resolves: https://github.com/wso2/api-manager/issues/3966, https://github.com/wso2/api-manager/issues/3291