### PR TITLE
Add builders and formatters for text/event-stream type

### DIFF
--- a/all-in-one-apim/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/tenant-axis2.xml.j2
+++ b/all-in-one-apim/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/tenant-axis2.xml.j2
@@ -105,6 +105,8 @@
                               class="{{message_formatter.text_javascript}}"/>
     <messageFormatter contentType="text/plain"
                          class="{{message_formatter.text_plain}}"/>
+    <messageFormatter contentType="text/event-stream"
+                         class="{{message_formatter.text_eventstream}}"/>
 
         <messageFormatter contentType="text/html"
                           class="{{message_formatter.text_html}}"/>
@@ -140,6 +142,8 @@
                             class="{{message_builder.text_javascript}}"/>
     <messageBuilder contentType="text/html"
                         class="{{message_builder.text_html}}"/>
+    <messageBuilder contentType="text/event-stream"
+                        class="{{message_builder.text_eventstream}}"/>
         <messageBuilder contentType="text/plain"
                         class="{{message_builder.text_plain}}"/>
         <messageBuilder contentType="application/octet-stream"

--- a/api-control-plane/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/tenant-axis2.xml.j2
+++ b/api-control-plane/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/tenant-axis2.xml.j2
@@ -118,6 +118,8 @@
                         class="org.wso2.carbon.relay.ExpandingMessageFormatter"/-->
         <!--messageFormatter contentType="text/html"
                         class="org.wso2.carbon.relay.ExpandingMessageFormatter"/-->
+        <messageFormatter contentType="text/event-stream"
+                        class="org.apache.axis2.format.PlainTextFormatter"/>
         <!--messageFormatter contentType="application/soap+xml"
                         class="org.wso2.carbon.relay.ExpandingMessageFormatter"/-->
         <!--messageFormatter contentType="x-application/hessian"
@@ -166,6 +168,8 @@
                        class="org.wso2.carbon.relay.BinaryRelayBuilder"/-->
         <!--messageBuilder contentType="text/xml"
                        class="org.wso2.carbon.relay.BinaryRelayBuilder"/-->
+        <messageBuilder contentType="text/event-stream"
+                       class="org.apache.axis2.format.PlainTextBuilder"/>
         <!--messageFormatter contentType="text/plain"
                         class="org.apache.axis2.format.PlainTextBuilder"/-->
         <!--messageBuilder contentType="x-application/hessian"

--- a/gateway/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/tenant-axis2.xml.j2
+++ b/gateway/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/tenant-axis2.xml.j2
@@ -105,6 +105,8 @@
                               class="{{message_formatter.text_javascript}}"/>
     <messageFormatter contentType="text/plain"
                          class="{{message_formatter.text_plain}}"/>
+    <messageFormatter contentType="text/event-stream"
+                             class="{{message_formatter.text_eventstream}}"/>
 
         <messageFormatter contentType="text/html"
                           class="{{message_formatter.text_html}}"/>
@@ -140,6 +142,8 @@
                             class="{{message_builder.text_javascript}}"/>
     <messageBuilder contentType="text/html"
                         class="{{message_builder.text_html}}"/>
+    <messageBuilder contentType="text/event-stream"
+                        class="{{message_builder.text_eventstream}}"/>
         <messageBuilder contentType="text/plain"
                         class="{{message_builder.text_plain}}"/>
         <messageBuilder contentType="application/octet-stream"

--- a/traffic-manager/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/tenant-axis2.xml.j2
+++ b/traffic-manager/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/tenant-axis2.xml.j2
@@ -105,6 +105,8 @@
                               class="{{message_formatter.text_javascript}}"/>
     <messageFormatter contentType="text/plain"
                          class="{{message_formatter.text_plain}}"/>
+    <messageFormatter contentType="text/event-stream"
+                         class="{{message_formatter.text_eventstream}}"/>
 
         <messageFormatter contentType="text/html"
                           class="{{message_formatter.text_html}}"/>
@@ -140,6 +142,8 @@
                             class="{{message_builder.text_javascript}}"/>
     <messageBuilder contentType="text/html"
                         class="{{message_builder.text_html}}"/>
+    <messageBuilder contentType="text/event-stream"
+                            class="{{message_builder.text_eventstream}}"/>
         <messageBuilder contentType="text/plain"
                         class="{{message_builder.text_plain}}"/>
         <messageBuilder contentType="application/octet-stream"


### PR DESCRIPTION
Fixes https://github.com/wso2/api-manager/issues/4364

- acp tenant-axis2.xml.j2 was added as a plain xml following the change in [1].
[1]. https://github.com/wso2/product-apim/pull/12502