### PR TITLE
Upgrade carbon-apimgt-ui version

### DIFF
--- a/all-in-one-apim/pom.xml
+++ b/all-in-one-apim/pom.xml
@@ -1307,7 +1307,7 @@
         <carbon.analytics.common.version>5.3.27</carbon.analytics.common.version>
 
         <!-- APIM Portals Component Version -->
-        <carbon.apimgt.ui.version>9.3.79</carbon.apimgt.ui.version>
+        <carbon.apimgt.ui.version>9.3.82</carbon.apimgt.ui.version>
 
         <!-- APIM Component Version -->
         <carbon.apimgt.version>9.32.109</carbon.apimgt.version>

--- a/api-control-plane/pom.xml
+++ b/api-control-plane/pom.xml
@@ -1286,7 +1286,7 @@
         <carbon.analytics.common.version>5.3.27</carbon.analytics.common.version>
 
         <!-- APIM Portals Component Version -->
-        <carbon.apimgt.ui.version>9.3.79</carbon.apimgt.ui.version>
+        <carbon.apimgt.ui.version>9.3.82</carbon.apimgt.ui.version>
 
         <!-- APIM Component Version -->
         <carbon.apimgt.version>9.32.109</carbon.apimgt.version>

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -1286,7 +1286,7 @@
         <carbon.analytics.common.version>5.3.27</carbon.analytics.common.version>
 
         <!-- APIM Portals Component Version -->
-        <carbon.apimgt.ui.version>9.3.79</carbon.apimgt.ui.version>
+        <carbon.apimgt.ui.version>9.3.82</carbon.apimgt.ui.version>
 
         <!-- APIM Component Version -->
         <carbon.apimgt.version>9.32.109</carbon.apimgt.version>

--- a/traffic-manager/pom.xml
+++ b/traffic-manager/pom.xml
@@ -1286,7 +1286,7 @@
         <carbon.analytics.common.version>5.3.27</carbon.analytics.common.version>
 
         <!-- APIM Portals Component Version -->
-        <carbon.apimgt.ui.version>9.3.79</carbon.apimgt.ui.version>
+        <carbon.apimgt.ui.version>9.3.82</carbon.apimgt.ui.version>
 
         <!-- APIM Component Version -->
         <carbon.apimgt.version>9.32.109</carbon.apimgt.version>


### PR DESCRIPTION
## Purpose

This pull request updates the APIM Portals Component version across multiple modules to ensure consistency and bring in the latest changes from the UI component.

Dependency version updates:

* Updated the `carbon.apimgt.ui.version` property from `9.3.79` to `9.3.82` in the following `pom.xml` files:
  * `all-in-one-apim/pom.xml`
  * `api-control-plane/pom.xml`
  * `gateway/pom.xml`
  * `traffic-manager/pom.xml`