### PR TITLE
Add property for signature property name for webhook APIs

### DIFF
--- a/gateway/modules/distribution/resources/api_templates/websub_api_template.xml
+++ b/gateway/modules/distribution/resources/api_templates/websub_api_template.xml
@@ -21,6 +21,7 @@
             #if($isSecurityEnabled)
             <property name="generated_signature" expression="fn:concat('$signingAlgorithm', hmac-generate($ctx:ORIGINAL_PAYLOAD, '$secret', '$hmacSignatureGenerationAlgorithm'))"/>
             <property name="received_signature" expression="$trp:$signatureHeader"/>
+            <property name="signature_header_name" expression="'$signatureHeader'"/>
             <filter xpath="get-property('received_signature') = get-property('generated_signature')">
                 <then>
             #end


### PR DESCRIPTION
Related issue: https://github.com/wso2/api-manager/issues/3962

This PR updates the API template to add a property containing the name of the signature for webhook APIs.