### PR TITLE
Upgrade carbon.apimgt and carbon.apimgt.ui versions

### DIFF
--- a/all-in-one-apim/pom.xml
+++ b/all-in-one-apim/pom.xml
@@ -1307,10 +1307,10 @@
         <carbon.analytics.common.version>5.3.27</carbon.analytics.common.version>
 
         <!-- APIM Portals Component Version -->
-        <carbon.apimgt.ui.version>9.3.67</carbon.apimgt.ui.version>
+        <carbon.apimgt.ui.version>9.3.71</carbon.apimgt.ui.version>
 
         <!-- APIM Component Version -->
-        <carbon.apimgt.version>9.32.96</carbon.apimgt.version>
+        <carbon.apimgt.version>9.32.101</carbon.apimgt.version>
 
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 

--- a/api-control-plane/pom.xml
+++ b/api-control-plane/pom.xml
@@ -1286,10 +1286,10 @@
         <carbon.analytics.common.version>5.3.27</carbon.analytics.common.version>
 
         <!-- APIM Portals Component Version -->
-        <carbon.apimgt.ui.version>9.3.67</carbon.apimgt.ui.version>
+        <carbon.apimgt.ui.version>9.3.71</carbon.apimgt.ui.version>
 
         <!-- APIM Component Version -->
-        <carbon.apimgt.version>9.32.96</carbon.apimgt.version>
+        <carbon.apimgt.version>9.32.101</carbon.apimgt.version>
 
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -1286,10 +1286,10 @@
         <carbon.analytics.common.version>5.3.27</carbon.analytics.common.version>
 
         <!-- APIM Portals Component Version -->
-        <carbon.apimgt.ui.version>9.3.67</carbon.apimgt.ui.version>
+        <carbon.apimgt.ui.version>9.3.71</carbon.apimgt.ui.version>
 
         <!-- APIM Component Version -->
-        <carbon.apimgt.version>9.32.96</carbon.apimgt.version>
+        <carbon.apimgt.version>9.32.101</carbon.apimgt.version>
 
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 

--- a/traffic-manager/pom.xml
+++ b/traffic-manager/pom.xml
@@ -1286,10 +1286,10 @@
         <carbon.analytics.common.version>5.3.27</carbon.analytics.common.version>
 
         <!-- APIM Portals Component Version -->
-        <carbon.apimgt.ui.version>9.3.67</carbon.apimgt.ui.version>
+        <carbon.apimgt.ui.version>9.3.71</carbon.apimgt.ui.version>
 
         <!-- APIM Component Version -->
-        <carbon.apimgt.version>9.32.96</carbon.apimgt.version>
+        <carbon.apimgt.version>9.32.101</carbon.apimgt.version>
 
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 


### PR DESCRIPTION
## Purpose

This pull request updates dependency versions across several Maven modules to ensure consistency and bring in the latest features and fixes for the APIM UI and core components.

Dependency version updates:

* Bumped `carbon.apimgt.ui.version` from `9.3.67` to `9.3.71` in the following `pom.xml` files: `all-in-one-apim`, `api-control-plane`, `gateway`, and `traffic-manager`. [[1]](diffhunk://#diff-37ca04d56dde2c3140a748c4be355ffb64d8a28606157f86fec386404047de9cL1310-R1313) [[2]](diffhunk://#diff-0b0c511abeb022a2cd0f61b646a09a5c9416c96bbaeb567c97fc0034048dc51cL1289-R1292) [[3]](diffhunk://#diff-f0f912d9ca26c50e0e246b37d0f5ad5ec0c258e15e94f837b2458c46c2bfc6adL1289-R1292) [[4]](diffhunk://#diff-685d5c31f7d907e91a20ccc09e906bf31097b0d46a7204f587e2637c8950307dL1289-R1292)
* Bumped `carbon.apimgt.version` from `9.32.96` to `9.32.101` in the same set of modules to align with the latest APIM core component release. [[1]](diffhunk://#diff-37ca04d56dde2c3140a748c4be355ffb64d8a28606157f86fec386404047de9cL1310-R1313) [[2]](diffhunk://#diff-0b0c511abeb022a2cd0f61b646a09a5c9416c96bbaeb567c97fc0034048dc51cL1289-R1292) [[3]](diffhunk://#diff-f0f912d9ca26c50e0e246b37d0f5ad5ec0c258e15e94f837b2458c46c2bfc6adL1289-R1292) [[4]](diffhunk://#diff-685d5c31f7d907e91a20ccc09e906bf31097b0d46a7204f587e2637c8950307dL1289-R1292)