### PR TITLE
Update azure-content-safety-guardrail.version

### DIFF
--- a/all-in-one-apim/pom.xml
+++ b/all-in-one-apim/pom.xml
@@ -1521,7 +1521,7 @@
         <!-- AM Policy Bundle Versions -->
         <regex-guardrail.version>1.0.0</regex-guardrail.version>
         <aws-bedrock-guardrail.version>1.1.0</aws-bedrock-guardrail.version>
-        <azure-content-safety-guardrail.version>1.0.0</azure-content-safety-guardrail.version>
+        <azure-content-safety-guardrail.version>1.0.1</azure-content-safety-guardrail.version>
         <content-length-guardrail.version>1.0.0</content-length-guardrail.version>
         <json-schema-guardrail.version>1.0.0</json-schema-guardrail.version>
         <pii-masking-regex.version>1.0.0</pii-masking-regex.version>

--- a/api-control-plane/pom.xml
+++ b/api-control-plane/pom.xml
@@ -1512,7 +1512,7 @@
         <!-- AM Policy Bundle Versions -->
         <regex-guardrail.version>1.0.0</regex-guardrail.version>
         <aws-bedrock-guardrail.version>1.1.0</aws-bedrock-guardrail.version>
-        <azure-content-safety-guardrail.version>1.0.0</azure-content-safety-guardrail.version>
+        <azure-content-safety-guardrail.version>1.0.1</azure-content-safety-guardrail.version>
         <content-length-guardrail.version>1.0.0</content-length-guardrail.version>
         <json-schema-guardrail.version>1.0.0</json-schema-guardrail.version>
         <pii-masking-regex.version>1.0.0</pii-masking-regex.version>

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -1507,7 +1507,7 @@
         <!-- AM Policy Bundle Versions -->
         <regex-guardrail.version>1.0.0</regex-guardrail.version>
         <aws-bedrock-guardrail.version>1.1.0</aws-bedrock-guardrail.version>
-        <azure-content-safety-guardrail.version>1.0.0</azure-content-safety-guardrail.version>
+        <azure-content-safety-guardrail.version>1.0.1</azure-content-safety-guardrail.version>
         <content-length-guardrail.version>1.0.0</content-length-guardrail.version>
         <json-schema-guardrail.version>1.0.0</json-schema-guardrail.version>
         <pii-masking-regex.version>1.0.0</pii-masking-regex.version>


### PR DESCRIPTION
Reference: https://github.com/wso2/api-manager/issues/4138