### PR TITLE
Remove apimserver.version from POM

### DIFF
--- a/all-in-one-apim/modules/integration/tests-integration/tests-backend/pom.xml
+++ b/all-in-one-apim/modules/integration/tests-integration/tests-backend/pom.xml
@@ -129,7 +129,7 @@ under the License.
                                 <sec.verifier.dir>${basedir}/target/security-verifier/</sec.verifier.dir>
                                 <instr.file>${basedir}/src/test/resources/instrumentation.txt</instr.file>
                                 <filters.file>${basedir}/src/test/resources/filters.txt</filters.file>
-                                <apim.server.version>${apimserver.version}</apim.server.version>
+                                <apim.server.version>${project.version}</apim.server.version>
                                 <startupScript>api-manager</startupScript>
                             </systemProperties>
                             <skipTests>${skipIntegrationTests}</skipTests>
@@ -247,7 +247,7 @@ under the License.
                                 <instr.file>${basedir}/src/test/resources/instrumentation.txt</instr.file>
                                 <filters.file>${basedir}/src/test/resources/filters.txt</filters.file>
                                 <startupScript>api-manager</startupScript>
-                                <apim.server.version>${apimserver.version}</apim.server.version>
+                                <apim.server.version>${project.version}</apim.server.version>
                             </systemProperties>
                             <workingDirectory>${basedir}/target</workingDirectory>
                             <classpathDependencyExcludes>

--- a/all-in-one-apim/modules/integration/tests-integration/tests-benchmark/pom.xml
+++ b/all-in-one-apim/modules/integration/tests-integration/tests-benchmark/pom.xml
@@ -111,7 +111,7 @@ under the License.
                                 <sec.verifier.dir>${basedir}/target/security-verifier/</sec.verifier.dir>
                                 <instr.file>${basedir}/src/test/resources/instrumentation.txt</instr.file>
                                 <filters.file>${basedir}/src/test/resources/filters.txt</filters.file>
-                                <apim.server.version>${apimserver.version}</apim.server.version>
+                                <apim.server.version>${project.version}</apim.server.version>
                                 <startupScript>api-manager</startupScript>
                             </systemProperties>
                             <skipTests>${skipBenchMarkTest}</skipTests>
@@ -249,7 +249,7 @@ under the License.
                                 <instr.file>${basedir}/src/test/resources/instrumentation.txt</instr.file>
                                 <filters.file>${basedir}/src/test/resources/filters.txt</filters.file>
                                 <startupScript>api-manager</startupScript>
-                                <apim.server.version>${apimserver.version}</apim.server.version>
+                                <apim.server.version>${project.version}</apim.server.version>
                             </systemProperties>
                             <skipTests>${skipBenchMarkTest}</skipTests>
                             <workingDirectory>${basedir}/target</workingDirectory>

--- a/all-in-one-apim/modules/integration/tests-integration/tests-restart/pom.xml
+++ b/all-in-one-apim/modules/integration/tests-integration/tests-restart/pom.xml
@@ -129,7 +129,7 @@ under the License.
                                 <sec.verifier.dir>${basedir}/target/security-verifier/</sec.verifier.dir>
                                 <instr.file>${basedir}/src/test/resources/instrumentation.txt</instr.file>
                                 <filters.file>${basedir}/src/test/resources/filters.txt</filters.file>
-                                <apim.server.version>${apimserver.version}</apim.server.version>
+                                <apim.server.version>${project.version}</apim.server.version>
                                 <startupScript>api-manager</startupScript>
                             </systemProperties>
                             <skipTests>${skipRestartTests}</skipTests>
@@ -246,7 +246,7 @@ under the License.
                                 <instr.file>${basedir}/src/test/resources/instrumentation.txt</instr.file>
                                 <filters.file>${basedir}/src/test/resources/filters.txt</filters.file>
                                 <startupScript>api-manager</startupScript>
-                                <apim.server.version>${apimserver.version}</apim.server.version>
+                                <apim.server.version>${project.version}</apim.server.version>
                             </systemProperties>
                             <workingDirectory>${basedir}/target</workingDirectory>
                             <classpathDependencyExcludes>

--- a/all-in-one-apim/modules/p2-profile/product/pom.xml
+++ b/all-in-one-apim/modules/p2-profile/product/pom.xml
@@ -252,7 +252,7 @@
                                     org.wso2.carbon.mediation:org.wso2.carbon.mediators.server.feature:${carbon.mediation.version}
                                 </featureArtifactDef>
                    
-                                <featureArtifactDef>org.wso2.am:org.wso2.am.styles.feature:${apimserver.version}
+                                <featureArtifactDef>org.wso2.am:org.wso2.am.styles.feature:${project.version}
                                 </featureArtifactDef>
                                 <featureArtifactDef>
                                     org.wso2.carbon.mediation:org.wso2.carbon.relay.feature:${carbon.mediation.version}
@@ -296,13 +296,13 @@
                                     org.wso2.carbon.apimgt:org.wso2.carbon.apimgt.internal.service.feature:${carbon.apimgt.version}
                                 </featureArtifactDef>
                                 <featureArtifactDef>
-                                    org.wso2.am:org.wso2.am.multitenancy.dashboard.ui.feature:${apimserver.version}
+                                    org.wso2.am:org.wso2.am.multitenancy.dashboard.ui.feature:${project.version}
                                 </featureArtifactDef>
                                 <featureArtifactDef>
-                                    org.wso2.am:org.wso2.am.security.feature:${apimserver.version}
+                                    org.wso2.am:org.wso2.am.security.feature:${project.version}
                                 </featureArtifactDef>
                                 <featureArtifactDef>
-                                    org.wso2.am:org.wso2.carbon.identity.local.auth.api.endpoint.feature:${apimserver.version}
+                                    org.wso2.am:org.wso2.carbon.identity.local.auth.api.endpoint.feature:${project.version}
                                 </featureArtifactDef>
 
                                 <featureArtifactDef>
@@ -705,7 +705,7 @@
 
                                 <!-- AM Policies Feature -->
                                 <featureArtifactDef>
-                                    org.wso2.am:org.wso2.am.policies.feature:${apimserver.version}
+                                    org.wso2.am:org.wso2.am.policies.feature:${project.version}
                                 </featureArtifactDef>
                             </featureArtifacts>
                         </configuration>
@@ -1066,7 +1066,7 @@
                                 </feature>
                                 <feature>
                                     <id>org.wso2.carbon.identity.local.auth.api.endpoint.feature.group</id>
-                                    <version>${apimserver.version}</version>
+                                    <version>${project.version}</version>
                                 </feature>
 
                                 <feature>
@@ -1097,16 +1097,16 @@
                                 </feature>
                                 <feature>
                                     <id>org.wso2.am.styles.feature.group</id>
-                                    <version>${apimserver.version}</version>
+                                    <version>${project.version}</version>
                                 </feature>
                                 
                                 <feature>
                                     <id>org.wso2.am.multitenancy.dashboard.ui.feature.group</id>
-                                    <version>${apimserver.version}</version>
+                                    <version>${project.version}</version>
                                 </feature>
                                 <feature>
                                     <id>org.wso2.am.security.feature.group</id>
-                                    <version>${apimserver.version}</version>
+                                    <version>${project.version}</version>
                                 </feature>
                                 <feature>
                                     <id>org.wso2.carbon.event.server.feature.group</id>
@@ -1511,7 +1511,7 @@
                                 </feature>
                                 <feature>
                                     <id>org.wso2.am.security.feature.group</id>
-                                    <version>${apimserver.version}</version>
+                                    <version>${project.version}</version>
                                 </feature>
                                 <feature>
                                     <id>org.wso2.carbon.identity.user.functionality.mgt.feature.group</id>
@@ -1571,7 +1571,7 @@
                                 <!-- AM Policy Feature -->
                                 <feature>
                                     <id>org.wso2.am.policies.feature.group</id>
-                                    <version>${apimserver.version}</version>
+                                    <version>${project.version}</version>
                                 </feature>
                             </features>
                         </configuration>
@@ -1767,7 +1767,7 @@
                                 </feature>
                                 <feature>
                                     <id>org.wso2.carbon.identity.local.auth.api.endpoint.feature.group</id>
-                                    <version>${apimserver.version}</version>
+                                    <version>${project.version}</version>
                                 </feature>
 
                                 <feature>
@@ -1790,12 +1790,12 @@
 
                                 <feature>
                                     <id>org.wso2.am.styles.feature.group</id>
-                                    <version>${apimserver.version}</version>
+                                    <version>${project.version}</version>
                                 </feature>
 
                                 <feature>
                                     <id>org.wso2.am.multitenancy.dashboard.ui.feature.group</id>
-                                    <version>${apimserver.version}</version>
+                                    <version>${project.version}</version>
                                 </feature>
                                 <feature>
                                     <id>org.wso2.carbon.event.server.feature.group</id>
@@ -2167,7 +2167,7 @@
                                 </feature>
                                 <feature>
                                     <id>org.wso2.am.security.feature.group</id>
-                                    <version>${apimserver.version}</version>
+                                    <version>${project.version}</version>
                                 </feature>
                                 <feature>
                                     <id>org.wso2.carbon.identity.user.functionality.mgt.feature.group</id>
@@ -2403,11 +2403,11 @@
                                 </feature>
                                 <feature>
                                     <id>org.wso2.am.styles.feature.group</id>
-                                    <version>${apimserver.version}</version>
+                                    <version>${project.version}</version>
                                 </feature>
                                 <feature>
                                     <id>org.wso2.am.multitenancy.dashboard.ui.feature.group</id>
-                                    <version>${apimserver.version}</version>
+                                    <version>${project.version}</version>
                                 </feature>
                                 <feature>
                                     <id>org.wso2.carbon.event.server.feature.group</id>
@@ -2660,7 +2660,7 @@
                                 </feature>
                                 <feature>
                                     <id>org.wso2.am.security.feature.group</id>
-                                    <version>${apimserver.version}</version>
+                                    <version>${project.version}</version>
                                 </feature>
                                 <feature>
                                     <id>org.wso2.carbon.system.statistics.server.feature.group</id>
@@ -2910,11 +2910,11 @@
                                 </feature>
                                 <feature>
                                     <id>org.wso2.am.styles.feature.group</id>
-                                    <version>${apimserver.version}</version>
+                                    <version>${project.version}</version>
                                 </feature>
                                 <feature>
                                     <id>org.wso2.am.multitenancy.dashboard.ui.feature.group</id>
-                                    <version>${apimserver.version}</version>
+                                    <version>${project.version}</version>
                                 </feature>
                                 <feature>
                                     <id>org.wso2.carbon.event.server.feature.group</id>
@@ -3199,7 +3199,7 @@
                                 </feature>
                                 <feature>
                                     <id>org.wso2.am.security.feature.group</id>
-                                    <version>${apimserver.version}</version>
+                                    <version>${project.version}</version>
                                 </feature>
                                 <feature>
                                     <id>org.wso2.carbon.identity.user.functionality.mgt.feature.group</id>
@@ -3407,11 +3407,11 @@
                               
                                 <feature>
                                     <id>org.wso2.am.styles.feature.group</id>
-                                    <version>${apimserver.version}</version>
+                                    <version>${project.version}</version>
                                 </feature>
                                 <feature>
                                     <id>org.wso2.am.multitenancy.dashboard.ui.feature.group</id>
-                                    <version>${apimserver.version}</version>
+                                    <version>${project.version}</version>
                                 </feature>
                                 <feature>
                                     <id>org.wso2.carbon.event.server.feature.group</id>
@@ -3697,7 +3697,7 @@
                                 </feature>
                                 <feature>
                                     <id>org.wso2.am.security.feature.group</id>
-                                    <version>${apimserver.version}</version>
+                                    <version>${project.version}</version>
                                 </feature>
                                 <feature>
                                     <id>org.wso2.carbon.identity.user.functionality.mgt.feature.group</id>
@@ -3958,7 +3958,7 @@
                                 </feature>
                                 <feature>
                                     <id>org.wso2.am.styles.feature.group</id>
-                                    <version>${apimserver.version}</version>
+                                    <version>${project.version}</version>
                                 </feature>
                                 <feature>
                                     <id>org.wso2.carbon.identity.provider.server.feature.group</id>
@@ -3966,7 +3966,7 @@
                                 </feature>
                                 <feature>
                                     <id>org.wso2.am.multitenancy.dashboard.ui.feature.group</id>
-                                    <version>${apimserver.version}</version>
+                                    <version>${project.version}</version>
                                 </feature>
                                 <feature>
                                     <id>org.wso2.carbon.event.server.feature.group</id>
@@ -4174,7 +4174,7 @@
                                 </feature>
                                 <feature>
                                     <id>org.wso2.am.security.feature.group</id>
-                                    <version>${apimserver.version}</version>
+                                    <version>${project.version}</version>
                                 </feature>
                                 <feature>
                                     <id>org.wso2.carbon.identity.user.functionality.mgt.feature.group</id>
@@ -4442,7 +4442,7 @@
 
                                 <feature>
                                     <id>org.wso2.am.styles.feature.group</id>
-                                    <version>${apimserver.version}</version>
+                                    <version>${project.version}</version>
                                 </feature>
                                 <feature>
                                     <id>org.wso2.carbon.event.receiver.feature.group</id>
@@ -4535,7 +4535,7 @@
                                 </feature>
                                 <feature>
                                     <id>org.wso2.am.security.feature.group</id>
-                                    <version>${apimserver.version}</version>
+                                    <version>${project.version}</version>
                                 </feature>
                                 <feature>
                                     <id>org.wso2.carbon.identity.user.functionality.mgt.feature.group</id>

--- a/all-in-one-apim/pom.xml
+++ b/all-in-one-apim/pom.xml
@@ -359,12 +359,12 @@
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.am.styles</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.am.thirdparty.km</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.h2database.wso2</groupId>
@@ -518,12 +518,12 @@
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.am.multitenancy.dashboard.ui</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.am.security.feature</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
 
             <!--Test framework dependencies -->
@@ -565,17 +565,17 @@
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.am.integration.admin.clients</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.am.integration.common.test.utils</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.am.integration.test.extensions</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
@@ -831,7 +831,7 @@
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.stratos.apimgt.login.ui</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
@@ -961,42 +961,42 @@
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.carbon.apimgt.clients.publisher.api</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.carbon.apimgt.clients.store.api</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.carbon.apimgt.clients.admin.api</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.am.integration.clients.gateway.api</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.am.integration.clients.service.catalog.api</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.am.integration.clients.internal.api</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.am.integration.clients.governance.api</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.carbon.apimgt.samples.utils</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.swagger</groupId>
@@ -1234,7 +1234,7 @@
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.am.integration.clients.publisher.api</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.am</groupId>
@@ -1313,7 +1313,6 @@
 
         <!--carbon versions-->
         <carbon.kernel.version>4.9.29</carbon.kernel.version>
-        <apimserver.version>${project.version}</apimserver.version>
 
         <cipher.tool.version>1.1.28</cipher.tool.version>
 

--- a/api-control-plane/modules/features/product/org.wso2.am.multitenancy.dashboard.ui.feature/pom.xml
+++ b/api-control-plane/modules/features/product/org.wso2.am.multitenancy.dashboard.ui.feature/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>org.wso2.am.acp</groupId>
             <artifactId>org.wso2.am.acp.multitenancy.dashboard.ui</artifactId>
-            <version>${apimserver.version}</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon</groupId>

--- a/api-control-plane/modules/features/product/org.wso2.am.styles.feature/pom.xml
+++ b/api-control-plane/modules/features/product/org.wso2.am.styles.feature/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>org.wso2.am.acp</groupId>
             <artifactId>org.wso2.am.acp.styles</artifactId>
-            <version>${apimserver.version}</version>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 

--- a/api-control-plane/modules/p2-profile/product/pom.xml
+++ b/api-control-plane/modules/p2-profile/product/pom.xml
@@ -249,7 +249,7 @@
                                 <featureArtifactDef>
                                     org.wso2.carbon.mediation:org.wso2.carbon.mediation.configadmin.server.feature:${carbon.mediation.version}
                                 </featureArtifactDef>
-                                <featureArtifactDef>org.wso2.am.acp:org.wso2.am.acp.styles.feature:${apimserver.version}
+                                <featureArtifactDef>org.wso2.am.acp:org.wso2.am.acp.styles.feature:${project.version}
                                 </featureArtifactDef>
                                 <featureArtifactDef>
                                     org.wso2.carbon.mediation:org.wso2.carbon.relay.feature:${carbon.mediation.version}
@@ -283,13 +283,13 @@
                                     org.wso2.carbon.apimgt:org.wso2.carbon.apimgt.internal.service.feature:${carbon.apimgt.version}
                                 </featureArtifactDef>
                                 <featureArtifactDef>
-                                    org.wso2.am.acp:org.wso2.am.acp.multitenancy.dashboard.ui.feature:${apimserver.version}
+                                    org.wso2.am.acp:org.wso2.am.acp.multitenancy.dashboard.ui.feature:${project.version}
                                 </featureArtifactDef>
                                 <featureArtifactDef>
-                                    org.wso2.am.acp:org.wso2.am.acp.security.feature:${apimserver.version}
+                                    org.wso2.am.acp:org.wso2.am.acp.security.feature:${project.version}
                                 </featureArtifactDef>
                                 <featureArtifactDef>
-                                    org.wso2.am.acp:org.wso2.am.acp.carbon.identity.local.auth.api.endpoint.feature:${apimserver.version}
+                                    org.wso2.am.acp:org.wso2.am.acp.carbon.identity.local.auth.api.endpoint.feature:${project.version}
                                 </featureArtifactDef>
 
                                 <featureArtifactDef>
@@ -918,7 +918,7 @@
                                 </feature>
                                 <feature>
                                     <id>org.wso2.am.acp.carbon.identity.local.auth.api.endpoint.feature.group</id>
-                                    <version>${apimserver.version}</version>
+                                    <version>${project.version}</version>
                                 </feature>
 
                                 <feature>
@@ -943,11 +943,11 @@
                                 </feature>
                                 <feature>
                                     <id>org.wso2.am.acp.styles.feature.group</id>
-                                    <version>${apimserver.version}</version>
+                                    <version>${project.version}</version>
                                 </feature>
                                 <feature>
                                     <id>org.wso2.am.acp.multitenancy.dashboard.ui.feature.group</id>
-                                    <version>${apimserver.version}</version>
+                                    <version>${project.version}</version>
                                 </feature>
                                 <feature>
                                     <id>org.wso2.carbon.event.server.feature.group</id>
@@ -1313,7 +1313,7 @@
                                 </feature>
                                 <feature>
                                     <id>org.wso2.am.acp.security.feature.group</id>
-                                    <version>${apimserver.version}</version>
+                                    <version>${project.version}</version>
                                 </feature>
                                 <feature>
                                     <id>org.wso2.carbon.identity.user.functionality.mgt.feature.group</id>

--- a/api-control-plane/pom.xml
+++ b/api-control-plane/pom.xml
@@ -355,12 +355,12 @@
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.am.styles</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.am.thirdparty.km</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.h2database.wso2</groupId>
@@ -514,12 +514,12 @@
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.am.multitenancy.dashboard.ui</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.am.security.feature</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
 
             <!--Test framework dependencies -->
@@ -561,17 +561,17 @@
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.am.integration.admin.clients</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.am.integration.common.test.utils</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.am.integration.test.extensions</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
@@ -827,7 +827,7 @@
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.stratos.apimgt.login.ui</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
@@ -957,37 +957,37 @@
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.carbon.apimgt.clients.publisher.api</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.carbon.apimgt.clients.store.api</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.carbon.apimgt.clients.admin.api</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.am.integration.clients.gateway.api</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.am.integration.clients.service.catalog.api</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.am.integration.clients.internal.api</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.carbon.apimgt.samples.utils</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.swagger</groupId>
@@ -1225,7 +1225,7 @@
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.am.integration.clients.publisher.api</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.am</groupId>
@@ -1304,7 +1304,6 @@
 
         <!--carbon versions-->
         <carbon.kernel.version>4.9.29</carbon.kernel.version>
-        <apimserver.version>${project.version}</apimserver.version>
 
         <cipher.tool.version>1.1.28</cipher.tool.version>
 

--- a/gateway/modules/features/product/org.wso2.am.multitenancy.dashboard.ui.feature/pom.xml
+++ b/gateway/modules/features/product/org.wso2.am.multitenancy.dashboard.ui.feature/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>org.wso2.am.gw</groupId>
             <artifactId>org.wso2.am.gw.multitenancy.dashboard.ui</artifactId>
-            <version>${apimserver.version}</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon</groupId>

--- a/gateway/modules/features/product/org.wso2.am.styles.feature/pom.xml
+++ b/gateway/modules/features/product/org.wso2.am.styles.feature/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>org.wso2.am.gw</groupId>
             <artifactId>org.wso2.am.gw.styles</artifactId>
-            <version>${apimserver.version}</version>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 

--- a/gateway/modules/p2-profile/product/pom.xml
+++ b/gateway/modules/p2-profile/product/pom.xml
@@ -273,7 +273,7 @@
                                     org.wso2.carbon.mediation:org.wso2.carbon.mediators.server.feature:${carbon.mediation.version}
                                 </featureArtifactDef>
 
-                                <featureArtifactDef>org.wso2.am.gw:org.wso2.am.gw.styles.feature:${apimserver.version}
+                                <featureArtifactDef>org.wso2.am.gw:org.wso2.am.gw.styles.feature:${project.version}
                                 </featureArtifactDef>
                                 <featureArtifactDef>
                                     org.wso2.carbon.apimgt:org.wso2.carbon.apimgt.rest.api.gateway.feature:${carbon.apimgt.version}
@@ -314,13 +314,13 @@
                                     org.wso2.carbon.apimgt:org.wso2.carbon.apimgt.internal.service.feature:${carbon.apimgt.version}
                                 </featureArtifactDef>
                                 <featureArtifactDef>
-                                    org.wso2.am.gw:org.wso2.am.gw.multitenancy.dashboard.ui.feature:${apimserver.version}
+                                    org.wso2.am.gw:org.wso2.am.gw.multitenancy.dashboard.ui.feature:${project.version}
                                 </featureArtifactDef>
                                 <featureArtifactDef>
-                                    org.wso2.am.gw:org.wso2.am.gw.security.feature:${apimserver.version}
+                                    org.wso2.am.gw:org.wso2.am.gw.security.feature:${project.version}
                                 </featureArtifactDef>
                                 <featureArtifactDef>
-                                    org.wso2.am.gw:org.wso2.am.gw.carbon.identity.local.auth.api.endpoint.feature:${apimserver.version}
+                                    org.wso2.am.gw:org.wso2.am.gw.carbon.identity.local.auth.api.endpoint.feature:${project.version}
                                 </featureArtifactDef>
 
                                 <featureArtifactDef>
@@ -702,7 +702,7 @@
 
                                 <!-- AM Policies Feature -->
                                 <featureArtifactDef>
-                                    org.wso2.am.gw:org.wso2.am.gw.policies.feature:${apimserver.version}
+                                    org.wso2.am.gw:org.wso2.am.gw.policies.feature:${project.version}
                                 </featureArtifactDef>
                             </featureArtifacts>
                         </configuration>
@@ -950,11 +950,11 @@
                                 </feature>
                                 <feature>
                                     <id>org.wso2.am.gw.styles.feature.group</id>
-                                    <version>${apimserver.version}</version>
+                                    <version>${project.version}</version>
                                 </feature>
                                 <feature>
                                     <id>org.wso2.am.gw.multitenancy.dashboard.ui.feature.group</id>
-                                    <version>${apimserver.version}</version>
+                                    <version>${project.version}</version>
                                 </feature>
                                 <feature>
                                     <id>org.wso2.carbon.event.server.feature.group</id>
@@ -1202,7 +1202,7 @@
                                 </feature>
                                 <feature>
                                     <id>org.wso2.am.gw.security.feature.group</id>
-                                    <version>${apimserver.version}</version>
+                                    <version>${project.version}</version>
                                 </feature>
                                 <feature>
                                     <id>org.wso2.carbon.identity.user.functionality.mgt.feature.group</id>
@@ -1261,7 +1261,7 @@
                                 <!-- AM Policy Feature -->
                                 <feature>
                                     <id>org.wso2.am.gw.policies.feature.group</id>
-                                    <version>${apimserver.version}</version>
+                                    <version>${project.version}</version>
                                 </feature>
                             </features>
                         </configuration>

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -355,12 +355,12 @@
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.am.styles</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.am.thirdparty.km</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.h2database.wso2</groupId>
@@ -514,12 +514,12 @@
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.am.multitenancy.dashboard.ui</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.am.security.feature</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
 
             <!--Test framework dependencies -->
@@ -561,17 +561,17 @@
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.am.integration.admin.clients</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.am.integration.common.test.utils</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.am.integration.test.extensions</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
@@ -827,7 +827,7 @@
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.stratos.apimgt.login.ui</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
@@ -957,37 +957,37 @@
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.carbon.apimgt.clients.publisher.api</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.carbon.apimgt.clients.store.api</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.carbon.apimgt.clients.admin.api</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.am.integration.clients.gateway.api</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.am.integration.clients.service.catalog.api</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.am.integration.clients.internal.api</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.carbon.apimgt.samples.utils</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.swagger</groupId>
@@ -1225,7 +1225,7 @@
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.am.integration.clients.publisher.api</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.am</groupId>
@@ -1304,7 +1304,6 @@
 
         <!--carbon versions-->
         <carbon.kernel.version>4.9.29</carbon.kernel.version>
-        <apimserver.version>${project.version}</apimserver.version>
 
         <cipher.tool.version>1.1.28</cipher.tool.version>
 

--- a/traffic-manager/modules/features/product/org.wso2.am.multitenancy.dashboard.ui.feature/pom.xml
+++ b/traffic-manager/modules/features/product/org.wso2.am.multitenancy.dashboard.ui.feature/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>org.wso2.am.tm</groupId>
             <artifactId>org.wso2.am.tm.multitenancy.dashboard.ui</artifactId>
-            <version>${apimserver.version}</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon</groupId>

--- a/traffic-manager/modules/features/product/org.wso2.am.styles.feature/pom.xml
+++ b/traffic-manager/modules/features/product/org.wso2.am.styles.feature/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>org.wso2.am.tm</groupId>
             <artifactId>org.wso2.am.tm.styles</artifactId>
-            <version>${apimserver.version}</version>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 

--- a/traffic-manager/modules/p2-profile/product/pom.xml
+++ b/traffic-manager/modules/p2-profile/product/pom.xml
@@ -293,7 +293,7 @@
                                     org.wso2.carbon.mediation:org.wso2.carbon.mediators.server.feature:${carbon.mediation.version}
                                 </featureArtifactDef>
 
-                                <featureArtifactDef>org.wso2.am.tm:org.wso2.am.tm.styles.feature:${apimserver.version}
+                                <featureArtifactDef>org.wso2.am.tm:org.wso2.am.tm.styles.feature:${project.version}
                                 </featureArtifactDef>
                                 <featureArtifactDef>
                                     org.wso2.carbon.mediation:org.wso2.carbon.relay.feature:${carbon.mediation.version}
@@ -337,13 +337,13 @@
                                     org.wso2.carbon.apimgt:org.wso2.carbon.apimgt.internal.service.feature:${carbon.apimgt.version}
                                 </featureArtifactDef>
                                 <featureArtifactDef>
-                                    org.wso2.am.tm:org.wso2.am.tm.multitenancy.dashboard.ui.feature:${apimserver.version}
+                                    org.wso2.am.tm:org.wso2.am.tm.multitenancy.dashboard.ui.feature:${project.version}
                                 </featureArtifactDef>
                                 <featureArtifactDef>
-                                    org.wso2.am.tm:org.wso2.am.tm.security.feature:${apimserver.version}
+                                    org.wso2.am.tm:org.wso2.am.tm.security.feature:${project.version}
                                 </featureArtifactDef>
                                 <featureArtifactDef>
-                                    org.wso2.am.tm:org.wso2.am.tm.carbon.identity.local.auth.api.endpoint.feature:${apimserver.version}
+                                    org.wso2.am.tm:org.wso2.am.tm.carbon.identity.local.auth.api.endpoint.feature:${project.version}
                                 </featureArtifactDef>
 
                                 <featureArtifactDef>
@@ -993,7 +993,7 @@
 
                                 <feature>
                                     <id>org.wso2.am.tm.styles.feature.group</id>
-                                    <version>${apimserver.version}</version>
+                                    <version>${project.version}</version>
                                 </feature>
                                 <feature>
                                     <id>org.wso2.carbon.event.receiver.feature.group</id>
@@ -1090,7 +1090,7 @@
                                 </feature>
                                 <feature>
                                     <id>org.wso2.am.tm.security.feature.group</id>
-                                    <version>${apimserver.version}</version>
+                                    <version>${project.version}</version>
                                 </feature>
                                 <feature>
                                     <id>org.wso2.carbon.identity.user.functionality.mgt.feature.group</id>

--- a/traffic-manager/pom.xml
+++ b/traffic-manager/pom.xml
@@ -355,12 +355,12 @@
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.am.styles</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.am.thirdparty.km</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.h2database.wso2</groupId>
@@ -514,12 +514,12 @@
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.am.multitenancy.dashboard.ui</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.am.security.feature</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
 
             <!--Test framework dependencies -->
@@ -561,17 +561,17 @@
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.am.integration.admin.clients</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.am.integration.common.test.utils</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.am.integration.test.extensions</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
@@ -827,7 +827,7 @@
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.stratos.apimgt.login.ui</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
@@ -957,37 +957,37 @@
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.carbon.apimgt.clients.publisher.api</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.carbon.apimgt.clients.store.api</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.carbon.apimgt.clients.admin.api</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.am.integration.clients.gateway.api</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.am.integration.clients.service.catalog.api</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.am.integration.clients.internal.api</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.carbon.apimgt.samples.utils</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.swagger</groupId>
@@ -1225,7 +1225,7 @@
             <dependency>
                 <groupId>org.wso2.am</groupId>
                 <artifactId>org.wso2.am.integration.clients.publisher.api</artifactId>
-                <version>${apimserver.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.am</groupId>
@@ -1304,7 +1304,6 @@
 
         <!--carbon versions-->
         <carbon.kernel.version>4.9.29</carbon.kernel.version>
-        <apimserver.version>${project.version}</apimserver.version>
 
         <cipher.tool.version>1.1.28</cipher.tool.version>
 


### PR DESCRIPTION
## Purpose

This pull request updates several Maven configuration files to use the `${project.version}` property instead of the previously used `${apimserver.version}` property.

Version property updates for integration test modules:

* Updated the `apim.server.version` property from `${apimserver.version}` to `${project.version}` in system properties for backend, benchmark, and restart integration test modules (`tests-backend/pom.xml`, `tests-benchmark/pom.xml`, `tests-restart/pom.xml`). [[1]](diffhunk://#diff-1457299dd07af25a49ee6333197653f88c2de09ed5497ed7fead0b39a4e89012L132-R132) [[2]](diffhunk://#diff-1457299dd07af25a49ee6333197653f88c2de09ed5497ed7fead0b39a4e89012L250-R250) [[3]](diffhunk://#diff-00d0f43aeac38f114110a4071097bf582e659d4ff00197cc5766fda71a266a78L114-R114) [[4]](diffhunk://#diff-00d0f43aeac38f114110a4071097bf582e659d4ff00197cc5766fda71a266a78L252-R252) [[5]](diffhunk://#diff-e0f348a0b4ee865860447e3fb65a781e0d782e8671d5f2bbf1e459415b31028aL132-R132) [[6]](diffhunk://#diff-e0f348a0b4ee865860447e3fb65a781e0d782e8671d5f2bbf1e459415b31028aL249-R249)

Version property updates for product profile features:

* Changed feature artifact definitions and feature group versions from `${apimserver.version}` to `${project.version}` in `product/pom.xml` for all relevant features (styles, multitenancy dashboard UI, security, policies, and local auth API endpoint). [[1]](diffhunk://#diff-3e1233f680c43c66ef693a8af0e83fd4b9563795399cb46507370722bcc4b892L255-R255) [[2]](diffhunk://#diff-3e1233f680c43c66ef693a8af0e83fd4b9563795399cb46507370722bcc4b892L299-R305) [[3]](diffhunk://#diff-3e1233f680c43c66ef693a8af0e83fd4b9563795399cb46507370722bcc4b892L708-R708) [[4]](diffhunk://#diff-3e1233f680c43c66ef693a8af0e83fd4b9563795399cb46507370722bcc4b892L1069-R1069) [[5]](diffhunk://#diff-3e1233f680c43c66ef693a8af0e83fd4b9563795399cb46507370722bcc4b892L1100-R1109) [[6]](diffhunk://#diff-3e1233f680c43c66ef693a8af0e83fd4b9563795399cb46507370722bcc4b892L1514-R1514) [[7]](diffhunk://#diff-3e1233f680c43c66ef693a8af0e83fd4b9563795399cb46507370722bcc4b892L1574-R1574) [[8]](diffhunk://#diff-3e1233f680c43c66ef693a8af0e83fd4b9563795399cb46507370722bcc4b892L1770-R1770) [[9]](diffhunk://#diff-3e1233f680c43c66ef693a8af0e83fd4b9563795399cb46507370722bcc4b892L1793-R1798) [[10]](diffhunk://#diff-3e1233f680c43c66ef693a8af0e83fd4b9563795399cb46507370722bcc4b892L2170-R2170) [[11]](diffhunk://#diff-3e1233f680c43c66ef693a8af0e83fd4b9563795399cb46507370722bcc4b892L2406-R2410) [[12]](diffhunk://#diff-3e1233f680c43c66ef693a8af0e83fd4b9563795399cb46507370722bcc4b892L2663-R2663) [[13]](diffhunk://#diff-3e1233f680c43c66ef693a8af0e83fd4b9563795399cb46507370722bcc4b892L2913-R2917) [[14]](diffhunk://#diff-3e1233f680c43c66ef693a8af0e83fd4b9563795399cb46507370722bcc4b892L3202-R3202) [[15]](diffhunk://#diff-3e1233f680c43c66ef693a8af0e83fd4b9563795399cb46507370722bcc4b892L3410-R3414) [[16]](diffhunk://#diff-3e1233f680c43c66ef693a8af0e83fd4b9563795399cb46507370722bcc4b892L3700-R3700) [[17]](diffhunk://#diff-3e1233f680c43c66ef693a8af0e83fd4b9563795399cb46507370722bcc4b892L3961-R3969) [[18]](diffhunk://#diff-3e1233f680c43c66ef693a8af0e83fd4b9563795399cb46507370722bcc4b892L4177-R4177)
