### PR TITLE
Add preserve_locally_added_claims default value

### DIFF
--- a/all-in-one-apim/modules/distribution/product/src/main/resources/conf/default.json
+++ b/all-in-one-apim/modules/distribution/product/src/main/resources/conf/default.json
@@ -208,6 +208,7 @@
   "identity.entitlement.policy_point.pip.attribute_designators": [
     "org.wso2.carbon.identity.entitlement.pip.DefaultAttributeFinder"
   ],
+  "authentication.jit_provisioning.preserve_locally_added_claims": false,
   "authentication.consent.data_source": "jdbc/WSO2AM_DB",
   "authentication.consent.prompt": false,
   "identity_mgt.user_self_registration.allow_self_registration": true,

--- a/api-control-plane/modules/distribution/product/src/main/resources/conf/default.json
+++ b/api-control-plane/modules/distribution/product/src/main/resources/conf/default.json
@@ -208,6 +208,7 @@
   "identity.entitlement.policy_point.pip.attribute_designators": [
     "org.wso2.carbon.identity.entitlement.pip.DefaultAttributeFinder"
   ],
+  "authentication.jit_provisioning.preserve_locally_added_claims": false,
   "authentication.consent.data_source": "jdbc/WSO2AM_DB",
   "authentication.consent.prompt": false,
   "identity_mgt.user_self_registration.allow_self_registration": true,

--- a/gateway/modules/distribution/product/src/main/resources/conf/default.json
+++ b/gateway/modules/distribution/product/src/main/resources/conf/default.json
@@ -208,6 +208,7 @@
   "identity.entitlement.policy_point.pip.attribute_designators": [
     "org.wso2.carbon.identity.entitlement.pip.DefaultAttributeFinder"
   ],
+  "authentication.jit_provisioning.preserve_locally_added_claims": false,
   "authentication.consent.data_source": "jdbc/WSO2AM_DB",
   "authentication.consent.prompt": false,
   "identity_mgt.user_self_registration.allow_self_registration": true,

--- a/traffic-manager/modules/distribution/product/src/main/resources/conf/default.json
+++ b/traffic-manager/modules/distribution/product/src/main/resources/conf/default.json
@@ -208,6 +208,7 @@
   "identity.entitlement.policy_point.pip.attribute_designators": [
     "org.wso2.carbon.identity.entitlement.pip.DefaultAttributeFinder"
   ],
+  "authentication.jit_provisioning.preserve_locally_added_claims": false,
   "authentication.consent.data_source": "jdbc/WSO2AM_DB",
   "authentication.consent.prompt": false,
   "identity_mgt.user_self_registration.allow_self_registration": true,


### PR DESCRIPTION
## Purpose
Add a configuration option to enable preserving locally added claims.
Set the default value to false to maintain existing behaviour.

## Related issue:
https://github.com/wso2/api-manager/issues/4053