### PR TITLE
Add missing subprotocol handler config to the templates

### DIFF
--- a/all-in-one-apim/modules/distribution/product/src/main/resources/conf/default.json
+++ b/all-in-one-apim/modules/distribution/product/src/main/resources/conf/default.json
@@ -249,7 +249,6 @@
   "apim.wss.dispatch.on_error.sequence" : "fault",
   "apim.wss.out_dispatch_seq" : "outDispatchSeq",
   "apim.wss.handler.class" : "org.wso2.carbon.apimgt.gateway.handlers.WebsocketHandler",
-  "apim.wss.subprotocol.handler.class" : "org.wso2.carbon.inbound.endpoint.protocol.websocket.subprotocols.EchoSubprotocolHandler",
   "apim.wss.dispatch.custom.sequence" : true,
   "apim.wss.outflow.dispatch.fault.sequence" : "fault",
   "apim.wss.client.side.broadcast.level" : "0",

--- a/all-in-one-apim/modules/distribution/product/src/main/resources/conf/templates/repository/deployment/server/synapse-configs/default/inbound-endpoints/SecureWebSocketInboundEndpoint.xml.j2
+++ b/all-in-one-apim/modules/distribution/product/src/main/resources/conf/templates/repository/deployment/server/synapse-configs/default/inbound-endpoints/SecureWebSocketInboundEndpoint.xml.j2
@@ -30,5 +30,8 @@
         {%if apim.wss.pass_through_control_frames is defined %}
         <parameter name="ws.pass.through.control.frames">{{apim.wss.pass_through_control_frames}}</parameter>
         {%endif%}
+        {%if apim.wss.subprotocol_handler is defined %}
+        <parameter name="ws.subprotocol.handler.class">{{apim.wss.subprotocol_handler}}</parameter>
+        {%endif%}
     </parameters>
 </inboundEndpoint>

--- a/all-in-one-apim/modules/distribution/product/src/main/resources/conf/templates/repository/deployment/server/synapse-configs/default/inbound-endpoints/WebSocketInboundEndpoint.xml.j2
+++ b/all-in-one-apim/modules/distribution/product/src/main/resources/conf/templates/repository/deployment/server/synapse-configs/default/inbound-endpoints/WebSocketInboundEndpoint.xml.j2
@@ -22,5 +22,8 @@
         {%if apim.ws.pass_through_control_frames is defined %}
         <parameter name="ws.pass.through.control.frames">{{apim.ws.pass_through_control_frames}}</parameter>
         {%endif%}
+        {%if apim.ws.subprotocol_handler is defined %}
+        <parameter name="ws.subprotocol.handler.class">{{apim.ws.subprotocol_handler}}</parameter>
+        {%endif%}
     </parameters>
 </inboundEndpoint> 

--- a/api-control-plane/modules/distribution/product/src/main/resources/conf/default.json
+++ b/api-control-plane/modules/distribution/product/src/main/resources/conf/default.json
@@ -249,7 +249,6 @@
   "apim.wss.dispatch.on_error.sequence" : "fault",
   "apim.wss.out_dispatch_seq" : "outDispatchSeq",
   "apim.wss.handler.class" : "org.wso2.carbon.apimgt.gateway.handlers.WebsocketHandler",
-  "apim.wss.subprotocol.handler.class" : "org.wso2.carbon.inbound.endpoint.protocol.websocket.subprotocols.EchoSubprotocolHandler",
   "apim.wss.dispatch.custom.sequence" : true,
   "apim.wss.outflow.dispatch.fault.sequence" : "fault",
   "apim.wss.client.side.broadcast.level" : "0",

--- a/gateway/modules/distribution/product/src/main/resources/conf/default.json
+++ b/gateway/modules/distribution/product/src/main/resources/conf/default.json
@@ -249,7 +249,6 @@
   "apim.wss.dispatch.on_error.sequence" : "fault",
   "apim.wss.out_dispatch_seq" : "outDispatchSeq",
   "apim.wss.handler.class" : "org.wso2.carbon.apimgt.gateway.handlers.WebsocketHandler",
-  "apim.wss.subprotocol.handler.class" : "org.wso2.carbon.inbound.endpoint.protocol.websocket.subprotocols.EchoSubprotocolHandler",
   "apim.wss.dispatch.custom.sequence" : true,
   "apim.wss.outflow.dispatch.fault.sequence" : "fault",
   "apim.wss.client.side.broadcast.level" : "0",

--- a/gateway/modules/distribution/product/src/main/resources/conf/templates/repository/deployment/server/synapse-configs/default/inbound-endpoints/SecureWebSocketInboundEndpoint.xml.j2
+++ b/gateway/modules/distribution/product/src/main/resources/conf/templates/repository/deployment/server/synapse-configs/default/inbound-endpoints/SecureWebSocketInboundEndpoint.xml.j2
@@ -30,5 +30,8 @@
         {%if apim.wss.pass_through_control_frames is defined %}
         <parameter name="ws.pass.through.control.frames">{{apim.wss.pass_through_control_frames}}</parameter>
         {%endif%}
+        {%if apim.wss.subprotocol_handler is defined %}
+        <parameter name="ws.subprotocol.handler.class">{{apim.wss.subprotocol_handler}}</parameter>
+        {%endif%}
     </parameters>
 </inboundEndpoint>

--- a/gateway/modules/distribution/product/src/main/resources/conf/templates/repository/deployment/server/synapse-configs/default/inbound-endpoints/WebSocketInboundEndpoint.xml.j2
+++ b/gateway/modules/distribution/product/src/main/resources/conf/templates/repository/deployment/server/synapse-configs/default/inbound-endpoints/WebSocketInboundEndpoint.xml.j2
@@ -22,5 +22,8 @@
         {%if apim.ws.pass_through_control_frames is defined %}
         <parameter name="ws.pass.through.control.frames">{{apim.ws.pass_through_control_frames}}</parameter>
         {%endif%}
+        {%if apim.ws.subprotocol_handler is defined %}
+        <parameter name="ws.subprotocol.handler.class">{{apim.ws.subprotocol_handler}}</parameter>
+        {%endif%}
     </parameters>
 </inboundEndpoint> 

--- a/traffic-manager/modules/distribution/product/src/main/resources/conf/default.json
+++ b/traffic-manager/modules/distribution/product/src/main/resources/conf/default.json
@@ -249,7 +249,6 @@
   "apim.wss.dispatch.on_error.sequence" : "fault",
   "apim.wss.out_dispatch_seq" : "outDispatchSeq",
   "apim.wss.handler.class" : "org.wso2.carbon.apimgt.gateway.handlers.WebsocketHandler",
-  "apim.wss.subprotocol.handler.class" : "org.wso2.carbon.inbound.endpoint.protocol.websocket.subprotocols.EchoSubprotocolHandler",
   "apim.wss.dispatch.custom.sequence" : true,
   "apim.wss.outflow.dispatch.fault.sequence" : "fault",
   "apim.wss.client.side.broadcast.level" : "0",


### PR DESCRIPTION
This pull request updates the configuration for WebSocket subprotocol handlers to improve flexibility and customization. The main change is the removal of the default subprotocol handler class from several `default.json` files, and the addition of support for specifying a custom subprotocol handler in the inbound endpoint XML templates. This allows users to define the subprotocol handler via configuration rather than being locked to a hardcoded default.

**Configuration updates for WebSocket subprotocol handlers:**

_Removal of hardcoded default handler:_
* Removed the `"apim.wss.subprotocol.handler.class"` property (which pointed to `EchoSubprotocolHandler`) from `default.json` in `all-in-one-apim`, `gateway`, `api-control-plane`, and `traffic-manager` modules. [[1]](diffhunk://#diff-e0b9f3bc583f6fefd5cfb6086273a9f520c432f64d58d6efc57c45ba3f79a2d5L252) [[2]](diffhunk://#diff-c0ced000f479ee0c6756b1b69a53d28b47a5630aac0dbebdff262fa1928df4bbL252) [[3]](diffhunk://#diff-ee154602b2f15fb82562a87cf630a0771210658c9aa7494f03b4b6464f222503L252) [[4]](diffhunk://#diff-812f940b34357cc03e42933f6986f2bc324f44cc04a0d7e86e833e0eef4e940eL252)

_Enhanced template support for custom handler:_
* Added conditional logic to `SecureWebSocketInboundEndpoint.xml.j2` and `WebSocketInboundEndpoint.xml.j2` templates in both `gateway` and `all-in-one-apim` modules to inject the `ws.subprotocol.handler.class` parameter if it is defined in configuration. [[1]](diffhunk://#diff-738d4c34de80e47c939dbee8e26a1ef0e6cdba534fcb6dd2015a8bfdeec58efeR33-R35) [[2]](diffhunk://#diff-c5c6705903fbedfc7e32c21be42cefdf652a88fcfe467eee99bf99b37ca66c8dR25-R27)

These changes make it easier to customize WebSocket subprotocol handling without modifying core configuration files, supporting more flexible deployments.This PR adds the missing `<parameter name="ws.subprotocol.handler.class">` configuration to the template files.