### PR TITLE
Upgrade dependencies

### DIFF
--- a/all-in-one-apim/pom.xml
+++ b/all-in-one-apim/pom.xml
@@ -1295,11 +1295,11 @@
         <carbon.analytics.common.version>5.3.27</carbon.analytics.common.version>
 
         <!-- APIM Portals Component Version -->
-        <carbon.apimgt.ui.version>9.3.46</carbon.apimgt.ui.version>
+        <carbon.apimgt.ui.version>9.3.49</carbon.apimgt.ui.version>
 
         <!-- APIM Component Version -->
 
-        <carbon.apimgt.version>9.32.71</carbon.apimgt.version>
+        <carbon.apimgt.version>9.32.75</carbon.apimgt.version>
 
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 
@@ -1514,9 +1514,9 @@
         <identity.branding.preference.management.version>1.0.17</identity.branding.preference.management.version>
 
         <!-- External Gateway Agent Versions -->
-        <aws.gwmanager.feature.version>1.2.1</aws.gwmanager.feature.version>
-        <azure.gwmanager.feature.version>0.2.0</azure.gwmanager.feature.version>
-        <kong.gwmanager.feature.version>0.3.0</kong.gwmanager.feature.version>
+        <aws.gwmanager.feature.version>1.3.0</aws.gwmanager.feature.version>
+        <azure.gwmanager.feature.version>0.3.0</azure.gwmanager.feature.version>
+        <kong.gwmanager.feature.version>0.4.0</kong.gwmanager.feature.version>
 
         <!-- AM Policy Bundle Versions -->
         <regex-guardrail.version>1.0.0</regex-guardrail.version>

--- a/api-control-plane/pom.xml
+++ b/api-control-plane/pom.xml
@@ -1286,11 +1286,11 @@
         <carbon.analytics.common.version>5.3.27</carbon.analytics.common.version>
 
         <!-- APIM Portals Component Version -->
-        <carbon.apimgt.ui.version>9.3.46</carbon.apimgt.ui.version>
+        <carbon.apimgt.ui.version>9.3.49</carbon.apimgt.ui.version>
 
         <!-- APIM Component Version -->
 
-        <carbon.apimgt.version>9.32.71</carbon.apimgt.version>
+        <carbon.apimgt.version>9.32.75</carbon.apimgt.version>
 
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 
@@ -1505,9 +1505,9 @@
         <identity.branding.preference.management.version>1.0.17</identity.branding.preference.management.version>
 
         <!-- External Gateway Agent Versions -->
-        <aws.gwmanager.feature.version>1.2.1</aws.gwmanager.feature.version>
-        <azure.gwmanager.feature.version>0.2.0</azure.gwmanager.feature.version>
-        <kong.gwmanager.feature.version>0.3.0</kong.gwmanager.feature.version>
+        <aws.gwmanager.feature.version>1.3.0</aws.gwmanager.feature.version>
+        <azure.gwmanager.feature.version>0.3.0</azure.gwmanager.feature.version>
+        <kong.gwmanager.feature.version>0.4.0</kong.gwmanager.feature.version>
 
         <!-- AM Policy Bundle Versions -->
         <regex-guardrail.version>1.0.0</regex-guardrail.version>

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -1286,11 +1286,11 @@
         <carbon.analytics.common.version>5.3.27</carbon.analytics.common.version>
 
         <!-- APIM Portals Component Version -->
-        <carbon.apimgt.ui.version>9.3.46</carbon.apimgt.ui.version>
+        <carbon.apimgt.ui.version>9.3.49</carbon.apimgt.ui.version>
 
         <!-- APIM Component Version -->
 
-        <carbon.apimgt.version>9.32.71</carbon.apimgt.version>
+        <carbon.apimgt.version>9.32.75</carbon.apimgt.version>
 
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 

--- a/traffic-manager/pom.xml
+++ b/traffic-manager/pom.xml
@@ -1286,11 +1286,11 @@
         <carbon.analytics.common.version>5.3.27</carbon.analytics.common.version>
 
         <!-- APIM Portals Component Version -->
-        <carbon.apimgt.ui.version>9.3.46</carbon.apimgt.ui.version>
+        <carbon.apimgt.ui.version>9.3.49</carbon.apimgt.ui.version>
 
         <!-- APIM Component Version -->
 
-        <carbon.apimgt.version>9.32.71</carbon.apimgt.version>
+        <carbon.apimgt.version>9.32.75</carbon.apimgt.version>
 
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 


### PR DESCRIPTION
## Purpose

This pull request updates several dependency versions across multiple Maven project files to ensure the codebase uses the latest releases for APIM components and external gateway agents. These updates help maintain compatibility, security, and access to new features.

**APIM component and UI version updates:**

* Upgraded `carbon.apimgt.ui.version` to `9.3.49` and `carbon.apimgt.version` to `9.32.75` in `all-in-one-apim/pom.xml`, `api-control-plane/pom.xml`, `gateway/pom.xml`, and `traffic-manager/pom.xml`. [[1]](diffhunk://#diff-37ca04d56dde2c3140a748c4be355ffb64d8a28606157f86fec386404047de9cL1298-R1302) [[2]](diffhunk://#diff-0b0c511abeb022a2cd0f61b646a09a5c9416c96bbaeb567c97fc0034048dc51cL1289-R1293) [[3]](diffhunk://#diff-f0f912d9ca26c50e0e246b37d0f5ad5ec0c258e15e94f837b2458c46c2bfc6adL1289-R1293) [[4]](diffhunk://#diff-685d5c31f7d907e91a20ccc09e906bf31097b0d46a7204f587e2637c8950307dL1289-R1293)

**External gateway agent version updates:**

* Updated `aws.gwmanager.feature.version` to `1.3.0`, `azure.gwmanager.feature.version` to `0.3.0`, and `kong.gwmanager.feature.version` to `0.4.0` in `all-in-one-apim/pom.xml` and `api-control-plane/pom.xml`. [[1]](diffhunk://#diff-37ca04d56dde2c3140a748c4be355ffb64d8a28606157f86fec386404047de9cL1517-R1519) [[2]](diffhunk://#diff-0b0c511abeb022a2cd0f61b646a09a5c9416c96bbaeb567c97fc0034048dc51cL1508-R1510)