### PR TITLE
Fix DocAPIParameterTamperingTest failure 

### DIFF
--- a/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/rest/DocAPIParameterTamperingTest.java
+++ b/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/rest/DocAPIParameterTamperingTest.java
@@ -72,11 +72,11 @@ public class DocAPIParameterTamperingTest extends APIMIntegrationBaseTest {
             Assert.fail("ApiException Exception expected to be thrown");
         } catch (ApiException e) {
             log.error(e);
-            if (e.getCode() == 404) {
+            if (e.getCode() == 401) {
                 expectedExceptionOccured = true;
             }
         }
-        Assert.assertTrue("Expected ApiException to be thrown with a response code 404. But it was not thrown " +
+        Assert.assertTrue("Expected ApiException to be thrown with a response code 401. But it was not thrown " +
                 "as that.", expectedExceptionOccured);
     }
 }


### PR DESCRIPTION
### Purpose:
- Fix DocAPIParameterTamperingTest: update assertion message to match 401 status code check