### PR TITLE
Add Integration Test for Missing Operation Throttling Tier and Improve Related Test Accuracy

### DIFF
--- a/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/throttling/unlimitedDisable/ConfigurableDefaultPolicyTestCase.java
+++ b/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/throttling/unlimitedDisable/ConfigurableDefaultPolicyTestCase.java
@@ -270,8 +270,8 @@ public class ConfigurableDefaultPolicyTestCase extends APIMIntegrationBaseTest {
             restAPIPublisher.updateAPI(retrievedDto, restAPIId);
             Assert.fail("API Update Successful with Unlimited Subscription Policy.");
         } catch (ApiException e) {
-            Assert.assertEquals(e.getCode(), 500);
-            Assert.assertTrue(e.getResponseBody().contains("Unlimited"));
+            Assert.assertEquals(e.getCode(), 400);
+            Assert.assertFalse(e.getResponseBody().contains("Unlimited"));
         }
     }
 

--- a/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/unlimitedTier/TestAPIUpdated.json
+++ b/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/unlimitedTier/TestAPIUpdated.json
@@ -1,0 +1,197 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "TestAPI",
+    "version": "v1"
+  },
+  "servers": [
+    {
+      "url": "/"
+    }
+  ],
+  "security": [
+    {
+      "default": []
+    }
+  ],
+  "paths": {
+    "/*": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "default": []
+          }
+        ],
+        "x-auth-type": "Application & Application User",
+        "x-throttling-tier" : "10KPerMin",
+        "x-wso2-application-security": {
+          "security-types": [
+            "oauth2"
+          ],
+          "optional": false
+        }
+      },
+      "put": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "default": []
+          }
+        ],
+        "x-auth-type": "Application & Application User",
+        "x-throttling-tier" : "10KPerMin",
+        "x-wso2-application-security": {
+          "security-types": [
+            "oauth2"
+          ],
+          "optional": false
+        }
+      },
+      "post": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "default": []
+          }
+        ],
+        "x-auth-type": "Application & Application User",
+        "x-throttling-tier" : "10KPerMin",
+        "x-wso2-application-security": {
+          "security-types": [
+            "oauth2"
+          ],
+          "optional": false
+        }
+      },
+      "delete": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "default": []
+          }
+        ],
+        "x-auth-type": "Application & Application User",
+        "x-throttling-tier" : "10KPerMin",
+        "x-wso2-application-security": {
+          "security-types": [
+            "oauth2"
+          ],
+          "optional": false
+        }
+      },
+      "patch": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "default": []
+          }
+        ],
+        "x-auth-type": "Application & Application User",
+        "x-throttling-tier" : "10KPerMin",
+        "x-wso2-application-security": {
+          "security-types": [
+            "oauth2"
+          ],
+          "optional": false
+        }
+      }
+    },
+    "/test" : {
+      "get" : {
+        "parameters" : [ ],
+        "responses" : {
+          "200" : {
+            "description" : "ok"
+          }
+        },
+        "security" : [ {
+          "default" : [ ]
+        } ],
+        "x-auth-type" : "Application & Application User",
+        "x-wso2-application-security" : {
+          "security-types" : [ "oauth2" ],
+          "optional" : false
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "default": {
+        "type": "oauth2",
+        "flows": {
+          "implicit": {
+            "authorizationUrl": "https://test.com",
+            "scopes": {}
+          }
+        }
+      }
+    }
+  },
+  "x-wso2-auth-header": "Authorization",
+  "x-wso2-cors": {
+    "corsConfigurationEnabled": false,
+    "accessControlAllowOrigins": [
+      "*"
+    ],
+    "accessControlAllowCredentials": false,
+    "accessControlAllowHeaders": [
+      "authorization",
+      "Access-Control-Allow-Origin",
+      "Content-Type",
+      "SOAPAction",
+      "apikey",
+      "testKey"
+    ],
+    "accessControlAllowMethods": [
+      "GET",
+      "PUT",
+      "POST",
+      "DELETE",
+      "PATCH",
+      "OPTIONS"
+    ]
+  },
+  "x-wso2-production-endpoints": {
+    "urls": [
+      "https://run.mocky.io/v3/6fe7dc9b-2012-4534-8662-bc57ebe66826"
+    ],
+    "type": "http"
+  },
+  "x-wso2-sandbox-endpoints": {
+    "urls": [
+      "https://run.mocky.io/v3/6fe7dc9b-2012-4534-8662-bc57ebe66826"
+    ],
+    "type": "http"
+  },
+  "x-wso2-basePath": "/test/v1",
+  "x-wso2-transports": [
+    "http",
+    "https"
+  ],
+  "x-wso2-response-cache": {
+    "enabled": false,
+    "cacheTimeoutInSeconds": 300
+  }
+}

--- a/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -519,7 +519,6 @@
             <class name="org.wso2.am.integration.tests.other.MandatoryPropertiesTestWithRestart"/>
         </classes>
     </test> -->
-    <!--
     <test name="apim-unlimited-tier-disabled-tests" preserve-order="true" parallel="false" group-by-instances="true">
         <parameter name="group" value="group2"/>
         <classes>
@@ -528,5 +527,4 @@
             <class name="org.wso2.am.integration.tests.throttling.unlimitedDisable.ConfigurableDefaultPolicyTestCase"/>
         </classes>
     </test>
-     -->
 </suite>


### PR DESCRIPTION
### Purpose
To add a new integration test to verify the correct handling of REST APIs when an operation's throttling tier is missing, and refine existing tests to improve accuracy. This also ensures proper cleanup of test resources and enables the relevant test suite in the configuration.

### Goal
Cover tests for https://github.com/wso2/api-manager/issues/760 and revert https://github.com/wso2/product-apim/pull/13151

### Approach
**Test improvements and additions:**

* Added a new test method `updateAPIWithThrottlingTierEmptyResource` in `UnlimitedTierDisabledTestCase.java` to verify that when a REST API operation is missing the `x-throttling-tier`, the system assigns the next available tier (`10KPerMin`) instead of `Unlimited`. The test also confirms the API can be published and that no operation is assigned the `Unlimited` policy.
* Updated the `destroy()` method in `UnlimitedTierDisabledTestCase.java` to ensure APIs created by the new test are properly deleted after tests run.

**Test accuracy and error handling:**

* Updated both `ConfigurableDefaultPolicyTestCase.java` and `UnlimitedTierDisabledTestCase.java` to expect a `400` error (instead of `500`) and to assert that the error response does not mention "Unlimited" when updating an API with a null throttling tier.
