### PR TITLE
Adding Lua and WASM Policies for KGW APIs

### DIFF
--- a/all-in-one-apim/modules/distribution/resources/operation_policies/specifications/apkLuaInterceptorService_v1.json
+++ b/all-in-one-apim/modules/distribution/resources/operation_policies/specifications/apkLuaInterceptorService_v1.json
@@ -1,0 +1,52 @@
+{
+  "category": "Mediation",
+  "name": "apkLuaInterceptorService",
+  "version": "v1",
+  "displayName": "Lua Extension Service",
+  "description": "This policy allows you to call an Lua extension service for a request message",
+  "policyAttributes": [
+    {
+      "name": "policyName",
+      "displayName": "Policy Name",
+      "description": "Name for the Lua policy(Must be unique within the gateway)",
+      "validationRegex": "^([a-zA-Z_\\:][a-zA-Z\\d_\\-\\ ]*)$",
+      "type": "String",
+      "required": true
+    },
+    {
+      "name": "sourceCode",
+      "displayName": "Source Code",
+      "description": "The source code as an inline string.",
+      "validationRegex": "^.+$",
+      "type": "String",
+      "required": false
+    },
+    {
+      "name": "sourceCodeRef",
+      "displayName": "Source Code Reference",
+      "description": "This is the source code specified as a local object reference",
+      "validationRegex": "^.+$",
+      "type": "String",
+      "required": false
+    },
+    {
+      "name": "mountInConfigMap",
+      "displayName": "Mount In ConfigMap",
+      "description": "Specifies that when both source code and a reference are provided, a ConfigMap is created with the reference name for reuse across the system.",
+      "validationRegex": "^(true|false)$",
+      "type": "Boolean",
+      "defaultValue": false,
+      "required": false
+    }
+  ],
+  "applicableFlows": [
+    "request",
+    "response"
+  ],
+  "supportedGateways": [
+    "ChoreoConnect"
+  ],
+  "supportedApiTypes": [
+    "HTTP"
+  ]
+}

--- a/all-in-one-apim/modules/distribution/resources/operation_policies/specifications/apkWASMInterceptorService_v1.json
+++ b/all-in-one-apim/modules/distribution/resources/operation_policies/specifications/apkWASMInterceptorService_v1.json
@@ -1,0 +1,85 @@
+{
+  "category": "Mediation",
+  "name": "apkWASMInterceptorService",
+  "version": "v1",
+  "displayName": "WASM Extension Service",
+  "description": "This policy allows you to call an WASM extension service for a request message",
+  "policyAttributes": [
+    {
+      "name": "policyName",
+      "displayName": "Policy Name",
+      "description": "Name for the WASM policy(Must be unique within the gateway).",
+      "validationRegex": "^([a-zA-Z_\\:][a-zA-Z\\d_\\-\\ ]*)$",
+      "type": "String",
+      "required": true
+    },
+    {
+      "name": "rootId",
+      "displayName": "Root ID",
+      "description": "This uniquely identifies a set of extensions within a VM that share the same RootContext and Contexts.",
+      "validationRegex": "^([a-zA-Z_\\:][a-zA-Z\\d_\\-\\ ]*)$",
+      "type": "String",
+      "required": true
+    },
+    {
+      "name": "wasmpolicyURL",
+      "displayName": "Policy URL",
+      "description": "The HTTP URL containing the Wasm code.",
+      "validationRegex": "^(([\\w+]+\\:\\/\\/)?([\\w\\d-]+\\.)*[\\w-]+([\\.\\:]\\w+)*([\\/\\?\\=\\&\\#\\.]?[\\w-]+)*\\/?)$",
+      "type": "String",
+      "required": false
+    },
+    {
+      "name": "wasmpolicyImage",
+      "displayName": "Policy Image",
+      "description": "The OCI image containing the WASM code.",
+      "validationRegex": "^.+$",
+      "type": "String",
+      "required": false
+    },
+    {
+      "name": "imagePullPolicy",
+      "displayName": "Image Pull Policy",
+      "description": "This is the policy to use when pulling the Wasm module by either the HTTP or Image source.",
+      "validationRegex": "^.+$",
+      "type": "Enum",
+      "allowedValues" : ["Always","IfNotPresent"],
+      "required": false
+    },
+    {
+      "name": "wasmConfig",
+      "displayName": "Config",
+      "description": "Configuration for the WASM extension(Must be a valid JSON string).",
+      "validationRegex": "^.+$",
+      "type": "String",
+      "required": false
+    },
+    {
+      "name": "failOpen",
+      "displayName": "FailOpen",
+      "description": "This is a switch used to control the behavior when a fatal error occurs during the initialization or the execution of the Wasm extension.",
+      "validationRegex": "^(true|false)$",
+      "type": "Boolean",
+      "defaultValue": false,
+      "required": false
+    },
+    {
+      "name": "hostKeys",
+      "displayName": "Host Keys",
+      "description": "Includes a comma separated list of keys for environment variables from the host envoy process that should be passed into the Wasm VM.",
+      "validationRegex": "^.+$",
+      "type": "String",
+      "required": false
+    }
+  ],
+  "applicableFlows": [
+    "request",
+    "response"
+  ],
+  "supportedGateways": [
+    "ChoreoConnect"
+  ],
+  "supportedApiTypes": [
+    "HTTP"
+  ]
+}

--- a/all-in-one-apim/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/impl/RestAPIPublisherImpl.java
+++ b/all-in-one-apim/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/impl/RestAPIPublisherImpl.java
@@ -2439,7 +2439,7 @@ public class RestAPIPublisherImpl {
 
         setActivityID();
         ApiResponse<OperationPolicyDataListDTO> apiResponse =
-                operationPoliciesApi.getAllCommonOperationPoliciesWithHttpInfo(50, 0, null);
+                operationPoliciesApi.getAllCommonOperationPoliciesWithHttpInfo(200, 0, null);
         Assert.assertEquals(apiResponse.getStatusCode(), HttpStatus.SC_OK,
                 "Unable to retrieve common policies " + apiResponse.getData());
         if (apiResponse != null && apiResponse.getData().getCount() >= 0) {

--- a/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/analytics/ELKAnalyticsWithRespondMediatorTestCase.java
+++ b/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/analytics/ELKAnalyticsWithRespondMediatorTestCase.java
@@ -115,7 +115,7 @@ public class ELKAnalyticsWithRespondMediatorTestCase extends APIManagerLifecycle
 
         // Add common operation policy with respond mediator
         addNewOperationPolicy();
-        Map<String, String> updatedCommonPolicyMap = restAPIPublisher.getAllCommonOperationPolicies(60, 0, null);
+        Map<String, String> updatedCommonPolicyMap = restAPIPublisher.getAllCommonOperationPolicies(70, 0, null);
         Assert.assertNotNull(updatedCommonPolicyMap.get("respondMediatorPolicy"),
                 "Unable to find the newly added common policy");
 

--- a/api-control-plane/modules/distribution/resources/operation_policies/specifications/apkLuaInterceptorService_v1.json
+++ b/api-control-plane/modules/distribution/resources/operation_policies/specifications/apkLuaInterceptorService_v1.json
@@ -1,0 +1,52 @@
+{
+  "category": "Mediation",
+  "name": "apkLuaInterceptorService",
+  "version": "v1",
+  "displayName": "Lua Extension Service",
+  "description": "This policy allows you to call an Lua extension service for a request message",
+  "policyAttributes": [
+    {
+      "name": "policyName",
+      "displayName": "Policy Name",
+      "description": "Name for the Lua policy(Must be unique within the gateway)",
+      "validationRegex": "^([a-zA-Z_\\:][a-zA-Z\\d_\\-\\ ]*)$",
+      "type": "String",
+      "required": true
+    },
+    {
+      "name": "sourceCode",
+      "displayName": "Source Code",
+      "description": "The source code as an inline string.",
+      "validationRegex": "^.+$",
+      "type": "String",
+      "required": false
+    },
+    {
+      "name": "sourceCodeRef",
+      "displayName": "Source Code Reference",
+      "description": "This is the source code specified as a local object reference",
+      "validationRegex": "^.+$",
+      "type": "String",
+      "required": false
+    },
+    {
+      "name": "mountInConfigMap",
+      "displayName": "Mount In ConfigMap",
+      "description": "Specifies that when both source code and a reference are provided, a ConfigMap is created with the reference name for reuse across the system.",
+      "validationRegex": "^(true|false)$",
+      "type": "Boolean",
+      "defaultValue": false,
+      "required": false
+    }
+  ],
+  "applicableFlows": [
+    "request",
+    "response"
+  ],
+  "supportedGateways": [
+    "ChoreoConnect"
+  ],
+  "supportedApiTypes": [
+    "HTTP"
+  ]
+}

--- a/api-control-plane/modules/distribution/resources/operation_policies/specifications/apkWASMInterceptorService_v1.json
+++ b/api-control-plane/modules/distribution/resources/operation_policies/specifications/apkWASMInterceptorService_v1.json
@@ -1,0 +1,85 @@
+{
+  "category": "Mediation",
+  "name": "apkWASMInterceptorService",
+  "version": "v1",
+  "displayName": "WASM Extension Service",
+  "description": "This policy allows you to call an WASM extension service for a request message",
+  "policyAttributes": [
+    {
+      "name": "policyName",
+      "displayName": "Policy Name",
+      "description": "Name for the WASM policy(Must be unique within the gateway).",
+      "validationRegex": "^([a-zA-Z_\\:][a-zA-Z\\d_\\-\\ ]*)$",
+      "type": "String",
+      "required": true
+    },
+    {
+      "name": "rootId",
+      "displayName": "Root ID",
+      "description": "This uniquely identifies a set of extensions within a VM that share the same RootContext and Contexts.",
+      "validationRegex": "^([a-zA-Z_\\:][a-zA-Z\\d_\\-\\ ]*)$",
+      "type": "String",
+      "required": true
+    },
+    {
+      "name": "wasmpolicyURL",
+      "displayName": "Policy URL",
+      "description": "The HTTP URL containing the Wasm code.",
+      "validationRegex": "^(([\\w+]+\\:\\/\\/)?([\\w\\d-]+\\.)*[\\w-]+([\\.\\:]\\w+)*([\\/\\?\\=\\&\\#\\.]?[\\w-]+)*\\/?)$",
+      "type": "String",
+      "required": false
+    },
+    {
+      "name": "wasmpolicyImage",
+      "displayName": "Policy Image",
+      "description": "The OCI image containing the WASM code.",
+      "validationRegex": "^.+$",
+      "type": "String",
+      "required": false
+    },
+    {
+      "name": "imagePullPolicy",
+      "displayName": "Image Pull Policy",
+      "description": "This is the policy to use when pulling the Wasm module by either the HTTP or Image source.",
+      "validationRegex": "^.+$",
+      "type": "Enum",
+      "allowedValues" : ["Always","IfNotPresent"],
+      "required": false
+    },
+    {
+      "name": "wasmConfig",
+      "displayName": "Config",
+      "description": "Configuration for the WASM extension(Must be a valid JSON string).",
+      "validationRegex": "^.+$",
+      "type": "String",
+      "required": false
+    },
+    {
+      "name": "failOpen",
+      "displayName": "FailOpen",
+      "description": "This is a switch used to control the behavior when a fatal error occurs during the initialization or the execution of the Wasm extension.",
+      "validationRegex": "^(true|false)$",
+      "type": "Boolean",
+      "defaultValue": false,
+      "required": false
+    },
+    {
+      "name": "hostKeys",
+      "displayName": "Host Keys",
+      "description": "Includes a comma separated list of keys for environment variables from the host envoy process that should be passed into the Wasm VM.",
+      "validationRegex": "^.+$",
+      "type": "String",
+      "required": false
+    }
+  ],
+  "applicableFlows": [
+    "request",
+    "response"
+  ],
+  "supportedGateways": [
+    "ChoreoConnect"
+  ],
+  "supportedApiTypes": [
+    "HTTP"
+  ]
+}


### PR DESCRIPTION
## Purpose
- This PR adds the changes required for introducing Lua and WASM policies to the APIs deployed into KGW. Also for the OperationPolicyTestCase and ELKAnalyticsWithRespondMediatorTestCase tests, a slight modification was added to the getAllCommonOperationPolicies() method, increasing the limit to prevent test failures happening due to exceeding the fetch limit after adding the new policies.

> Related Issues: 
> - https://github.com/wso2/apk/issues/3180