### PR TITLE
Enhance failover configuration handling for load-balanced endpoints

### DIFF
--- a/all-in-one-apim/modules/distribution/product/src/main/resources/conf/infer.json
+++ b/all-in-one-apim/modules/distribution/product/src/main/resources/conf/infer.json
@@ -147,5 +147,13 @@
         "loggedInUser"
       ]
     }
+  },
+  "preserve_previous_product_behaviour.version": {
+    "4.4.0": {
+      "apim.endpoint_config.enable_failover_in_loadbalanced_endpoints": false
+    },
+    "4.5.0": {
+      "apim.endpoint_config.enable_failover_in_loadbalanced_endpoints": false
+    }
   }
 }

--- a/all-in-one-apim/modules/distribution/product/src/main/resources/conf/infer.json
+++ b/all-in-one-apim/modules/distribution/product/src/main/resources/conf/infer.json
@@ -150,10 +150,10 @@
   },
   "preserve_previous_product_behaviour.version": {
     "4.4.0": {
-      "apim.endpoint_config.enable_failover_in_loadbalanced_endpoints": false
+      "apim.endpoint_config.loadbalanced.enable_failover": false
     },
     "4.5.0": {
-      "apim.endpoint_config.enable_failover_in_loadbalanced_endpoints": false
+      "apim.endpoint_config.loadbalanced.enable_failover": false
     }
   }
 }

--- a/all-in-one-apim/modules/distribution/resources/api_templates/endpoint_template.xml
+++ b/all-in-one-apim/modules/distribution/resources/api_templates/endpoint_template.xml
@@ -272,8 +272,14 @@ optimize="$advance_ep.get("optimize")"
 </session>
         #end
 <loadbalance algorithm="$!endpoint_config.get("algoClassName")"
-        #if($endpoint_config.get("failOver") && $endpoint_config.get("failOver") != "" && $endpoint_config.get("failOver") == "False")
-        failover="false"
+        #if($failoverInLoadbalancedEndpoints)
+            #if($endpoint_config.get("failOver") == false)
+            failover="false"
+            #end
+        #else
+            #if($endpoint_config.get("failOver") && $endpoint_config.get("failOver") != "" && $endpoint_config.get("failOver") == "False")
+            failover="false"
+            #end
         #end>
         #set( $i = 0)
         #foreach($endpoint in $endpoints)

--- a/all-in-one-apim/modules/distribution/resources/api_templates/endpoint_template.xml
+++ b/all-in-one-apim/modules/distribution/resources/api_templates/endpoint_template.xml
@@ -272,7 +272,7 @@ optimize="$advance_ep.get("optimize")"
 </session>
         #end
 <loadbalance algorithm="$!endpoint_config.get("algoClassName")"
-        #if($failoverInLoadbalancedEndpoints)
+        #if($enableFailoverInLoadbalancedEndpoints)
             #if($endpoint_config.get("failOver") == false)
             failover="false"
             #end

--- a/api-control-plane/modules/distribution/product/src/main/resources/conf/infer.json
+++ b/api-control-plane/modules/distribution/product/src/main/resources/conf/infer.json
@@ -112,10 +112,10 @@
   },
   "preserve_previous_product_behaviour.version": {
     "4.4.0": {
-      "apim.endpoint_config.enable_failover_in_loadbalanced_endpoints": false
+      "apim.endpoint_config.loadbalanced.enable_failover": false
     },
     "4.5.0": {
-      "apim.endpoint_config.enable_failover_in_loadbalanced_endpoints": false
+      "apim.endpoint_config.loadbalanced.enable_failover": false
     }
   }
 }

--- a/api-control-plane/modules/distribution/product/src/main/resources/conf/infer.json
+++ b/api-control-plane/modules/distribution/product/src/main/resources/conf/infer.json
@@ -109,5 +109,13 @@
         "loggedInUser"
       ]
     }
+  },
+  "preserve_previous_product_behaviour.version": {
+    "4.4.0": {
+      "apim.endpoint_config.enable_failover_in_loadbalanced_endpoints": false
+    },
+    "4.5.0": {
+      "apim.endpoint_config.enable_failover_in_loadbalanced_endpoints": false
+    }
   }
 }

--- a/api-control-plane/modules/distribution/resources/api_templates/endpoint_template.xml
+++ b/api-control-plane/modules/distribution/resources/api_templates/endpoint_template.xml
@@ -272,8 +272,14 @@ optimize="$advance_ep.get("optimize")"
 </session>
         #end
 <loadbalance algorithm="$!endpoint_config.get("algoClassName")"
-        #if($endpoint_config.get("failOver") && $endpoint_config.get("failOver") != "" && $endpoint_config.get("failOver") == "False")
-        failover="false"
+        #if($failoverInLoadbalancedEndpoints)
+            #if($endpoint_config.get("failOver") == false)
+            failover="false"
+            #end
+        #else
+            #if($endpoint_config.get("failOver") && $endpoint_config.get("failOver") != "" && $endpoint_config.get("failOver") == "False")
+            failover="false"
+            #end
         #end>
         #set( $i = 0)
         #foreach($endpoint in $endpoints)

--- a/api-control-plane/modules/distribution/resources/api_templates/endpoint_template.xml
+++ b/api-control-plane/modules/distribution/resources/api_templates/endpoint_template.xml
@@ -272,7 +272,7 @@ optimize="$advance_ep.get("optimize")"
 </session>
         #end
 <loadbalance algorithm="$!endpoint_config.get("algoClassName")"
-        #if($failoverInLoadbalancedEndpoints)
+        #if($enableFailoverInLoadbalancedEndpoints)
             #if($endpoint_config.get("failOver") == false)
             failover="false"
             #end

--- a/gateway/modules/distribution/product/src/main/resources/conf/infer.json
+++ b/gateway/modules/distribution/product/src/main/resources/conf/infer.json
@@ -108,5 +108,13 @@
         "loggedInUser"
       ]
     }
+  },
+  "preserve_previous_product_behaviour.version": {
+    "4.4.0": {
+      "apim.endpoint_config.enable_failover_in_loadbalanced_endpoints": false
+    },
+    "4.5.0": {
+      "apim.endpoint_config.enable_failover_in_loadbalanced_endpoints": false
+    }
   }
 }

--- a/gateway/modules/distribution/product/src/main/resources/conf/infer.json
+++ b/gateway/modules/distribution/product/src/main/resources/conf/infer.json
@@ -111,10 +111,10 @@
   },
   "preserve_previous_product_behaviour.version": {
     "4.4.0": {
-      "apim.endpoint_config.enable_failover_in_loadbalanced_endpoints": false
+      "apim.endpoint_config.loadbalanced.enable_failover": false
     },
     "4.5.0": {
-      "apim.endpoint_config.enable_failover_in_loadbalanced_endpoints": false
+      "apim.endpoint_config.loadbalanced.enable_failover": false
     }
   }
 }

--- a/traffic-manager/modules/distribution/product/src/main/resources/conf/infer.json
+++ b/traffic-manager/modules/distribution/product/src/main/resources/conf/infer.json
@@ -108,5 +108,13 @@
         "loggedInUser"
       ]
     }
+  },
+  "preserve_previous_product_behaviour.version": {
+    "4.4.0": {
+      "apim.endpoint_config.enable_failover_in_loadbalanced_endpoints": false
+    },
+    "4.5.0": {
+      "apim.endpoint_config.enable_failover_in_loadbalanced_endpoints": false
+    }
   }
 }

--- a/traffic-manager/modules/distribution/product/src/main/resources/conf/infer.json
+++ b/traffic-manager/modules/distribution/product/src/main/resources/conf/infer.json
@@ -111,10 +111,10 @@
   },
   "preserve_previous_product_behaviour.version": {
     "4.4.0": {
-      "apim.endpoint_config.enable_failover_in_loadbalanced_endpoints": false
+      "apim.endpoint_config.loadbalanced.enable_failover": false
     },
     "4.5.0": {
-      "apim.endpoint_config.enable_failover_in_loadbalanced_endpoints": false
+      "apim.endpoint_config.loadbalanced.enable_failover": false
     }
   }
 }


### PR DESCRIPTION
## Purpose
* **Added conditional logic** in `endpoint_template.xml` to control the `failover` attribute based on the `failoverInLoadbalancedEndpoints` flag.
* **Updated `infer.json`** to set the default `enable_failover_in_loadbalanced_endpoints` value to `false` for versions **4.4.0** and **4.5.0**, preserving previous product behaviour.
* Fixes: https://github.com/wso2/api-manager/issues/4111
