### PR TITLE
Remove duplicate dependancies

### DIFF
--- a/all-in-one-apim/pom.xml
+++ b/all-in-one-apim/pom.xml
@@ -1300,7 +1300,7 @@
 
         <project.scm.id>scm-server</project.scm.id>
 
-        <carbon.analytics.common.version>5.4.4</carbon.analytics.common.version>
+        <carbon.analytics.common.version>5.4.6</carbon.analytics.common.version>
 
         <!-- APIM Portals Component Version -->
         <carbon.apimgt.ui.version>9.3.177</carbon.apimgt.ui.version>
@@ -1311,7 +1311,7 @@
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 
         <!-- Carbon Registry -->
-        <carbon.registry.version>4.9.8</carbon.registry.version>
+        <carbon.registry.version>4.9.10</carbon.registry.version>
         <carbon.registry.package.import.version.range>[4.7.0, 5.0.0)</carbon.registry.package.import.version.range>
 
 
@@ -1337,7 +1337,7 @@
         <carbon.identity-inbound-auth-oauth.version>6.14.12</carbon.identity-inbound-auth-oauth.version>
         <carbon.identity-data-publisher-oauth.version>1.9.0</carbon.identity-data-publisher-oauth.version>
         <carbon.identity-user-ws.version>5.10.0</carbon.identity-user-ws.version>
-        <carbon.identity-inbound-auth-openid.version>5.12.1</carbon.identity-inbound-auth-openid.version>
+        <carbon.identity-inbound-auth-openid.version>5.12.2</carbon.identity-inbound-auth-openid.version>
         <org.wso2.carbon.identity.local.auth.api.version>2.6.0</org.wso2.carbon.identity.local.auth.api.version>
         <carbon.identity-local-auth-basicauth.version>6.10.0</carbon.identity-local-auth-basicauth.version>
         <carbon.identity-outbound-auth-samlsso.version>5.11.2</carbon.identity-outbound-auth-samlsso.version>
@@ -1436,7 +1436,7 @@
         <carbon.metrics.version>1.4.0</carbon.metrics.version>
         <!-- MB Features -->
 
-        <carbon.messaging.version>3.4.0</carbon.messaging.version>
+        <carbon.messaging.version>3.4.1</carbon.messaging.version>
         <carbon.event-processing.version>2.4.2</carbon.event-processing.version>
         <andes.version>3.4.1</andes.version>
         <orbit.version.geronimo-jms_1.1_spec>1.1.1.wso2v1</orbit.version.geronimo-jms_1.1_spec>

--- a/api-control-plane/pom.xml
+++ b/api-control-plane/pom.xml
@@ -1279,7 +1279,7 @@
 
         <project.scm.id>scm-server</project.scm.id>
 
-        <carbon.analytics.common.version>5.4.4</carbon.analytics.common.version>
+        <carbon.analytics.common.version>5.4.6</carbon.analytics.common.version>
 
         <!-- APIM Portals Component Version -->
          <carbon.apimgt.ui.version>9.3.177</carbon.apimgt.ui.version>
@@ -1290,7 +1290,7 @@
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 
         <!-- Carbon Registry -->
-        <carbon.registry.version>4.9.8</carbon.registry.version>
+        <carbon.registry.version>4.9.10</carbon.registry.version>
         <carbon.registry.package.import.version.range>[4.7.0, 5.0.0)</carbon.registry.package.import.version.range>
 
 
@@ -1316,7 +1316,7 @@
         <carbon.identity-inbound-auth-oauth.version>6.14.12</carbon.identity-inbound-auth-oauth.version>
         <carbon.identity-data-publisher-oauth.version>1.9.0</carbon.identity-data-publisher-oauth.version>
         <carbon.identity-user-ws.version>5.10.0</carbon.identity-user-ws.version>
-        <carbon.identity-inbound-auth-openid.version>5.12.1</carbon.identity-inbound-auth-openid.version>
+        <carbon.identity-inbound-auth-openid.version>5.12.2</carbon.identity-inbound-auth-openid.version>
         <org.wso2.carbon.identity.local.auth.api.version>2.6.0</org.wso2.carbon.identity.local.auth.api.version>
         <carbon.identity-local-auth-basicauth.version>6.10.0</carbon.identity-local-auth-basicauth.version>
         <carbon.identity-outbound-auth-samlsso.version>5.11.2</carbon.identity-outbound-auth-samlsso.version>
@@ -1415,7 +1415,7 @@
         <carbon.metrics.version>1.4.0</carbon.metrics.version>
         <!-- MB Features -->
 
-        <carbon.messaging.version>3.4.0</carbon.messaging.version>
+        <carbon.messaging.version>3.4.1</carbon.messaging.version>
         <carbon.event-processing.version>2.4.2</carbon.event-processing.version>
         <andes.version>3.4.1</andes.version>
         <orbit.version.geronimo-jms_1.1_spec>1.1.1.wso2v1</orbit.version.geronimo-jms_1.1_spec>

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -1279,7 +1279,7 @@
 
         <project.scm.id>scm-server</project.scm.id>
 
-        <carbon.analytics.common.version>5.4.4</carbon.analytics.common.version>
+        <carbon.analytics.common.version>5.4.6</carbon.analytics.common.version>
 
         <!-- APIM Portals Component Version -->
         <carbon.apimgt.ui.version>9.3.177</carbon.apimgt.ui.version>
@@ -1290,7 +1290,7 @@
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 
         <!-- Carbon Registry -->
-        <carbon.registry.version>4.9.8</carbon.registry.version>
+        <carbon.registry.version>4.9.10</carbon.registry.version>
         <carbon.registry.package.import.version.range>[4.7.0, 5.0.0)</carbon.registry.package.import.version.range>
 
 
@@ -1316,7 +1316,7 @@
         <carbon.identity-inbound-auth-oauth.version>6.14.12</carbon.identity-inbound-auth-oauth.version>
         <carbon.identity-data-publisher-oauth.version>1.9.0</carbon.identity-data-publisher-oauth.version>
         <carbon.identity-user-ws.version>5.10.0</carbon.identity-user-ws.version>
-        <carbon.identity-inbound-auth-openid.version>5.12.1</carbon.identity-inbound-auth-openid.version>
+        <carbon.identity-inbound-auth-openid.version>5.12.2</carbon.identity-inbound-auth-openid.version>
         <org.wso2.carbon.identity.local.auth.api.version>2.6.0</org.wso2.carbon.identity.local.auth.api.version>
         <carbon.identity-local-auth-basicauth.version>6.10.0</carbon.identity-local-auth-basicauth.version>
         <carbon.identity-outbound-auth-samlsso.version>5.11.2</carbon.identity-outbound-auth-samlsso.version>
@@ -1415,7 +1415,7 @@
         <carbon.metrics.version>1.4.0</carbon.metrics.version>
         <!-- MB Features -->
 
-        <carbon.messaging.version>3.4.0</carbon.messaging.version>
+        <carbon.messaging.version>3.4.1</carbon.messaging.version>
         <carbon.event-processing.version>2.4.2</carbon.event-processing.version>
         <andes.version>3.4.1</andes.version>
         <orbit.version.geronimo-jms_1.1_spec>1.1.1.wso2v1</orbit.version.geronimo-jms_1.1_spec>

--- a/traffic-manager/pom.xml
+++ b/traffic-manager/pom.xml
@@ -1281,7 +1281,7 @@
 
         <project.scm.id>scm-server</project.scm.id>
 
-        <carbon.analytics.common.version>5.4.4</carbon.analytics.common.version>
+        <carbon.analytics.common.version>5.4.6</carbon.analytics.common.version>
 
         <!-- APIM Portals Component Version -->
         <carbon.apimgt.ui.version>9.3.177</carbon.apimgt.ui.version>
@@ -1292,7 +1292,7 @@
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 
         <!-- Carbon Registry -->
-        <carbon.registry.version>4.9.8</carbon.registry.version>
+        <carbon.registry.version>4.9.10</carbon.registry.version>
         <carbon.registry.package.import.version.range>[4.7.0, 5.0.0)</carbon.registry.package.import.version.range>
 
 
@@ -1318,7 +1318,7 @@
         <carbon.identity-inbound-auth-oauth.version>6.14.12</carbon.identity-inbound-auth-oauth.version>
         <carbon.identity-data-publisher-oauth.version>1.9.0</carbon.identity-data-publisher-oauth.version>
         <carbon.identity-user-ws.version>5.10.0</carbon.identity-user-ws.version>
-        <carbon.identity-inbound-auth-openid.version>5.12.1</carbon.identity-inbound-auth-openid.version>
+        <carbon.identity-inbound-auth-openid.version>5.12.2</carbon.identity-inbound-auth-openid.version>
         <org.wso2.carbon.identity.local.auth.api.version>2.6.0</org.wso2.carbon.identity.local.auth.api.version>
         <carbon.identity-local-auth-basicauth.version>6.10.0</carbon.identity-local-auth-basicauth.version>
         <carbon.identity-outbound-auth-samlsso.version>5.11.2</carbon.identity-outbound-auth-samlsso.version>
@@ -1417,7 +1417,7 @@
         <carbon.metrics.version>1.4.0</carbon.metrics.version>
         <!-- MB Features -->
 
-        <carbon.messaging.version>3.4.0</carbon.messaging.version>
+        <carbon.messaging.version>3.4.1</carbon.messaging.version>
         <carbon.event-processing.version>2.4.2</carbon.event-processing.version>
         <andes.version>3.4.1</andes.version>
         <orbit.version.geronimo-jms_1.1_spec>1.1.1.wso2v1</orbit.version.geronimo-jms_1.1_spec>


### PR DESCRIPTION
Remove duplicate dependancies related to 
- Guava and guava.failureaccess
- httpclient

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependencies for analytics, registry, authentication, and messaging components to latest stable versions across multiple product modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->