### PR TITLE
Add ApiKeyMediator block to api_product_template.xml

### DIFF
--- a/all-in-one-apim/modules/distribution/resources/api_templates/api_product_template.xml
+++ b/all-in-one-apim/modules/distribution/resources/api_templates/api_product_template.xml
@@ -35,6 +35,17 @@
 
         ## IF endpoint secured
         #if($endpointsecurity.enabled)
+        #if($endpointsecurity.type == "apikey" || $endpointsecurity.type == "APIKEY")
+<class name="org.wso2.carbon.apimgt.gateway.mediators.ApiKeyMediator">
+<property name="apiKeyIdentifier" value="$util.escapeXml($endpointsecurity.apiKeyIdentifier)" type="STRING"/>
+<property name="apiKeyIdentifierType" value="$util.escapeXml($endpointsecurity.apiKeyIdentifierType)" type="STRING"/>
+#if($isSecureVaultEnabled)
+<property name="apiKeyValue" expression="wso2:vault-lookup('$endpointsecurity.apiKeyValue')" type="STRING"/>
+#else
+<property name="apiKeyValue" value="$util.escapeXml($endpointsecurity.apiKeyValue)" type="STRING"/>
+#end
+</class>
+        #else
         #if($endpointsecurity.type == "basic" || $endpointsecurity.type == "BASIC")
         #if($isSecureVaultEnabled)
 <property xmlns="http://ws.apache.org/ns/synapse" name="password" expression="wso2:vault-lookup('$endpointsecurity.alias')"/>
@@ -95,6 +106,7 @@
 #end
 #end
 </class>
+        #end
         #end
         #end
         #end

--- a/api-control-plane/modules/distribution/resources/api_templates/api_product_template.xml
+++ b/api-control-plane/modules/distribution/resources/api_templates/api_product_template.xml
@@ -35,6 +35,17 @@
 
         ## IF endpoint secured
         #if($endpointsecurity.enabled)
+        #if($endpointsecurity.type == "apikey" || $endpointsecurity.type == "APIKEY")
+<class name="org.wso2.carbon.apimgt.gateway.mediators.ApiKeyMediator">
+<property name="apiKeyIdentifier" value="$util.escapeXml($endpointsecurity.apiKeyIdentifier)" type="STRING"/>
+<property name="apiKeyIdentifierType" value="$util.escapeXml($endpointsecurity.apiKeyIdentifierType)" type="STRING"/>
+#if($isSecureVaultEnabled)
+<property name="apiKeyValue" expression="wso2:vault-lookup('$endpointsecurity.apiKeyValue')" type="STRING"/>
+#else
+<property name="apiKeyValue" value="$util.escapeXml($endpointsecurity.apiKeyValue)" type="STRING"/>
+#end
+</class>
+        #else
         #if($endpointsecurity.type == "basic" || $endpointsecurity.type == "BASIC")
         #if($isSecureVaultEnabled)
 <property xmlns="http://ws.apache.org/ns/synapse" name="password" expression="wso2:vault-lookup('$endpointsecurity.alias')"/>
@@ -95,6 +106,7 @@
 #end
 #end
 </class>
+        #end
         #end
         #end
         #end

--- a/gateway/modules/distribution/resources/api_templates/api_product_template.xml
+++ b/gateway/modules/distribution/resources/api_templates/api_product_template.xml
@@ -35,6 +35,17 @@
 
         ## IF endpoint secured
         #if($endpointsecurity.enabled)
+        #if($endpointsecurity.type == "apikey" || $endpointsecurity.type == "APIKEY")
+<class name="org.wso2.carbon.apimgt.gateway.mediators.ApiKeyMediator">
+<property name="apiKeyIdentifier" value="$util.escapeXml($endpointsecurity.apiKeyIdentifier)" type="STRING"/>
+<property name="apiKeyIdentifierType" value="$util.escapeXml($endpointsecurity.apiKeyIdentifierType)" type="STRING"/>
+#if($isSecureVaultEnabled)
+<property name="apiKeyValue" expression="wso2:vault-lookup('$endpointsecurity.apiKeyValue')" type="STRING"/>
+#else
+<property name="apiKeyValue" value="$util.escapeXml($endpointsecurity.apiKeyValue)" type="STRING"/>
+#end
+</class>
+        #else
         #if($endpointsecurity.type == "basic" || $endpointsecurity.type == "BASIC")
         #if($isSecureVaultEnabled)
 <property xmlns="http://ws.apache.org/ns/synapse" name="password" expression="wso2:vault-lookup('$endpointsecurity.alias')"/>
@@ -95,6 +106,7 @@
 #end
 #end
 </class>
+        #end
         #end
         #end
         #end

--- a/traffic-manager/modules/distribution/resources/api_templates/api_product_template.xml
+++ b/traffic-manager/modules/distribution/resources/api_templates/api_product_template.xml
@@ -35,6 +35,17 @@
 
         ## IF endpoint secured
         #if($endpointsecurity.enabled)
+        #if($endpointsecurity.type == "apikey" || $endpointsecurity.type == "APIKEY")
+<class name="org.wso2.carbon.apimgt.gateway.mediators.ApiKeyMediator">
+<property name="apiKeyIdentifier" value="$util.escapeXml($endpointsecurity.apiKeyIdentifier)" type="STRING"/>
+<property name="apiKeyIdentifierType" value="$util.escapeXml($endpointsecurity.apiKeyIdentifierType)" type="STRING"/>
+#if($isSecureVaultEnabled)
+<property name="apiKeyValue" expression="wso2:vault-lookup('$endpointsecurity.apiKeyValue')" type="STRING"/>
+#else
+<property name="apiKeyValue" value="$util.escapeXml($endpointsecurity.apiKeyValue)" type="STRING"/>
+#end
+</class>
+        #else
         #if($endpointsecurity.type == "basic" || $endpointsecurity.type == "BASIC")
         #if($isSecureVaultEnabled)
 <property xmlns="http://ws.apache.org/ns/synapse" name="password" expression="wso2:vault-lookup('$endpointsecurity.alias')"/>
@@ -95,6 +106,7 @@
 #end
 #end
 </class>
+        #end
         #end
         #end
         #end


### PR DESCRIPTION
## Summary
- API Products were missing the `ApiKeyMediator` configuration in their Velocity template (`api_product_template.xml`)
- This caused API key endpoint security headers (e.g., `x-api-key` for AI APIs) to never be forwarded to backend services when accessed through an API Product
- Added the same `apikey` handling block that exists in `velocity_template.xml` (used for regular APIs) to all four copies of `api_product_template.xml`

## Related
- Fixes https://github.com/wso2/api-manager/issues/4856
- Companion PR: https://github.com/wso2/carbon-apimgt/pull/13731

## Test plan
- [x] Verified: API Product with AI API (Anthropic) endpoint security correctly forwards `x-api-key` header to backend
- [x] Standalone AI API returns `"invalid x-api-key"` (key sent, expected with dummy key)
- [x] API Product returns `"invalid x-api-key"` (key sent — was previously `"x-api-key header is required"`)
- [x] No Velocity template errors during deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added API key authentication type for endpoint security configurations across APIM modules
  * Supports API key values stored directly or in secure vault for enhanced security flexibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->