### PR TITLE
fixing error message in a log statement

### DIFF
--- a/all-in-one-apim/modules/integration/tests-common/admin-clients/src/main/java/org/wso2/am/admin/clients/registry/ResourceAdminServiceClient.java
+++ b/all-in-one-apim/modules/integration/tests-common/admin-clients/src/main/java/org/wso2/am/admin/clients/registry/ResourceAdminServiceClient.java
@@ -221,7 +221,7 @@ public class ResourceAdminServiceClient {
 		try {
 			return resourceAdminServiceStub.getMimeTypeFromHuman(mediaType);
 		} catch (Exception e) {
-			String msg = "get human readable media type error ";
+			String msg = "get mime type from human error ";
 			throw new Exception(msg, e);
 
 		}


### PR DESCRIPTION
It seems that the old message had been incorrectly copy pasted without modifying the error message.

Another issue might be that the potentially specific Exception is cast to the base Exception type, losing the more specific error signal.

What's interesting to note is that the try catch statement adds no value, removing it altogether would have actually fixed both issues.