### PR TITLE
Add the APIM_ prefix to the version in the preserve_previous_product_behaviour config

### DIFF
--- a/all-in-one-apim/modules/distribution/product/src/main/resources/conf/infer.json
+++ b/all-in-one-apim/modules/distribution/product/src/main/resources/conf/infer.json
@@ -149,29 +149,29 @@
     }
   },
   "preserve_previous_product_behaviour.version": {
-    "3.2.0": {
+    "APIM_3.2.0": {
       "synapse_properties.'limit_java_class_access_in_scripts.enable'": false
     },
-    "3.2.1": {
+    "APIM_3.2.1": {
       "synapse_properties.'limit_java_class_access_in_scripts.enable'": false
     },
-    "4.0.0": {
+    "APIM_4.0.0": {
       "synapse_properties.'limit_java_class_access_in_scripts.enable'": false
     },
-    "4.1.0": {
+    "APIM_4.1.0": {
       "synapse_properties.'limit_java_class_access_in_scripts.enable'": false
     },
-    "4.2.0": {
+    "APIM_4.2.0": {
       "synapse_properties.'limit_java_class_access_in_scripts.enable'": false
     },
-    "4.3.0": {
+    "APIM_4.3.0": {
       "synapse_properties.'limit_java_class_access_in_scripts.enable'": false
     },
-    "4.4.0": {
+    "APIM_4.4.0": {
       "apim.endpoint_config.loadbalanced.enable_failover": false,
       "synapse_properties.'limit_java_class_access_in_scripts.enable'": false
     },
-    "4.5.0": {
+    "APIM_4.5.0": {
       "apim.endpoint_config.loadbalanced.enable_failover": false,
       "synapse_properties.'limit_java_class_access_in_scripts.enable'": false
     }

--- a/api-control-plane/modules/distribution/product/src/main/resources/conf/infer.json
+++ b/api-control-plane/modules/distribution/product/src/main/resources/conf/infer.json
@@ -111,29 +111,29 @@
     }
   },
   "preserve_previous_product_behaviour.version": {
-    "3.2.0": {
+    "APIM_3.2.0": {
       "synapse_properties.'limit_java_class_access_in_scripts.enable'": false
     },
-    "3.2.1": {
+    "APIM_3.2.1": {
       "synapse_properties.'limit_java_class_access_in_scripts.enable'": false
     },
-    "4.0.0": {
+    "APIM_4.0.0": {
       "synapse_properties.'limit_java_class_access_in_scripts.enable'": false
     },
-    "4.1.0": {
+    "APIM_4.1.0": {
       "synapse_properties.'limit_java_class_access_in_scripts.enable'": false
     },
-    "4.2.0": {
+    "APIM_4.2.0": {
       "synapse_properties.'limit_java_class_access_in_scripts.enable'": false
     },
-    "4.3.0": {
+    "APIM_4.3.0": {
       "synapse_properties.'limit_java_class_access_in_scripts.enable'": false
     },
-    "4.4.0": {
+    "APIM_4.4.0": {
       "apim.endpoint_config.loadbalanced.enable_failover": false,
       "synapse_properties.'limit_java_class_access_in_scripts.enable'": false
     },
-    "4.5.0": {
+    "APIM_4.5.0": {
       "apim.endpoint_config.loadbalanced.enable_failover": false,
       "synapse_properties.'limit_java_class_access_in_scripts.enable'": false
     }

--- a/gateway/modules/distribution/product/src/main/resources/conf/infer.json
+++ b/gateway/modules/distribution/product/src/main/resources/conf/infer.json
@@ -110,29 +110,29 @@
     }
   },
   "preserve_previous_product_behaviour.version": {
-    "3.2.0": {
+    "APIM_3.2.0": {
       "synapse_properties.'limit_java_class_access_in_scripts.enable'": false
     },
-    "3.2.1": {
+    "APIM_3.2.1": {
       "synapse_properties.'limit_java_class_access_in_scripts.enable'": false
     },
-    "4.0.0": {
+    "APIM_4.0.0": {
       "synapse_properties.'limit_java_class_access_in_scripts.enable'": false
     },
-    "4.1.0": {
+    "APIM_4.1.0": {
       "synapse_properties.'limit_java_class_access_in_scripts.enable'": false
     },
-    "4.2.0": {
+    "APIM_4.2.0": {
       "synapse_properties.'limit_java_class_access_in_scripts.enable'": false
     },
-    "4.3.0": {
+    "APIM_4.3.0": {
       "synapse_properties.'limit_java_class_access_in_scripts.enable'": false
     },
-    "4.4.0": {
+    "APIM_4.4.0": {
       "apim.endpoint_config.loadbalanced.enable_failover": false,
       "synapse_properties.'limit_java_class_access_in_scripts.enable'": false
     },
-    "4.5.0": {
+    "APIM_4.5.0": {
       "apim.endpoint_config.loadbalanced.enable_failover": false,
       "synapse_properties.'limit_java_class_access_in_scripts.enable'": false
     }

--- a/traffic-manager/modules/distribution/product/src/main/resources/conf/infer.json
+++ b/traffic-manager/modules/distribution/product/src/main/resources/conf/infer.json
@@ -110,29 +110,29 @@
     }
   },
   "preserve_previous_product_behaviour.version": {
-    "3.2.0": {
+    "APIM_3.2.0": {
       "synapse_properties.'limit_java_class_access_in_scripts.enable'": false
     },
-    "3.2.1": {
+    "APIM_3.2.1": {
       "synapse_properties.'limit_java_class_access_in_scripts.enable'": false
     },
-    "4.0.0": {
+    "APIM_4.0.0": {
       "synapse_properties.'limit_java_class_access_in_scripts.enable'": false
     },
-    "4.1.0": {
+    "APIM_4.1.0": {
       "synapse_properties.'limit_java_class_access_in_scripts.enable'": false
     },
-    "4.2.0": {
+    "APIM_4.2.0": {
       "synapse_properties.'limit_java_class_access_in_scripts.enable'": false
     },
-    "4.3.0": {
+    "APIM_4.3.0": {
       "synapse_properties.'limit_java_class_access_in_scripts.enable'": false
     },
-    "4.4.0": {
+    "APIM_4.4.0": {
       "apim.endpoint_config.loadbalanced.enable_failover": false,
       "synapse_properties.'limit_java_class_access_in_scripts.enable'": false
     },
-    "4.5.0": {
+    "APIM_4.5.0": {
       "apim.endpoint_config.loadbalanced.enable_failover": false,
       "synapse_properties.'limit_java_class_access_in_scripts.enable'": false
     }


### PR DESCRIPTION
## Purpose

- Add the `APIM_` prefix to the version in the `preserve_previous_product_behaviour` configuration to maintain consistency across configuration versioning in WSO2 products.

