### PR TITLE
Update apim analytics publisher version

### DIFF
--- a/all-in-one-apim/pom.xml
+++ b/all-in-one-apim/pom.xml
@@ -1313,7 +1313,7 @@
 
         <!--carbon versions-->
         <carbon.kernel.version>4.9.29</carbon.kernel.version>
-        <apimserver.version>4.6.0-SNAPSHOT</apimserver.version>
+        <apimserver.version>${project.version}</apimserver.version>
 
         <cipher.tool.version>1.1.28</cipher.tool.version>
 
@@ -1493,7 +1493,7 @@
         <auth0.keymanager.feature.version>1.0.7</auth0.keymanager.feature.version>
         <pingfederate.keymanager.feature.version>1.0.7</pingfederate.keymanager.feature.version>
         <forgerock.keymanager.feature.version>1.1.8</forgerock.keymanager.feature.version>
-        <apim.analytics.publisher.version>1.2.24</apim.analytics.publisher.version>
+        <apim.analytics.publisher.version>1.2.27</apim.analytics.publisher.version>
         <disruptor.orbit.version>3.4.2.wso2v1</disruptor.orbit.version>
         <wss4j.version>1.6.0-wso2v7</wss4j.version>
         <charon3.version>4.0.23</charon3.version>

--- a/api-control-plane/pom.xml
+++ b/api-control-plane/pom.xml
@@ -1304,7 +1304,7 @@
 
         <!--carbon versions-->
         <carbon.kernel.version>4.9.29</carbon.kernel.version>
-        <apimserver.version>4.6.0-SNAPSHOT</apimserver.version>
+        <apimserver.version>${project.version}</apimserver.version>
 
         <cipher.tool.version>1.1.28</cipher.tool.version>
 
@@ -1484,7 +1484,7 @@
         <auth0.keymanager.feature.version>1.0.7</auth0.keymanager.feature.version>
         <pingfederate.keymanager.feature.version>1.0.7</pingfederate.keymanager.feature.version>
         <forgerock.keymanager.feature.version>1.1.8</forgerock.keymanager.feature.version>
-        <apim.analytics.publisher.version>1.2.24</apim.analytics.publisher.version>
+        <apim.analytics.publisher.version>1.2.27</apim.analytics.publisher.version>
         <disruptor.orbit.version>3.4.2.wso2v1</disruptor.orbit.version>
         <wss4j.version>1.6.0-wso2v7</wss4j.version>
         <charon3.version>4.0.23</charon3.version>

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -1304,7 +1304,7 @@
 
         <!--carbon versions-->
         <carbon.kernel.version>4.9.29</carbon.kernel.version>
-        <apimserver.version>4.6.0-SNAPSHOT</apimserver.version>
+        <apimserver.version>${project.version}</apimserver.version>
 
         <cipher.tool.version>1.1.28</cipher.tool.version>
 
@@ -1484,7 +1484,7 @@
         <auth0.keymanager.feature.version>1.0.7</auth0.keymanager.feature.version>
         <pingfederate.keymanager.feature.version>1.0.7</pingfederate.keymanager.feature.version>
         <forgerock.keymanager.feature.version>1.1.8</forgerock.keymanager.feature.version>
-        <apim.analytics.publisher.version>1.2.24</apim.analytics.publisher.version>
+        <apim.analytics.publisher.version>1.2.27</apim.analytics.publisher.version>
         <disruptor.orbit.version>3.4.2.wso2v1</disruptor.orbit.version>
         <wss4j.version>1.6.0-wso2v7</wss4j.version>
         <charon3.version>4.0.23</charon3.version>

--- a/traffic-manager/pom.xml
+++ b/traffic-manager/pom.xml
@@ -1304,7 +1304,7 @@
 
         <!--carbon versions-->
         <carbon.kernel.version>4.9.29</carbon.kernel.version>
-        <apimserver.version>4.6.0-SNAPSHOT</apimserver.version>
+        <apimserver.version>${project.version}</apimserver.version>
 
         <cipher.tool.version>1.1.28</cipher.tool.version>
 
@@ -1484,7 +1484,7 @@
         <auth0.keymanager.feature.version>1.0.7</auth0.keymanager.feature.version>
         <pingfederate.keymanager.feature.version>1.0.7</pingfederate.keymanager.feature.version>
         <forgerock.keymanager.feature.version>1.1.8</forgerock.keymanager.feature.version>
-        <apim.analytics.publisher.version>1.2.24</apim.analytics.publisher.version>
+        <apim.analytics.publisher.version>1.2.27</apim.analytics.publisher.version>
         <disruptor.orbit.version>3.4.2.wso2v1</disruptor.orbit.version>
         <wss4j.version>1.6.0-wso2v7</wss4j.version>
         <charon3.version>4.0.23</charon3.version>


### PR DESCRIPTION
## Purpose

This pull request updates dependency versions in several Maven `pom.xml` files to ensure consistency and bring in the latest analytics publisher version. The most important changes are grouped below:

Version alignment across modules:

* Updated the `apimserver.version` property to use the current project version (`${project.version}`) instead of a hardcoded snapshot value in `all-in-one-apim/pom.xml`, `api-control-plane/pom.xml`, `gateway/pom.xml`, and `traffic-manager/pom.xml`. [[1]](diffhunk://#diff-37ca04d56dde2c3140a748c4be355ffb64d8a28606157f86fec386404047de9cL1316-R1316) [[2]](diffhunk://#diff-0b0c511abeb022a2cd0f61b646a09a5c9416c96bbaeb567c97fc0034048dc51cL1307-R1307) [[3]](diffhunk://#diff-f0f912d9ca26c50e0e246b37d0f5ad5ec0c258e15e94f837b2458c46c2bfc6adL1307-R1307) [[4]](diffhunk://#diff-685d5c31f7d907e91a20ccc09e906bf31097b0d46a7204f587e2637c8950307dL1307-R1307)

Analytics publisher upgrade:

* Increased the `apim.analytics.publisher.version` from `1.2.24` to `1.2.27` in all affected `pom.xml` files to use the latest release. [[1]](diffhunk://#diff-37ca04d56dde2c3140a748c4be355ffb64d8a28606157f86fec386404047de9cL1496-R1496) [[2]](diffhunk://#diff-0b0c511abeb022a2cd0f61b646a09a5c9416c96bbaeb567c97fc0034048dc51cL1487-R1487) [[3]](diffhunk://#diff-f0f912d9ca26c50e0e246b37d0f5ad5ec0c258e15e94f837b2458c46c2bfc6adL1487-R1487) [[4]](diffhunk://#diff-685d5c31f7d907e91a20ccc09e906bf31097b0d46a7204f587e2637c8950307dL1487-R1487)