### PR TITLE
Add tests for API policies with secret attributes

### DIFF
--- a/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/operationPolicy/addSecretHeadersPolicy.j2
+++ b/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/operationPolicy/addSecretHeadersPolicy.j2
@@ -1,0 +1,2 @@
+<property action="set" name="apiKey" value="{{apiKey}}" scope="transport" />
+<property action="set" name="token" value="{{token}}" scope="transport" />

--- a/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/operationPolicy/addSecretHeadersPolicy.json
+++ b/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/operationPolicy/addSecretHeadersPolicy.json
@@ -1,0 +1,37 @@
+{
+  "category": "Mediation",
+  "name": "AddSecretHeaders",
+  "version": "v1",
+  "displayName": "Add Secret Headers",
+  "description": "Add secret header values (API key and token)",
+  "applicableFlows": [
+    "request",
+    "response",
+    "fault"
+  ],
+  "supportedGateways": [
+    "Synapse"
+  ],
+  "supportedApiTypes": [
+    "HTTP"
+  ],
+  "policyAttributes": [
+    {
+      "name": "apiKey",
+      "displayName": "API Key",
+      "description": "Add the secret API key to the header",
+      "type": "Secret",
+      "validationRegex": "^test.*",
+      "allowedValues": [],
+      "required": true
+    },
+    {
+      "name": "token",
+      "displayName": "Token",
+      "description": "Add the secret token to the header (Optional)",
+      "type": "Secret",
+      "allowedValues": [],
+      "required": false
+    }
+  ]
+}


### PR DESCRIPTION
### Purpose
Purpose of this PR is to add the integration tests for the API policies with `secret` type policy attributes
which is the feature developed under https://github.com/wso2/api-manager/issues/3797

### Approach
- Added a new policy with secret type policy attributes
- Added tests for create, attach, retrieval, and update scenarios

#### Added the following tests:

```
testAddAPISpecificOperationPolicyWithSecrets (Add API specific operation policy with secret attributes)
testAPIBeforeAttachingPolicyWithSecretAttributes (Test API before attaching secret policy)
testAPIAfterAttachingPolicyWithSecretAttributes (Test API after attaching policy with secret attributes)
testRetrievePolicyWithSecretAttributes (Test secret policy attribute retrieval)
testUpdatePolicyWithSecretAttributes (Test updating secret policy attributes with preserve option)
testVersionCreationWithPolicyWithSecretAttributes (Test version creation with secret policy attributes)
testDeleteAPISpecificOperationPolicyWithSecrets (Delete API specific operation policy with secret attributes)
```