### PR TITLE
Update default version for Universal Gateway

### DIFF
--- a/all-in-one-apim/modules/distribution/product/src/main/resources/conf/default.json
+++ b/all-in-one-apim/modules/distribution/product/src/main/resources/conf/default.json
@@ -285,7 +285,7 @@
   "apim.publisher.subscriber_claims": "http://wso2.org/claims/givenname,http://wso2.org/claims/lastname,http://wso2.org/claims/emailaddress,http://wso2.org/claims/organization",
   "apim.publisher.enable_portal_configuration_only_mode": false,
   "apim.jwt_authenitcation.subscription_validation_via_km": true,
-  "apim.universal_gateway.version": "0.11.0",
+  "apim.universal_gateway.versions": ["1.0.0"],
   "keystore.ssl_profile.default.servers": "*",
   "keystore.listener_profile.ssl_verify_client" : "optional",
   "keystore.listener_profile.bind_address" : "0.0.0.0",

--- a/api-control-plane/modules/distribution/product/src/main/resources/conf/default.json
+++ b/api-control-plane/modules/distribution/product/src/main/resources/conf/default.json
@@ -283,7 +283,7 @@
   "apim.publisher.subscriber_claims": "http://wso2.org/claims/givenname,http://wso2.org/claims/lastname,http://wso2.org/claims/emailaddress,http://wso2.org/claims/organization",
   "apim.publisher.enable_portal_configuration_only_mode": false,
   "apim.jwt_authenitcation.subscription_validation_via_km": true,
-  "apim.universal_gateway.version": "0.11.0",
+  "apim.universal_gateway.versions": ["1.0.0"],
   "keystore.ssl_profile.default.servers": "*",
   "keystore.listener_profile.ssl_verify_client" : "optional",
   "keystore.listener_profile.bind_address" : "0.0.0.0",


### PR DESCRIPTION
This pull request updates the configuration for the Universal Gateway versioning in two different `default.json` files. The main change is to replace the single string value for the Universal Gateway version with an array of version strings, updating the version from "0.11.0" to "1.0.0".

Configuration updates:

* Changed the `apim.universal_gateway.version` property from a single string ("0.11.0") to an array property `apim.universal_gateway.versions` with the value `["1.0.0"]` in both `all-in-one-apim/modules/distribution/product/src/main/resources/conf/default.json` [[1]](diffhunk://#diff-e0b9f3bc583f6fefd5cfb6086273a9f520c432f64d58d6efc57c45ba3f79a2d5L288-R288) and `api-control-plane/modules/distribution/product/src/main/resources/conf/default.json` [[2]](diffhunk://#diff-ee154602b2f15fb82562a87cf630a0771210658c9aa7494f03b4b6464f222503L286-R286).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Universal Gateway to version 1.0.0.
  * Modified configuration format for version management to support list-based structure, enabling improved multi-version support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->