### PR TITLE
Add missing configurations for [admin_console.control_access]

### DIFF
--- a/all-in-one-apim/modules/distribution/product/src/main/assembly/bin.xml
+++ b/all-in-one-apim/modules/distribution/product/src/main/assembly/bin.xml
@@ -43,6 +43,7 @@
                 <exclude>**/conf/tomcat/catalina-server.xml</exclude>
                 <exclude>**/conf/tomcat/catalina-server.xml.j2</exclude>
                 <exclude>**/conf/tomcat/carbon/WEB-INF/web.xml.j2</exclude>
+                <exclude>**/conf/tomcat/carbon/META-INF/context.xml.j2</exclude>
                 <exclude>**/log4j2.properties</exclude>
                 <exclude>**/pax-logging.properties</exclude>
                 <exclude>**/services/sample01.aar</exclude>
@@ -243,6 +244,7 @@
                 <exclude>**/conf/axis2/*.j2</exclude>
                 <exclude>**/catalina-server.xml.j2</exclude>
                 <exclude>**/conf/tomcat/carbon/WEB-INF/web.xml.j2</exclude>
+                <exclude>**/conf/tomcat/carbon/META-INF/context.xml.j2</exclude>
                 <exclude>**/webapps/authenticationendpoint/WEB-INF/web.xml.j2</exclude>
             </excludes>
         </fileSet>

--- a/all-in-one-apim/modules/distribution/product/src/main/resources/conf/templates/repository/conf/tomcat/carbon/META-INF/context.xml.j2
+++ b/all-in-one-apim/modules/distribution/product/src/main/resources/conf/templates/repository/conf/tomcat/carbon/META-INF/context.xml.j2
@@ -1,0 +1,43 @@
+<!--
+  ~ Copyright 2019 WSO2, Inc. (http://wso2.com)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!-- The contents of this file will be loaded for each web application -->
+<Context privileged="true" useHttpOnly="true" useRelativeRedirects="false">
+    <Resources allowLinking="true" />
+
+    <!-- Default set of monitored resources -->
+    <WatchedResource>WEB-INF/web.xml</WatchedResource>
+
+    <!-- comment this out to enable session persistence across Tomcat restarts -->
+    <Manager pathname=""/>
+
+    <JarScanner className="org.wso2.carbon.tomcat.ext.scan.CarbonTomcatJarScanner" scanClassPath="true"
+                scanAllFiles="false" scanAllDirectories="false"/>
+
+    <!-- Following are default values. But we specifically add them in kernel, becuase they get overridden in WSO2 AS -->
+    <Loader className="org.apache.catalina.loader.WebappLoader"
+            loaderClass="org.apache.catalina.loader.WebappClassLoader"/>
+
+    {% if admin_console.authenticator.iwa_ui_authenticator.enable is sameas true %}
+    <Valve className="waffle.apache.NegotiateAuthenticator" principalFormat="fqn" roleFormat="both"/>
+    <Realm className="waffle.apache.WindowsRealm"/>
+    {% endif %}
+
+    {% if admin_console.control_access.enable is sameas true %}
+    <Valve className="org.apache.catalina.valves.RemoteAddrValve"
+        allow="{% for ip in admin_console.control_access.allow %}{{ip}}{{ "|" if not loop.last}}{% endfor %}"/>
+    {% endif %}
+</Context>

--- a/all-in-one-apim/modules/distribution/product/src/main/resources/conf/templates/repository/conf/tomcat/carbon/META-INF/context.xml.j2
+++ b/all-in-one-apim/modules/distribution/product/src/main/resources/conf/templates/repository/conf/tomcat/carbon/META-INF/context.xml.j2
@@ -1,17 +1,19 @@
 <!--
-  ~ Copyright 2019 WSO2, Inc. (http://wso2.com)
+  ~ Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
   ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
   ~ http://www.apache.org/licenses/LICENSE-2.0
   ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
   -->
 
 <!-- The contents of this file will be loaded for each web application -->

--- a/api-control-plane/modules/distribution/product/src/main/assembly/bin.xml
+++ b/api-control-plane/modules/distribution/product/src/main/assembly/bin.xml
@@ -43,6 +43,7 @@
                 <exclude>**/conf/tomcat/catalina-server.xml</exclude>
                 <exclude>**/conf/tomcat/catalina-server.xml.j2</exclude>
                 <exclude>**/conf/tomcat/carbon/WEB-INF/web.xml.j2</exclude>
+                <exclude>**/conf/tomcat/carbon/META-INF/context.xml.j2</exclude>
                 <exclude>**/log4j2.properties</exclude>
                 <exclude>**/pax-logging.properties</exclude>
                 <exclude>**/services/sample01.aar</exclude>
@@ -243,6 +244,7 @@
                 <exclude>**/conf/axis2/*.j2</exclude>
                 <exclude>**/catalina-server.xml.j2</exclude>
                 <exclude>**/conf/tomcat/carbon/WEB-INF/web.xml.j2</exclude>
+                <exclude>**/conf/tomcat/carbon/META-INF/context.xml.j2</exclude>
                 <exclude>**/webapps/authenticationendpoint/WEB-INF/web.xml.j2</exclude>
             </excludes>
         </fileSet>

--- a/api-control-plane/modules/distribution/product/src/main/resources/conf/templates/repository/conf/tomcat/carbon/META-INF/context.xml.j2
+++ b/api-control-plane/modules/distribution/product/src/main/resources/conf/templates/repository/conf/tomcat/carbon/META-INF/context.xml.j2
@@ -1,0 +1,43 @@
+<!--
+  ~ Copyright 2019 WSO2, Inc. (http://wso2.com)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!-- The contents of this file will be loaded for each web application -->
+<Context privileged="true" useHttpOnly="true" useRelativeRedirects="false">
+    <Resources allowLinking="true" />
+
+    <!-- Default set of monitored resources -->
+    <WatchedResource>WEB-INF/web.xml</WatchedResource>
+
+    <!-- comment this out to enable session persistence across Tomcat restarts -->
+    <Manager pathname=""/>
+
+    <JarScanner className="org.wso2.carbon.tomcat.ext.scan.CarbonTomcatJarScanner" scanClassPath="true"
+                scanAllFiles="false" scanAllDirectories="false"/>
+
+    <!-- Following are default values. But we specifically add them in kernel, becuase they get overridden in WSO2 AS -->
+    <Loader className="org.apache.catalina.loader.WebappLoader"
+            loaderClass="org.apache.catalina.loader.WebappClassLoader"/>
+
+    {% if admin_console.authenticator.iwa_ui_authenticator.enable is sameas true %}
+    <Valve className="waffle.apache.NegotiateAuthenticator" principalFormat="fqn" roleFormat="both"/>
+    <Realm className="waffle.apache.WindowsRealm"/>
+    {% endif %}
+
+    {% if admin_console.control_access.enable is sameas true %}
+    <Valve className="org.apache.catalina.valves.RemoteAddrValve"
+        allow="{% for ip in admin_console.control_access.allow %}{{ip}}{{ "|" if not loop.last}}{% endfor %}"/>
+    {% endif %}
+</Context>

--- a/api-control-plane/modules/distribution/product/src/main/resources/conf/templates/repository/conf/tomcat/carbon/META-INF/context.xml.j2
+++ b/api-control-plane/modules/distribution/product/src/main/resources/conf/templates/repository/conf/tomcat/carbon/META-INF/context.xml.j2
@@ -1,17 +1,19 @@
 <!--
-  ~ Copyright 2019 WSO2, Inc. (http://wso2.com)
+  ~ Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
   ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
   ~ http://www.apache.org/licenses/LICENSE-2.0
   ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
   -->
 
 <!-- The contents of this file will be loaded for each web application -->


### PR DESCRIPTION
### Purpose

This PR adds the missing configurations in current context.xml.j2 file. With this we can control the access to /carbon portal by adding following config in `deployment.toml` file.

```
[admin_console.control_access]
enable = true
```
Fixes wso2/api-manager/issues/2169

### Approach
Added existing and missing content to context.xml.j2 file by creating directories in both all-in-one-apim and api-control-plain (/resources/conf/templates/repository/conf/tomcat/carbon/META-INF/context.xml.j2) . Therefore, excluded the incoming context.xml.j2 files from bin.xml.

