### PR TITLE
Bump synapse version of other distributions to 4.0.0-wso2v240

### DIFF
--- a/api-control-plane/pom.xml
+++ b/api-control-plane/pom.xml
@@ -1356,7 +1356,7 @@
         <opencsv.version>1.8</opencsv.version>
         <poi.version>3.0-FINAL</poi.version>
         <woden.version>1.0.0.M8-wso2v1</woden.version>
-        <synapse.version>4.0.0-wso2v221</synapse.version>
+        <synapse.version>4.0.0-wso2v240</synapse.version>
         <passthru.transport.patch.version>1.0.2</passthru.transport.patch.version>
         <axis2.wso2.version>1.6.1-wso2v102</axis2.wso2.version>
         <axiom.wso2.version>1.2.11-wso2v29</axiom.wso2.version>

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -1356,7 +1356,7 @@
         <opencsv.version>1.8</opencsv.version>
         <poi.version>3.0-FINAL</poi.version>
         <woden.version>1.0.0.M8-wso2v1</woden.version>
-        <synapse.version>4.0.0-wso2v221</synapse.version>
+        <synapse.version>4.0.0-wso2v240</synapse.version>
         <passthru.transport.patch.version>1.0.2</passthru.transport.patch.version>
         <axis2.wso2.version>1.6.1-wso2v102</axis2.wso2.version>
         <axiom.wso2.version>1.2.11-wso2v29</axiom.wso2.version>

--- a/traffic-manager/pom.xml
+++ b/traffic-manager/pom.xml
@@ -1356,7 +1356,7 @@
         <opencsv.version>1.8</opencsv.version>
         <poi.version>3.0-FINAL</poi.version>
         <woden.version>1.0.0.M8-wso2v1</woden.version>
-        <synapse.version>4.0.0-wso2v221</synapse.version>
+        <synapse.version>4.0.0-wso2v240</synapse.version>
         <passthru.transport.patch.version>1.0.2</passthru.transport.patch.version>
         <axis2.wso2.version>1.6.1-wso2v102</axis2.wso2.version>
         <axiom.wso2.version>1.2.11-wso2v29</axiom.wso2.version>


### PR DESCRIPTION
## Purpose
This PR bumps the synapse version of other distributions to 4.0.0-wso2v240