### PR TITLE
Revert "Comment out JWT API Key related tests until the JWT generation class is added to the test base"

### DIFF
--- a/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/aiapi/AIAPITestCase.java
+++ b/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/aiapi/AIAPITestCase.java
@@ -280,7 +280,7 @@ public class AIAPITestCase extends APIMIntegrationBaseTest {
     /**
      * Test Unsecured AI API invocation
      */
-    /*@Test(groups = {"wso2.am"}, description = "Test AI API invocation",
+    @Test(groups = {"wso2.am"}, description = "Test AI API invocation",
             dependsOnMethods = "testUnsecuredAiApiCreationAndPublish")
     public void testUnsecuredAiApiInvocation() throws Exception {
         apiKey = subscribeToApiAndGenerateKey(unsecuredApiId);
@@ -294,7 +294,7 @@ public class AIAPITestCase extends APIMIntegrationBaseTest {
 
         assertEquals(serviceResponse.getResponseCode(), HttpStatus.SC_OK, "Unsecured AI API invocation failed");
         assertEquals(serviceResponse.getData(), model1Response, "Unsecured AI API response mismatch");
-    }*/
+    }
 
     /**
      * Updates the created AI service provider with apikey auth configurations and verifies the update.
@@ -334,7 +334,7 @@ public class AIAPITestCase extends APIMIntegrationBaseTest {
     /**
      * Test Mistral AI API invocation
      */
-    /*@Test(groups = {"wso2.am"}, description = "Test AI API invocation",
+    @Test(groups = {"wso2.am"}, description = "Test AI API invocation",
             dependsOnMethods = "testSecuredAiApiCreationAndPublish")
     public void testSecuredAiApiInvocation() throws Exception {
         // Note: Use existing API key from previous test to avoid regeneration
@@ -356,7 +356,7 @@ public class AIAPITestCase extends APIMIntegrationBaseTest {
 
         assertEquals(serviceResponse.getResponseCode(), HttpStatus.SC_OK, "AI API invocation failed");
         assertEquals(serviceResponse.getData(), model1Response, "AI API response mismatch");
-    }*/
+    }
 
     /**
      * Test endpoint addition to Mistral AI API - handles multiple endpoints (production and sandbox)
@@ -1037,7 +1037,7 @@ public class AIAPITestCase extends APIMIntegrationBaseTest {
      * @return API key
      * @throws Exception if subscription or key generation fails
      */
-    /*(String apiId) throws Exception {
+    private String subscribeToApiAndGenerateKey(String apiId) throws Exception {
         // Subscribe to API
         SubscriptionDTO subscriptionDTO = restAPIStore.subscribeToAPI(apiId, applicationId,
                 APIMIntegrationConstants.API_TIER.UNLIMITED);
@@ -1048,7 +1048,7 @@ public class AIAPITestCase extends APIMIntegrationBaseTest {
                 ApplicationKeyGenerateRequestDTO.KeyTypeEnum.PRODUCTION.toString(), -1, null, null);
         assertNotNull(apiKeyDTO, "API Key should not be null");
         return apiKeyDTO.getApikey();
-    }*/
+    }
 
     /**
      * Create a temporary file with the given content

--- a/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/aiapi/AIAPITestCase.java
+++ b/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/aiapi/AIAPITestCase.java
@@ -280,7 +280,7 @@ public class AIAPITestCase extends APIMIntegrationBaseTest {
     /**
      * Test Unsecured AI API invocation
      */
-    @Test(groups = {"wso2.am"}, description = "Test AI API invocation",
+    /*@Test(groups = {"wso2.am"}, description = "Test AI API invocation",
             dependsOnMethods = "testUnsecuredAiApiCreationAndPublish")
     public void testUnsecuredAiApiInvocation() throws Exception {
         apiKey = subscribeToApiAndGenerateKey(unsecuredApiId);
@@ -294,7 +294,7 @@ public class AIAPITestCase extends APIMIntegrationBaseTest {
 
         assertEquals(serviceResponse.getResponseCode(), HttpStatus.SC_OK, "Unsecured AI API invocation failed");
         assertEquals(serviceResponse.getData(), model1Response, "Unsecured AI API response mismatch");
-    }
+    }*/
 
     /**
      * Updates the created AI service provider with apikey auth configurations and verifies the update.
@@ -334,7 +334,7 @@ public class AIAPITestCase extends APIMIntegrationBaseTest {
     /**
      * Test Mistral AI API invocation
      */
-    @Test(groups = {"wso2.am"}, description = "Test AI API invocation",
+    /*@Test(groups = {"wso2.am"}, description = "Test AI API invocation",
             dependsOnMethods = "testSecuredAiApiCreationAndPublish")
     public void testSecuredAiApiInvocation() throws Exception {
         // Note: Use existing API key from previous test to avoid regeneration
@@ -356,7 +356,7 @@ public class AIAPITestCase extends APIMIntegrationBaseTest {
 
         assertEquals(serviceResponse.getResponseCode(), HttpStatus.SC_OK, "AI API invocation failed");
         assertEquals(serviceResponse.getData(), model1Response, "AI API response mismatch");
-    }
+    }*/
 
     /**
      * Test endpoint addition to Mistral AI API - handles multiple endpoints (production and sandbox)
@@ -1037,7 +1037,7 @@ public class AIAPITestCase extends APIMIntegrationBaseTest {
      * @return API key
      * @throws Exception if subscription or key generation fails
      */
-    private String subscribeToApiAndGenerateKey(String apiId) throws Exception {
+    /*(String apiId) throws Exception {
         // Subscribe to API
         SubscriptionDTO subscriptionDTO = restAPIStore.subscribeToAPI(apiId, applicationId,
                 APIMIntegrationConstants.API_TIER.UNLIMITED);
@@ -1048,7 +1048,7 @@ public class AIAPITestCase extends APIMIntegrationBaseTest {
                 ApplicationKeyGenerateRequestDTO.KeyTypeEnum.PRODUCTION.toString(), -1, null, null);
         assertNotNull(apiKeyDTO, "API Key should not be null");
         return apiKeyDTO.getApikey();
-    }
+    }*/
 
     /**
      * Create a temporary file with the given content

--- a/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/APISecurityTestCase.java
+++ b/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/APISecurityTestCase.java
@@ -491,7 +491,7 @@ public class APISecurityTestCase extends APIManagerLifecycleBaseTest {
         Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_UNAUTHORIZED);
     }
 
-    /*@Test(description = "Testing the invocation with API Keys", dependsOnMethods = {
+    @Test(description = "Testing the invocation with API Keys", dependsOnMethods = {
             "testCreateAndPublishAPIWithOAuth2"})
     public void testInvocationWithApiKeys() throws Exception {
         APIKeyDTO apiKeyDTO = restAPIStore
@@ -505,7 +505,7 @@ public class APISecurityTestCase extends APIManagerLifecycleBaseTest {
         HttpResponse response = HTTPSClientUtils.doGet(getAPIInvocationURLHttps(apiKeySecuredAPIContext,
                 API_VERSION_1_0_0) + API_END_POINT_METHOD, requestHeaders);
         Assert.assertEquals(response.getResponseCode(), HttpStatus.SC_OK);
-    }*/
+    }
 
     @Test(description = "Testing the invocation with Basic Auth for APIKey Only API", dependsOnMethods = {
             "testCreateAndPublishAPIWithOAuth2"})
@@ -755,7 +755,7 @@ public class APISecurityTestCase extends APIManagerLifecycleBaseTest {
                 "Mutual SSL Authentication has succeeded for a different certificate");
     }
 
-    /*@Test(description = "Testing the invocation with API Keys having IP restriction",
+    @Test(description = "Testing the invocation with API Keys having IP restriction",
             dependsOnMethods = {"testCreateAndPublishAPIWithOAuth2"})
     public void testInvocationWithApiKeysWithIPCondition() throws Exception {
         String permittedIP = "152.23.5.6, 192.168.1.2/24, 2001:c00::/23";
@@ -801,9 +801,9 @@ public class APISecurityTestCase extends APIManagerLifecycleBaseTest {
                 getAPIInvocationURLHttps(mutualSSLWithOAuthAPI, API_VERSION_1_0_0) + API_END_POINT_METHOD,
                 requestHeaders5);
         Assert.assertEquals(response5.getResponseCode(), HttpStatus.SC_FORBIDDEN);
-    }*/
+    }
 
-    /*@Test(description = "Testing the invocation with API Keys having Http Referer restriction",
+    @Test(description = "Testing the invocation with API Keys having Http Referer restriction",
             dependsOnMethods = {"testCreateAndPublishAPIWithOAuth2"})
     public void testInvocationWithApiKeysWithRefererCondition() throws Exception {
         String permittedReferer = "www.abc.com/path, sub.cds.com/*, *.gef.com/*";
@@ -846,9 +846,9 @@ public class APISecurityTestCase extends APIManagerLifecycleBaseTest {
                 API_VERSION_1_0_0) + API_END_POINT_METHOD,
                 requestHeaders4);
         Assert.assertEquals(response4.getResponseCode(), HttpStatus.SC_OK);
-    }*/
+    }
 
-    /*@Test(description = "Testing the invocation of API Secured only with API Keys", dependsOnMethods = {
+    @Test(description = "Testing the invocation of API Secured only with API Keys", dependsOnMethods = {
             "testCreateAndPublishAPIWithOAuth2"})
     public void testInvocationWithApiKeysOnly() throws Exception {
         APIKeyDTO apiKeyDTO1 = restAPIStore
@@ -880,7 +880,7 @@ public class APISecurityTestCase extends APIManagerLifecycleBaseTest {
                 "Response data mismatched when invoke with sandbox endpoint" + " Response Data:" + response2.getData()
                         + ". Expected Response Data: " + API_RESPONSE_DATA);
 
-    }*/
+    }
 
     private Map<String, String> createRequestHeadersForAPIKey(String apiKey, String ip, String referer) {
 
@@ -896,7 +896,7 @@ public class APISecurityTestCase extends APIManagerLifecycleBaseTest {
         return requestHeaders;
     }
 
-    /*@Test(description = "Testing the invocation with Revoked API Keys", dependsOnMethods =
+    @Test(description = "Testing the invocation with Revoked API Keys", dependsOnMethods =
             {"testCreateAndPublishAPIWithOAuth2"})
     public void testInvocationWithRevokedApiKeys() throws Exception {
         APIKeyDTO apiKeyDTO = restAPIStore.generateAPIKeys(applicationId, ApplicationKeyGenerateRequestDTO.KeyTypeEnum
@@ -934,9 +934,9 @@ public class APISecurityTestCase extends APIManagerLifecycleBaseTest {
         Assert.assertFalse(isApiKeyValid, "API Key revocation failed. " +
                 "API invocation response code is expected to be : " + HTTP_RESPONSE_CODE_UNAUTHORIZED +
                 ", but got " + invocationResponseAfterRevoked.getResponseCode());
-    }*/
+    }
 
-    /*@Test(description = "Testing the invocation with Revoked API Keys", dependsOnMethods =
+    @Test(description = "Testing the invocation with Revoked API Keys", dependsOnMethods =
             {"testCreateAndPublishAPIWithOAuth2"})
     public void testInvokeApiKeyAsJWTNegative() throws Exception {
         APIKeyDTO apiKeyDTO = restAPIStore.generateAPIKeys(applicationId, ApplicationKeyGenerateRequestDTO.KeyTypeEnum
@@ -951,7 +951,7 @@ public class APISecurityTestCase extends APIManagerLifecycleBaseTest {
                 getAPIInvocationURLHttps(mutualSSLWithOAuthAPI, API_VERSION_1_0_0) + API_END_POINT_METHOD,
                 requestHeader);
         Assert.assertEquals(response.getResponseCode(), 401);
-    }*/
+    }
 
     @Test(description = "Testing the invocation with Revoked API Keys", dependsOnMethods =
             {"testCreateAndPublishAPIWithOAuth2"})
@@ -1013,7 +1013,7 @@ public class APISecurityTestCase extends APIManagerLifecycleBaseTest {
         Assert.assertEquals(response.getResponseCode(), 401);
     }
 
-    /*@Test(description = "Testing the invocation with Revoked API Keys", dependsOnMethods =
+    @Test(description = "Testing the invocation with Revoked API Keys", dependsOnMethods =
             {"testCreateAndPublishAPIWithOAuth2"})
     public void testInvokeAPIKeyAsInternalKeyNegative() throws Exception {
         APIKeyDTO apiKeyDTO = restAPIStore.generateAPIKeys(applicationId, ApplicationKeyGenerateRequestDTO.KeyTypeEnum
@@ -1021,7 +1021,7 @@ public class APISecurityTestCase extends APIManagerLifecycleBaseTest {
         HttpResponse response = invokeApiWithInternalKey(mutualSSLWithOAuthAPI, API_VERSION_1_0_0,
                 API_END_POINT_METHOD, apiKeyDTO.getApikey());
         Assert.assertEquals(response.getResponseCode(), 401);
-    }*/
+    }
 
     @Test(description = "Testing the invocation with Revoked API Keys", dependsOnMethods =
             {"testCreateAndPublishAPIWithOAuth2"})
@@ -1086,7 +1086,7 @@ public class APISecurityTestCase extends APIManagerLifecycleBaseTest {
         Assert.assertEquals(response.getResponseCode(), 401);
     }
 
-    /*@Test(description = "Testing the invocation with APIkey Token for BasicAuth api", dependsOnMethods =
+    @Test(description = "Testing the invocation with APIkey Token for BasicAuth api", dependsOnMethods =
             {"testCreateAndPublishAPIWithOAuth2"})
     public void testInvokeAPIKeyForBasicOauthAPINegative() throws Exception {
         APIKeyDTO apiKeyDTO = restAPIStore.generateAPIKeys(applicationId, ApplicationKeyGenerateRequestDTO.KeyTypeEnum
@@ -1101,7 +1101,7 @@ public class APISecurityTestCase extends APIManagerLifecycleBaseTest {
                 getAPIInvocationURLHttps(basicAuthSecuredAPIContext, API_VERSION_1_0_0) + API_END_POINT_METHOD,
                 requestHeader);
         Assert.assertEquals(response.getResponseCode(), 401);
-    }*/
+    }
 
     @Test(description = "Testing the User Token Invocation and Password Reset", dependsOnMethods = {
             "testInvokeBasicAuth"})
@@ -1200,7 +1200,7 @@ public class APISecurityTestCase extends APIManagerLifecycleBaseTest {
         }
     }
 
-    /*@Test(description = "Testing the invocation with API Keys after removing subscription", dependsOnMethods =
+    @Test(description = "Testing the invocation with API Keys after removing subscription", dependsOnMethods =
             {"testInvokeBasicAuthAfterCredentialsInvalid"})
     public void testInvocationWithApiKeysWithoutSubscription() throws Exception {
         APIKeyDTO apiKeyDTO = restAPIStore.generateAPIKeys(applicationId, ApplicationKeyGenerateRequestDTO.KeyTypeEnum
@@ -1238,7 +1238,7 @@ public class APISecurityTestCase extends APIManagerLifecycleBaseTest {
         Assert.assertFalse(isApiKeyValid, "API Key internal subscription validation failed. " +
                 "API invocation response code is expected to be : " + HTTP_RESPONSE_CODE_FORBIDDEN +
                 ", but got " + invocationResponseAfterSubscriptionRemoved.getResponseCode());
-    }*/
+    }
 
     @Test(description = "Testing the WWW-Authorization header when invocating an API with API Keys using invalid Authorization header",
             dependsOnMethods = {"testCreateAndPublishAPIWithOAuth2"})

--- a/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/APISecurityTestCase.java
+++ b/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/APISecurityTestCase.java
@@ -1157,7 +1157,7 @@ public class APISecurityTestCase extends APIManagerLifecycleBaseTest {
         Assert.assertEquals(response.getResponseCode(), 200);
     }
 
-//    @Test(description = "Validating the security of API resources", dependsOnMethods = {"testInvocationWithRevokedApiKeys"})
+    @Test(description = "Validating the security of API resources", dependsOnMethods = {"testInvocationWithRevokedApiKeys"})
     public void testValidateSecurityOfResources() throws Exception {
 
         // Validate for security disabled API

--- a/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/application/groupSharing/ApplicationSharingTestCase.java
+++ b/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/application/groupSharing/ApplicationSharingTestCase.java
@@ -127,7 +127,7 @@ public class ApplicationSharingTestCase extends APIMIntegrationBaseTest {
         Assert.assertEquals(serviceResponse.getResponseCode(), HttpStatus.SC_FORBIDDEN);
     }
 
-    /*@Test(groups = "wso2.am", description = "Generate API key from user 1 and make sure that user 2 can revoke the key")
+    @Test(groups = "wso2.am", description = "Generate API key from user 1 and make sure that user 2 can revoke the key")
     public void testAPIKeyRevocationBySharedUser()
             throws ApiException {
 
@@ -142,7 +142,7 @@ public class ApplicationSharingTestCase extends APIMIntegrationBaseTest {
                 ApplicationKeyGenerateRequestDTO.KeyTypeEnum.PRODUCTION.toString(), -1, null, null);
         //Revoke api key by user 2
         restAPIStoreClientUser2.revokeAPIKey(userOneSharedApplicationId, key.getApikey());
-    }*/
+    }
 
     private void createUsersAndApplications() throws Exception {
         //signup of user one

--- a/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/header/CustomHeaderTestCase.java
+++ b/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/header/CustomHeaderTestCase.java
@@ -142,7 +142,7 @@ public class CustomHeaderTestCase extends APIManagerLifecycleBaseTest {
                 "Response code mismatched");
     }
 
-    /*@Test(groups = {"wso2.am"}, description = "Invoke an API with default API Key header",
+    @Test(groups = {"wso2.am"}, description = "Invoke an API with default API Key header",
             dependsOnMethods = "testSystemWideCustomAuthHeader")
     public void testInvokeAPIWIthDefaultApiKeyHeader() throws Exception {
 
@@ -168,9 +168,9 @@ public class CustomHeaderTestCase extends APIManagerLifecycleBaseTest {
         HttpResponse apiResponse2 = HttpRequestUtil.doGet(invocationUrl, requestHeaders2);
         assertEquals(apiResponse2.getResponseCode(), Response.Status.UNAUTHORIZED.getStatusCode(),
                 "Response code mismatched");
-    }*/
+    }
 
-    /*@Test(groups = {"wso2.am"}, description = "Invoke an API with custom API Key header",
+    @Test(groups = {"wso2.am"}, description = "Invoke an API with custom API Key header",
             dependsOnMethods = "testInvokeAPIWIthDefaultApiKeyHeader")
     public void testInvokeAPIWIthCustomApiKeyHeader() throws Exception {
 
@@ -203,7 +203,7 @@ public class CustomHeaderTestCase extends APIManagerLifecycleBaseTest {
         HttpResponse apiResponse2 = HttpRequestUtil.doGet(invocationUrl, requestHeaders2);
         assertEquals(apiResponse2.getResponseCode(), Response.Status.UNAUTHORIZED.getStatusCode(),
                 "Response code mismatched");
-    }*/
+    }
 
     @AfterClass(alwaysRun = true)
     public void destroy() throws Exception {

--- a/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/jwt/JWTTestCase.java
+++ b/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/jwt/JWTTestCase.java
@@ -184,8 +184,8 @@ public class JWTTestCase extends APIManagerLifecycleBaseTest {
                 ApplicationKeyGenerateRequestDTO.KeyTypeEnum.PRODUCTION, null, grantTypes);
         restAPIStore.generateKeys(jwtApplicationId, "36000", CALLBACK_URL,
                 ApplicationKeyGenerateRequestDTO.KeyTypeEnum.PRODUCTION, null, grantTypes);
-        /*restAPIStore.generateAPIKeys(apiKeyApplicationId,
-                ApplicationKeyGenerateRequestDTO.KeyTypeEnum.PRODUCTION.toString(), 36000, null, null);*/
+        restAPIStore.generateAPIKeys(apiKeyApplicationId,
+                ApplicationKeyGenerateRequestDTO.KeyTypeEnum.PRODUCTION.toString(), 36000, null, null);
         restAPIStore.generateKeys(authCodeApplicationId, "36000", CALLBACK_URL,
                 ApplicationKeyGenerateRequestDTO.KeyTypeEnum.PRODUCTION, null, grantTypes);
         createUser();
@@ -320,7 +320,7 @@ public class JWTTestCase extends APIManagerLifecycleBaseTest {
         }
     }
 
-    /*@Test(groups = {"wso2.am"}, description = "Test invoking API that is secured only with 'API key' when back end " +
+    @Test(groups = {"wso2.am"}, description = "Test invoking API that is secured only with 'API key' when back end " +
             "JWT generation is enabled")
     public void testAPIKeyOnlySecuredAPIInvocation() throws Exception {
         APIKeyDTO apiKeyDTO = restAPIStore.generateAPIKeys(apiKeyApplicationId,
@@ -339,9 +339,9 @@ public class JWTTestCase extends APIManagerLifecycleBaseTest {
         Header[] responseHeaders = response.getAllHeaders();
         Header jwtheader = pickHeader(responseHeaders, JWT_ASSERTION_HEADER);
         Assert.assertNotNull(jwtheader, JWT_ASSERTION_HEADER + " is not available in the backend request.");
-    }*/
+    }
 
-    /*@Test(groups = {"wso2.am"}, description = "Backend JWT Token Generation for API Key Based App")
+    @Test(groups = {"wso2.am"}, description = "Backend JWT Token Generation for API Key Based App")
     public void testEnableJWTAndClaimsForAPIKeyApp() throws Exception {
         APIKeyDTO apiKeyDTO = restAPIStore.generateAPIKeys(apiKeyApplicationId,
                 ApplicationKeyGenerateRequestDTO.KeyTypeEnum.PRODUCTION.toString(), 36000, null, null);
@@ -383,7 +383,7 @@ public class JWTTestCase extends APIManagerLifecycleBaseTest {
         assertTrue("JWT claim API context not received " + claim, claim.contains(apiContext));
         // verify wrong claims
         BackendJWTUtil.verifyWrongClaims(jsonObject);
-    }*/
+    }
 
     @Test(groups = {"wso2.am"}, description = "Backend JWT Token Generation with Client Credentials Grant Type")
     public void testBackendJWTWithClientCredentialsGrant() throws Exception {

--- a/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/jwt/jwtdecoding/JWTDecodingTestCase.java
+++ b/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/jwt/jwtdecoding/JWTDecodingTestCase.java
@@ -123,7 +123,7 @@ public class JWTDecodingTestCase extends APIManagerLifecycleBaseTest {
                 APIMIntegrationConstants.IS_API_EXISTS);
     }
 
-    /*@Test(groups = { "wso2.am" }, description = "Generate keys and invoking custom application")
+    @Test(groups = { "wso2.am" }, description = "Generate keys and invoking custom application")
     public void testJWTDecodingforCustomApplication() throws Exception {
 
         //Call the API with apikey
@@ -157,7 +157,7 @@ public class JWTDecodingTestCase extends APIManagerLifecycleBaseTest {
         HttpResponse decodingFourthResponse = decodingTokenHttpClient.execute(decodingThirdGet);
         Assert.assertEquals(decodingFourthResponse.getStatusLine().getStatusCode(), Response.Status.OK.getStatusCode(),
                 "Response code mismatched when api invocation");
-    }*/
+    }
 
     @AfterClass(alwaysRun = true) public void destroy() throws Exception {
         userManagementClient.deleteUser(enduserName);

--- a/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/websocket/WebSocketAPITestCase.java
+++ b/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/websocket/WebSocketAPITestCase.java
@@ -472,7 +472,7 @@ public class WebSocketAPITestCase extends APIMIntegrationBaseTest {
         }
     }
 
-    /*@Test(description = "Invoke API using API key when API Key authentication is not enabled",
+    @Test(description = "Invoke API using API key when API Key authentication is not enabled",
             dependsOnMethods = "testWebSocketAPIInvalidTokenInvocation")
     public void testWebSocketAPIInvocationUsingAPIKeyWhenAPIKeyAuthenticationDisabled() throws Exception {
 
@@ -495,9 +495,9 @@ public class WebSocketAPITestCase extends APIMIntegrationBaseTest {
             }
             client.stop();
         }
-    }*/
+    }
 
-    /*@Test(description = "Invoke API using API key",
+    @Test(description = "Invoke API using API key",
             dependsOnMethods = "testWebSocketAPIInvocationUsingAPIKeyWhenAPIKeyAuthenticationDisabled")
     public void testWebSocketAPIInvocationUsingAPIKey() throws Exception {
 
@@ -522,7 +522,7 @@ public class WebSocketAPITestCase extends APIMIntegrationBaseTest {
         } finally {
             client.stop();
         }
-    }*/
+    }
 
     @Test(description = "Invoke API using OAuth access token when OAuth authentication is not enabled",
             dependsOnMethods = "testWebSocketAPIInvocationUsingAPIKey")
@@ -547,7 +547,7 @@ public class WebSocketAPITestCase extends APIMIntegrationBaseTest {
         }
     }
 
-    /*@Test(description = "Invoke API using Expired API key",
+    @Test(description = "Invoke API using Expired API key",
             dependsOnMethods = "testWebSocketAPIInvocationUsingOAuthWhenOAuthAuthenticationDisabled")
     public void testWebSocketAPIInvocationUsingExpiredAPIKey() throws Exception {
 
@@ -571,9 +571,9 @@ public class WebSocketAPITestCase extends APIMIntegrationBaseTest {
             }
             client.stop();
         }
-    }*/
+    }
 
-    /*@Test(description = "Invoke API using API key generated using IP restrictions",
+    @Test(description = "Invoke API using API key generated using IP restrictions",
             dependsOnMethods = "testWebSocketAPIInvocationUsingExpiredAPIKey")
     public void testWebSocketAPIInvocationUsingAPIKeyGeneratedUsingIPRestrictions() throws Exception {
 
@@ -590,9 +590,9 @@ public class WebSocketAPITestCase extends APIMIntegrationBaseTest {
         } finally {
             client.stop();
         }
-    }*/
+    }
 
-    /*@Test(description = "Invoke API using an API key restricted for another IP",
+    @Test(description = "Invoke API using an API key restricted for another IP",
             dependsOnMethods = "testWebSocketAPIInvocationUsingAPIKeyGeneratedUsingIPRestrictions")
     public void testWebSocketAPIInvocationUsingAPIKeyRestrictedForAnotherIP() throws Exception {
 
@@ -616,9 +616,9 @@ public class WebSocketAPITestCase extends APIMIntegrationBaseTest {
             }
             client.stop();
         }
-    }*/
+    }
 
-    /*@Test(description = "Invoke API using API key generated using Referer restrictions",
+    @Test(description = "Invoke API using API key generated using Referer restrictions",
             dependsOnMethods = "testWebSocketAPIInvocationUsingAPIKeyRestrictedForAnotherIP")
     public void testWebSocketAPIInvocationUsingAPIKeyGeneratedUsingRefererRestrictions() throws Exception {
 
@@ -637,9 +637,9 @@ public class WebSocketAPITestCase extends APIMIntegrationBaseTest {
         } finally {
             client.stop();
         }
-    }*/
+    }
 
-    /*@Test(description = "Invoke API using API key restricted for another Referer",
+    @Test(description = "Invoke API using API key restricted for another Referer",
             dependsOnMethods = "testWebSocketAPIInvocationUsingAPIKeyGeneratedUsingRefererRestrictions")
     public void testWebSocketAPIInvocationUsingAPIKeyGeneratedForAnotherReferer() throws Exception {
 
@@ -665,7 +665,7 @@ public class WebSocketAPITestCase extends APIMIntegrationBaseTest {
             }
             client.stop();
         }
-    }*/
+    }
 
     @Test(description = "Create WebSocket API with malformed context",
             dependsOnMethods = "testWebSocketAPIRemoveEndpoint")

--- a/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/websocket/WebSocketAPITestCase.java
+++ b/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/websocket/WebSocketAPITestCase.java
@@ -524,8 +524,8 @@ public class WebSocketAPITestCase extends APIMIntegrationBaseTest {
         }
     }*/
 
-//    @Test(description = "Invoke API using OAuth access token when OAuth authentication is not enabled",
-//            dependsOnMethods = "testWebSocketAPIInvocationUsingAPIKey")
+    @Test(description = "Invoke API using OAuth access token when OAuth authentication is not enabled",
+            dependsOnMethods = "testWebSocketAPIInvocationUsingAPIKey")
     public void testWebSocketAPIInvocationUsingOAuthWhenOAuthAuthenticationDisabled() throws Exception {
 
         WebSocketClient client = new WebSocketClient();

--- a/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -37,8 +37,7 @@
             <class name="org.wso2.am.integration.tests.api.APICreationTestCase"/>
             <class name="org.wso2.am.integration.tests.other.APIInvocationWithMessageTypeProperty"/>
             <class name="org.wso2.am.integration.tests.other.AdvancedConfigurationsTestCase"/>
-            <!-- Comment out JWT API Key related tests until the JWT generation class is added to the test -->
-<!--            <class name="org.wso2.am.integration.tests.aiapi.AIAPITestCase"/>-->
+            <class name="org.wso2.am.integration.tests.aiapi.AIAPITestCase"/>
             <class name="org.wso2.am.integration.tests.mcp.MCPServerTestCase"/>
         </classes>
     </test>


### PR DESCRIPTION
Reverts wso2/product-apim#14001

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Re-enabled multiple API security and integration test cases covering API key authentication, JWT validation, header handling, WebSocket APIs, application sharing, and AI API functionality.
  * Activated test suite configuration to include additional test coverage for API security scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->