### PR TITLE
Bump Apache CXF version to 3.6.9 in POM files

### DIFF
--- a/all-in-one-apim/pom.xml
+++ b/all-in-one-apim/pom.xml
@@ -1417,7 +1417,7 @@
         <carbon.automation.version>4.4.10</carbon.automation.version>
         <carbon.automationutils.version>4.5.3</carbon.automationutils.version>
         <testng.version>6.11</testng.version>
-        <org.apache.cxf.version>3.6.8</org.apache.cxf.version>
+        <org.apache.cxf.version>3.6.9</org.apache.cxf.version>
         <org.springframework.version>5.1.13.RELEASE</org.springframework.version>
         <org.apache.tomcat>7.0.96</org.apache.tomcat>
         <org.codehaus.jackson.version>1.9.13</org.codehaus.jackson.version>

--- a/api-control-plane/pom.xml
+++ b/api-control-plane/pom.xml
@@ -1396,7 +1396,7 @@
         <carbon.automation.version>4.4.10</carbon.automation.version>
         <carbon.automationutils.version>4.5.3</carbon.automationutils.version>
         <testng.version>6.11</testng.version>
-        <org.apache.cxf.version>3.6.8</org.apache.cxf.version>
+        <org.apache.cxf.version>3.6.9</org.apache.cxf.version>
         <org.springframework.version>5.1.13.RELEASE</org.springframework.version>
         <org.apache.tomcat>7.0.96</org.apache.tomcat>
         <org.codehaus.jackson.version>1.9.13</org.codehaus.jackson.version>

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -1396,7 +1396,7 @@
         <carbon.automation.version>4.4.10</carbon.automation.version>
         <carbon.automationutils.version>4.5.3</carbon.automationutils.version>
         <testng.version>6.11</testng.version>
-        <org.apache.cxf.version>3.6.8</org.apache.cxf.version>
+        <org.apache.cxf.version>3.6.9</org.apache.cxf.version>
         <org.springframework.version>5.1.13.RELEASE</org.springframework.version>
         <org.apache.tomcat>7.0.96</org.apache.tomcat>
         <org.codehaus.jackson.version>1.9.13</org.codehaus.jackson.version>

--- a/traffic-manager/pom.xml
+++ b/traffic-manager/pom.xml
@@ -1396,7 +1396,7 @@
         <carbon.automation.version>4.4.10</carbon.automation.version>
         <carbon.automationutils.version>4.5.3</carbon.automationutils.version>
         <testng.version>6.11</testng.version>
-        <org.apache.cxf.version>3.6.8</org.apache.cxf.version>
+        <org.apache.cxf.version>3.6.9</org.apache.cxf.version>
         <org.springframework.version>5.1.13.RELEASE</org.springframework.version>
         <org.apache.tomcat>7.0.96</org.apache.tomcat>
         <org.codehaus.jackson.version>1.9.13</org.codehaus.jackson.version>


### PR DESCRIPTION
## Purpose 

$subject 

## Related issues

https://github.com/wso2/api-manager/issues/4605

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Apache CXF library to version 3.6.9 across all modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->