### PR TITLE
Remove policy version from common policy retrieval 

### DIFF
--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/BaseSteps.java
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/BaseSteps.java
@@ -18,6 +18,7 @@
 package org.wso2.am.integration.cucumbertests.stepdefinitions;
 
 import com.google.gson.JsonObject;
+import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
@@ -300,7 +301,38 @@ public class BaseSteps {
             throw new IOException("No value found in response for field: " + responseField);
         }
 
-        TestContext.set(Utils.normalizeContextKey(contextKey), String.valueOf(value));
+        if (value instanceof net.minidev.json.JSONArray) {
+            value = new JSONArray(value.toString());
+        } else if (value instanceof net.minidev.json.JSONObject) {
+            value = new JSONObject(value.toString());
+        }
+        TestContext.set(Utils.normalizeContextKey(contextKey), value);
+    }
+
+    /**
+     * Extracts a field value from a JSONObject stored in TestContext and stores it under another key.
+     *
+     * @param sourceKey TestContext key containing the JSONObject
+     * @param fieldName JSON field name to extract
+     * @param targetKey TestContext key to store the extracted value
+     */
+    @And("I extract field {string} from {string} and store it as {string}")
+    public void iExtractFieldFromAndStoreItAs(String fieldName, String sourceKey, String targetKey) {
+
+        Object contextValue = Utils.resolveFromContext(sourceKey);
+
+        if (!(contextValue instanceof JSONObject jsonObject)) {
+            throw new IllegalStateException("Expected JSONObject in TestContext for key '" + sourceKey
+                            + "' but found: " + contextValue.getClass().getSimpleName());
+        }
+
+        if (!jsonObject.has(fieldName)) {
+            throw new AssertionError(
+                    "Field '" + fieldName + "' not found in object stored under key '" + sourceKey + "'");
+        }
+
+        Object extractedValue = jsonObject.get(fieldName);
+        TestContext.set(Utils.normalizeContextKey(targetKey), extractedValue);
     }
 
     /**
@@ -637,5 +669,33 @@ public class BaseSteps {
         Object parsedValue = Utils.parseConfigValue(valueToAppend);
         jsonArray.put(parsedValue);
         TestContext.set(Utils.normalizeContextKey(arrayContextKey), jsonArray.toString());
+    }
+
+    /**
+     * Finds a resource in the JSON array stored in the given context key using
+     * the provided property-value pairs, and stores the matched object in TestContext.
+     * Expected DataTable format:
+     * | name    | addHeader |
+     * | version | v1        |
+     *
+     * @param contextKey the TestContext key containing the JSONArray
+     * @param outputKey the TestContext key to store the matched JSONObject
+     * @param propertiesTable property-value pairs used for matching
+     */
+    @And("I find the resource with following properties in {string} as {string}")
+    public void iFindTheResourceWithFollowingPropertiesInAs(String contextKey, String outputKey,
+                                                            DataTable propertiesTable) {
+
+        Object contextValue = Utils.resolveFromContext(contextKey);
+        if (!(contextValue instanceof JSONArray jsonArray)) {
+            throw new IllegalStateException(
+                    "Expected JSONArray in TestContext for key '" + contextKey + "' but found: "
+                            + contextValue.getClass().getSimpleName());
+        }
+
+        Map<String, String> expectedProperties = propertiesTable.asMap(String.class, String.class);
+
+        JSONObject matchedObject = Utils.findMatchingJsonObjectInArray(jsonArray, expectedProperties);
+        TestContext.set(Utils.normalizeContextKey(outputKey), matchedObject);
     }
 }

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/PublisherBaseSteps.java
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/PublisherBaseSteps.java
@@ -1201,41 +1201,6 @@ public class PublisherBaseSteps {
     }
 
     /**
-     * Searches for a resource ( policy etc.) by name and version
-     *
-     * @param key The field name to extract (typically "id")
-     * @param name The name of the resource to search for
-     * @param version The version of the resource to search for
-     * @param id Context key where the found ID will be stored
-     */
-    @When("I find the {string} with name {string} and version {string} as {string}")
-    public void iFindTheResourceWithNameAndVersionAs(String key, String name, String version, String id) {
-
-        HttpResponse response = (HttpResponse) TestContext.get("httpResponse");
-        JSONObject json = new JSONObject(response.getData());
-
-        JSONArray list = json.getJSONArray("list");
-        String foundId = null;
-
-        for (int i = 0; i < list.length(); i++) {
-            JSONObject item = list.getJSONObject(i);
-            String itemName = item.optString("name", "");
-            String itemVersion = item.optString("version", "");
-
-            if (itemName.equalsIgnoreCase(name) && itemVersion.equalsIgnoreCase(version)) {
-                foundId = item.getString(key);
-                break;
-            }
-        }
-
-        if (foundId == null) {
-            throw new AssertionError("Resource with name '" + name + "' and version '" + version + "' not found");
-        }
-
-        TestContext.set(id, foundId);
-    }
-
-    /**
      * Creates a new common (shared) operation policy.
      * Common policies can be reused across multiple APIs.
      *
@@ -1377,16 +1342,14 @@ public class PublisherBaseSteps {
     /**
      * Creates a new global policy (gateway policy) from a common policy.
      *
-     * @param globalPolicyId Context key where the created global policy ID will be stored
      * @param policyPayload Context key containing the global policy creation JSON payload
      */
-    @And("I create a new global policy as {string} with {string}")
-    public void iCreateANewGlobalPolicyAs(String globalPolicyId, String policyPayload) throws IOException {
+    @And("I create a new global policy with payload {string}")
+    public void iCreateANewGlobalPolicy(String policyPayload) throws IOException {
 
-        String jsonPayload = Utils.resolveFromContext(policyPayload).toString();
-        String commonPolicyId = Utils.resolveFromContext("existingPolicyId").toString();
-
-        jsonPayload = jsonPayload.replace("<id>", commonPolicyId);
+        String jsonPayloadTemplate = Utils.resolveFromContext(policyPayload).toString();
+        // Replace {{existingPolicyId}} with the actual id of the common policy
+        String jsonPayload = Utils.resolveContextPlaceholders(jsonPayloadTemplate);
 
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION,
@@ -1397,7 +1360,6 @@ public class PublisherBaseSteps {
                         Constants.CONTENT_TYPES.APPLICATION_JSON);
 
         TestContext.set("httpResponse", response);
-        TestContext.set(globalPolicyId, Utils.extractValueFromPayload(response.getData(), "id"));
     }
 
     /**

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/utils/Utils.java
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/utils/Utils.java
@@ -31,6 +31,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.jaxen.JaxenException;
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.apache.commons.lang3.StringUtils;
 import org.json.JSONTokener;
@@ -664,6 +665,13 @@ public class Utils {
         return String.join(Constants.COMPOSITE_KEY_DELIMITER, dbType, tenantDomain, username);
     }
 
+    /**
+     * Replaces context placeholders (for example, {{subscriptionId}}) in the given input
+     * string with the corresponding values stored in {@link TestContext}.
+     *
+     * @param input the input string
+     * @return the input string with all placeholders resolved using values from {@link TestContext}
+     */
     public static String resolveContextPlaceholders(String input) {
         if (input == null) {
             return null;
@@ -685,5 +693,36 @@ public class Utils {
 
         matcher.appendTail(resolved);
         return resolved.toString();
+    }
+
+    /**
+     * Returns the first JSON object in the given array that matches all provided key-value pairs.
+     *
+     * @param list the JSON array containing objects to search
+     * @param criteria map of field names and expected values to match
+     * @return the matching JSON object
+     * @throws AssertionError if no matching object is found
+     */
+    public static JSONObject findMatchingJsonObjectInArray(JSONArray list, Map<String, String> criteria) {
+
+        for (int i = 0; i < list.length(); i++) {
+            JSONObject item = list.getJSONObject(i);
+            boolean matches = true;
+
+            for (Map.Entry<String, String> entry : criteria.entrySet()) {
+                String actualValue = item.optString(entry.getKey(), "");
+                String expectedValue = entry.getValue();
+
+                if (!actualValue.equalsIgnoreCase(expectedValue)) {
+                    matches = false;
+                    break;
+                }
+            }
+
+            if (matches) {
+                return item;
+            }
+        }
+        throw new AssertionError("No matching resource found for criteria: " + criteria);
     }
 }

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/artifacts/payloads/policySpecFiles/custom_global_policy.json
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/artifacts/payloads/policySpecFiles/custom_global_policy.json
@@ -6,8 +6,8 @@
     "request": [
       {
         "policyName": "addHeader",
-        "policyVersion": "v2",
-        "policyId": "<id>",
+        "policyVersion": "{{existingPolicyVersion}}",
+        "policyId": "{{existingPolicyId}}",
         "parameters": {
           "headerName": "custom_global_header",
           "headerValue": "custom_global_value"
@@ -17,8 +17,8 @@
     "response": [
       {
         "policyName": "addHeader",
-        "policyVersion": "v2",
-        "policyId": "<id>",
+        "policyVersion": "{{existingPolicyVersion}}",
+        "policyId": "{{existingPolicyId}}",
         "parameters": {
           "headerName": "custom_global_header",
           "headerValue": "custom_global_value"

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/features/migration/api_policies.feature
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/features/migration/api_policies.feature
@@ -223,13 +223,20 @@ Feature: Migrated Applications
   Scenario: Find existing common policies
     When I retrieve available common policies
     Then The response status code should be 200
-    And I find the "id" with name "addHeader" and version "v2" as "existingPolicyId"
+    And I extract response field "list" and store it as "<commonPoliciesList>"
+    # Get the id and version of the "Add header" common policy
+    Then I find the resource with following properties in "<commonPoliciesList>" as "<existingPolicy>"
+      | name | addHeader |
+    And I extract field "id" from "<existingPolicy>" and store it as "<existingPolicyId>"
+    And I extract field "version" from "<existingPolicy>" and store it as "<existingPolicyVersion>"
 
   # Step 6: Add global policies
   Scenario: Add Global policies
     When I put JSON payload from file "artifacts/payloads/policySpecFiles/custom_global_policy.json" in context as "globalPolicyPayload"
-    And I create a new global policy as "globalPolicyId" with "globalPolicyPayload"
+    # Add "Add header" common policy as a global policy
+    And I create a new global policy with payload "globalPolicyPayload"
     Then The response status code should be 201
+    And I extract response field "id" and store it as "globalPolicyId"
 
     When I put the following JSON payload in context as "gatewayPolicyPayload"
       """


### PR DESCRIPTION
### Description

This PR removes the dependency on a fixed common policy version (e.g: add header v2) when retrieving existing policies, preventing test failures caused by version changes. 
It also introduces reusable steps to find resources from JSON lists using a given set of properties and values (such as name and version), and to extract required fields from stored JSON objects.