### PR TITLE
Add configs related to missing certificate error in active-active setup

### DIFF
--- a/all-in-one-apim/modules/distribution/product/src/main/resources/conf/infer.json
+++ b/all-in-one-apim/modules/distribution/product/src/main/resources/conf/infer.json
@@ -9,7 +9,8 @@
       "system.parameter.profile": "gateway-worker",
       "apim.key_manager.enable_registration": false,
       "oauth.grant_type.token_exchange.enable": false,
-      "apim.ai.llm_provider_events_enabled": false
+      "apim.ai.llm_provider_events_enabled": false,
+      "apim.certificate_manager.events_enabled": false
     },
     "api-key-manager-deprecated": {
       "apim.throttling.enable_policy_deploy": false,
@@ -33,7 +34,8 @@
       "apim.throttling.enable_decision_connection": false,
       "apim.throttling.enable_blacklist_condition": false,
       "oauth.grant_type.token_exchange.enable": false,
-      "apim.ai.llm_provider_events_enabled": false
+      "apim.ai.llm_provider_events_enabled": false,
+      "apim.certificate_manager.events_enabled": false
     },
     "control-plane": {
       "system.parameter.profile": "control-plane",
@@ -45,7 +47,8 @@
       "transport.ws.sender.enable": false,
       "transport.wss.sender.enable": false,
       "apim.sync_runtime_artifacts.gateway.enable": "false",
-      "apim.ai.llm_provider_events_enabled": true
+      "apim.ai.llm_provider_events_enabled": true,
+      "apim.certificate_manager.events_enabled": true
     },
     "default": {
       "oauth.extensions.token_generator": "org.wso2.carbon.identity.oauth2.token.OauthTokenIssuerImpl"

--- a/api-control-plane/modules/distribution/product/src/main/resources/conf/infer.json
+++ b/api-control-plane/modules/distribution/product/src/main/resources/conf/infer.json
@@ -10,7 +10,8 @@
       "transport.ws.sender.enable": false,
       "transport.wss.sender.enable": false,
       "apim.sync_runtime_artifacts.gateway.enable": "false",
-      "apim.ai.llm_provider_events_enabled": true
+      "apim.ai.llm_provider_events_enabled": true,
+      "apim.certificate_manager.events_enabled": true
     }
   },
   "apim.jwt.encoding": {

--- a/gateway/modules/distribution/product/src/main/resources/conf/infer.json
+++ b/gateway/modules/distribution/product/src/main/resources/conf/infer.json
@@ -9,7 +9,8 @@
       "indexing.enable": false,
       "apim.key_manager.enable_registration": false,
       "oauth.grant_type.token_exchange.enable": false,
-      "apim.ai.llm_provider_events_enabled": false
+      "apim.ai.llm_provider_events_enabled": false,
+      "apim.certificate_manager.events_enabled": false
     }
   },
   "apim.jwt.encoding": {

--- a/traffic-manager/modules/distribution/product/src/main/resources/conf/infer.json
+++ b/traffic-manager/modules/distribution/product/src/main/resources/conf/infer.json
@@ -9,7 +9,8 @@
       "apim.throttling.enable_decision_connection": false,
       "apim.throttling.enable_blacklist_condition": false,
       "oauth.grant_type.token_exchange.enable": false,
-      "apim.ai.llm_provider_events_enabled": false
+      "apim.ai.llm_provider_events_enabled": false,
+      "apim.certificate_manager.events_enabled": false
     }
   },
   "apim.jwt.encoding": {


### PR DESCRIPTION
Fix https://github.com/wso2/api-manager/issues/3388

This pull request introduces a new configuration property, apim.certificate_manager.events_enabled, to the infer.json configuration files across different modules. This property enables or disables event handling for the certificate manager, preventing the gateway and traffic manager from subscribing to JMS events, as these events are only relevant to the control plane.