### PR TITLE
Preserve the content-transfer-encoding in multipart/form data

### DIFF
--- a/all-in-one-apim/modules/distribution/product/src/main/resources/conf/default.json
+++ b/all-in-one-apim/modules/distribution/product/src/main/resources/conf/default.json
@@ -72,6 +72,8 @@
   "message_formatter.json": "org.apache.synapse.commons.json.JsonStreamFormatter",
   "message_formatter.json_badgerfish": "org.apache.axis2.json.JSONBadgerfishMessageFormatter",
   "message_formatter.text_javascript": "org.apache.axis2.json.JSONMessageFormatter",
+  "message_formatters.disableSendingMultipartPartCharset": true,
+  "message_formatters.preserveMultipartPartContentTransferEncoding": true,
   "message_formatter.text_plain": "org.apache.axis2.format.PlainTextFormatter",
   "message_formatter.text_eventstream": "org.apache.axis2.format.PlainTextFormatter",
   "message_formatter.text_html": "org.apache.axis2.transport.http.ApplicationXMLFormatter",

--- a/all-in-one-apim/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/axis2.xml.j2
+++ b/all-in-one-apim/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/axis2.xml.j2
@@ -46,6 +46,9 @@
     <!-- Configuration to disable appending the charset parameter to each part of multipart form data -->
     <parameter name="disableSendingMultipartPartCharset" locked="false">{{message_formatter.options.disableSendingMultipartPartCharset | default(true)}}</parameter>
 
+    <!-- Configuration to preserve Content-Transfer-Encoding header in each part of multipart form data -->
+    <parameter name="preserveMultipartPartContentTransferEncoding" locked="false">{{message_formatter.options.preserveMultipartPartContentTransferEncoding | default(true)}}</parameter>
+
     <!-- Sandesha2 persistance storage manager -->
     <parameter name="Sandesha2StorageManager" locked="false">inmemory</parameter>
 

--- a/all-in-one-apim/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/axis2_ControlPlane.xml.j2
+++ b/all-in-one-apim/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/axis2_ControlPlane.xml.j2
@@ -46,6 +46,9 @@
     <!-- Configuration to disable appending the charset parameter to each part of multipart form data -->
     <parameter name="disableSendingMultipartPartCharset" locked="false">{{message_formatter.options.disableSendingMultipartPartCharset | default(true)}}</parameter>
 
+    <!-- Configuration to preserve Content-Transfer-Encoding header in each part of multipart form data -->
+    <parameter name="preserveMultipartPartContentTransferEncoding" locked="false">{{message_formatter.options.preserveMultipartPartContentTransferEncoding | default(true)}}</parameter>
+
     <!-- Sandesha2 persistance storage manager -->
     <parameter name="Sandesha2StorageManager" locked="false">inmemory</parameter>
 

--- a/all-in-one-apim/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/axis2_KM.xml.j2
+++ b/all-in-one-apim/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/axis2_KM.xml.j2
@@ -46,6 +46,9 @@
     <!-- Configuration to disable appending the charset parameter to each part of multipart form data -->
     <parameter name="disableSendingMultipartPartCharset" locked="false">{{message_formatter.options.disableSendingMultipartPartCharset | default(true)}}</parameter>
 
+    <!-- Configuration to preserve Content-Transfer-Encoding header in each part of multipart form data -->
+    <parameter name="preserveMultipartPartContentTransferEncoding" locked="false">{{message_formatter.options.preserveMultipartPartContentTransferEncoding | default(true)}}</parameter>
+
     <!-- Sandesha2 persistance storage manager -->
     <parameter name="Sandesha2StorageManager" locked="false">inmemory</parameter>
 

--- a/all-in-one-apim/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/axis2_TM.xml.j2
+++ b/all-in-one-apim/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/axis2_TM.xml.j2
@@ -62,6 +62,9 @@
     <!-- Configuration to disable appending the charset parameter to each part of multipart form data -->
     <parameter name="disableSendingMultipartPartCharset" locked="false">{{message_formatter.options.disableSendingMultipartPartCharset | default(true)}}</parameter>
 
+    <!-- Configuration to preserve Content-Transfer-Encoding header in each part of multipart form data -->
+    <parameter name="preserveMultipartPartContentTransferEncoding" locked="false">{{message_formatter.options.preserveMultipartPartContentTransferEncoding | default(true)}}</parameter>
+
     <parameter name="Sandesha2StorageManager">inmemory</parameter>
 
     <!-- This deployment interceptor will be called whenever before a module is initialized or

--- a/all-in-one-apim/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/axis2_blocking_client.xml.j2
+++ b/all-in-one-apim/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/axis2_blocking_client.xml.j2
@@ -91,6 +91,9 @@
     <!-- Configuration to disable appending the charset parameter to each part of multipart form data -->
     <parameter name="disableSendingMultipartPartCharset" locked="false">{{message_formatter.options.disableSendingMultipartPartCharset | default(true)}}</parameter>
 
+    <!-- Configuration to preserve Content-Transfer-Encoding header in each part of multipart form data -->
+    <parameter name="preserveMultipartPartContentTransferEncoding" locked="false">{{message_formatter.options.preserveMultipartPartContentTransferEncoding | default(true)}}</parameter>
+
     <!--POJO deployer , this will alow users to drop .class file and make that into a service-->
     <deployer extension=".class" directory="pojo" class="org.apache.axis2.deployment.POJODeployer"/>
 

--- a/all-in-one-apim/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/axis2_client.xml.j2
+++ b/all-in-one-apim/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/axis2_client.xml.j2
@@ -70,6 +70,9 @@
     <!-- Configuration to disable appending the charset parameter to each part of multipart form data -->
     <parameter name="disableSendingMultipartPartCharset" locked="false">{{message_formatter.options.disableSendingMultipartPartCharset | default(true)}}</parameter>
 
+    <!-- Configuration to preserve Content-Transfer-Encoding header in each part of multipart form data -->
+    <parameter name="preserveMultipartPartContentTransferEncoding" locked="false">{{message_formatter.options.preserveMultipartPartContentTransferEncoding | default(true)}}</parameter>
+
     <!--POJO deployer , this will alow users to drop .class file and make that into a service-->
     <deployer extension=".class" directory="pojo" class="org.apache.axis2.deployment.POJODeployer"/>
 

--- a/all-in-one-apim/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/tenant-axis2.xml.j2
+++ b/all-in-one-apim/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/tenant-axis2.xml.j2
@@ -49,6 +49,9 @@
     <!-- Configuration to disable appending the charset parameter to each part of multipart form data -->
     <parameter name="disableSendingMultipartPartCharset" locked="false">{{message_formatter.options.disableSendingMultipartPartCharset | default(true)}}</parameter>
 
+    <!-- Configuration to preserve Content-Transfer-Encoding header in each part of multipart form data -->
+    <parameter name="preserveMultipartPartContentTransferEncoding" locked="false">{{message_formatter.options.preserveMultipartPartContentTransferEncoding | default(true)}}</parameter>
+
     <!--the directory in which .aar services are deployed inside axis2 repository-->
     <parameter name="ServicesDirectory">axis2services</parameter>
 

--- a/all-in-one-apim/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/tenant-axis2_ControlPlane.xml.j2
+++ b/all-in-one-apim/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/tenant-axis2_ControlPlane.xml.j2
@@ -49,6 +49,9 @@
     <!-- Configuration to disable appending the charset parameter to each part of multipart form data -->
     <parameter name="disableSendingMultipartPartCharset" locked="false">{{message_formatter.options.disableSendingMultipartPartCharset | default(true)}}</parameter>
 
+    <!-- Configuration to preserve Content-Transfer-Encoding header in each part of multipart form data -->
+    <parameter name="preserveMultipartPartContentTransferEncoding" locked="false">{{message_formatter.options.preserveMultipartPartContentTransferEncoding | default(true)}}</parameter>
+
     <!--the directory in which .aar services are deployed inside axis2 repository-->
     <parameter name="ServicesDirectory">axis2services</parameter>
 

--- a/all-in-one-apim/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/tenant-axis2_KM.xml.j2
+++ b/all-in-one-apim/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/tenant-axis2_KM.xml.j2
@@ -49,6 +49,9 @@
     <!-- Configuration to disable appending the charset parameter to each part of multipart form data -->
     <parameter name="disableSendingMultipartPartCharset" locked="false">{{message_formatter.options.disableSendingMultipartPartCharset | default(true)}}</parameter>
 
+    <!-- Configuration to preserve Content-Transfer-Encoding header in each part of multipart form data -->
+    <parameter name="preserveMultipartPartContentTransferEncoding" locked="false">{{message_formatter.options.preserveMultipartPartContentTransferEncoding | default(true)}}</parameter>
+
     <!--the directory in which .aar services are deployed inside axis2 repository-->
     <parameter name="ServicesDirectory">axis2services</parameter>
 

--- a/api-control-plane/modules/distribution/product/src/main/resources/conf/default.json
+++ b/api-control-plane/modules/distribution/product/src/main/resources/conf/default.json
@@ -72,6 +72,8 @@
   "message_formatter.json": "org.apache.synapse.commons.json.JsonStreamFormatter",
   "message_formatter.json_badgerfish": "org.apache.axis2.json.JSONBadgerfishMessageFormatter",
   "message_formatter.text_javascript": "org.apache.axis2.json.JSONMessageFormatter",
+  "message_formatters.disableSendingMultipartPartCharset": true,
+  "message_formatters.preserveMultipartPartContentTransferEncoding": true,
   "message_formatter.text_plain": "org.apache.axis2.format.PlainTextFormatter",
   "message_formatter.text_eventstream": "org.apache.axis2.format.PlainTextFormatter",
   "message_formatter.text_html": "org.apache.axis2.transport.http.ApplicationXMLFormatter",

--- a/api-control-plane/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/axis2.xml.j2
+++ b/api-control-plane/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/axis2.xml.j2
@@ -46,6 +46,9 @@
     <!-- Configuration to disable appending the charset parameter to each part of multipart form data -->
     <parameter name="disableSendingMultipartPartCharset" locked="false">{{message_formatter.options.disableSendingMultipartPartCharset | default(true)}}</parameter>
 
+    <!-- Configuration to preserve Content-Transfer-Encoding header in each part of multipart form data -->
+    <parameter name="preserveMultipartPartContentTransferEncoding" locked="false">{{message_formatter.options.preserveMultipartPartContentTransferEncoding | default(true)}}</parameter>
+
     <!-- Sandesha2 persistance storage manager -->
     <parameter name="Sandesha2StorageManager" locked="false">inmemory</parameter>
 

--- a/api-control-plane/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/axis2_KM.xml.j2
+++ b/api-control-plane/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/axis2_KM.xml.j2
@@ -46,6 +46,9 @@
     <!-- Configuration to disable appending the charset parameter to each part of multipart form data -->
     <parameter name="disableSendingMultipartPartCharset" locked="false">{{message_formatter.options.disableSendingMultipartPartCharset | default(true)}}</parameter>
 
+    <!-- Configuration to preserve Content-Transfer-Encoding header in each part of multipart form data -->
+    <parameter name="preserveMultipartPartContentTransferEncoding" locked="false">{{message_formatter.options.preserveMultipartPartContentTransferEncoding | default(true)}}</parameter>
+
     <!-- Sandesha2 persistance storage manager -->
     <parameter name="Sandesha2StorageManager" locked="false">inmemory</parameter>
 

--- a/api-control-plane/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/axis2_blocking_client.xml.j2
+++ b/api-control-plane/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/axis2_blocking_client.xml.j2
@@ -91,6 +91,9 @@
     <!-- Configuration to disable appending the charset parameter to each part of multipart form data -->
     <parameter name="disableSendingMultipartPartCharset" locked="false">{{message_formatter.options.disableSendingMultipartPartCharset | default(true)}}</parameter>
 
+    <!-- Configuration to preserve Content-Transfer-Encoding header in each part of multipart form data -->
+    <parameter name="preserveMultipartPartContentTransferEncoding" locked="false">{{message_formatter.options.preserveMultipartPartContentTransferEncoding | default(true)}}</parameter>
+
     <!--POJO deployer , this will alow users to drop .class file and make that into a service-->
     <deployer extension=".class" directory="pojo" class="org.apache.axis2.deployment.POJODeployer"/>
 

--- a/api-control-plane/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/axis2_client.xml.j2
+++ b/api-control-plane/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/axis2_client.xml.j2
@@ -70,6 +70,9 @@
     <!-- Configuration to disable appending the charset parameter to each part of multipart form data -->
     <parameter name="disableSendingMultipartPartCharset" locked="false">{{message_formatter.options.disableSendingMultipartPartCharset | default(true)}}</parameter>
 
+    <!-- Configuration to preserve Content-Transfer-Encoding header in each part of multipart form data -->
+    <parameter name="preserveMultipartPartContentTransferEncoding" locked="false">{{message_formatter.options.preserveMultipartPartContentTransferEncoding | default(true)}}</parameter>
+
     <!--POJO deployer , this will alow users to drop .class file and make that into a service-->
     <deployer extension=".class" directory="pojo" class="org.apache.axis2.deployment.POJODeployer"/>
 

--- a/api-control-plane/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/tenant-axis2.xml.j2
+++ b/api-control-plane/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/tenant-axis2.xml.j2
@@ -49,6 +49,9 @@
     <!-- Configuration to disable appending the charset parameter to each part of multipart form data -->
     <parameter name="disableSendingMultipartPartCharset" locked="false">{{message_formatter.options.disableSendingMultipartPartCharset | default(true)}}</parameter>
 
+    <!-- Configuration to preserve Content-Transfer-Encoding header in each part of multipart form data -->
+    <parameter name="preserveMultipartPartContentTransferEncoding" locked="false">{{message_formatter.options.preserveMultipartPartContentTransferEncoding | default(true)}}</parameter>
+
     <!--the directory in which .aar services are deployed inside axis2 repository-->
     <parameter name="ServicesDirectory">axis2services</parameter>
 

--- a/api-control-plane/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/tenant-axis2_KM.xml.j2
+++ b/api-control-plane/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/tenant-axis2_KM.xml.j2
@@ -49,6 +49,9 @@
     <!-- Configuration to disable appending the charset parameter to each part of multipart form data -->
     <parameter name="disableSendingMultipartPartCharset" locked="false">{{message_formatter.options.disableSendingMultipartPartCharset | default(true)}}</parameter>
 
+    <!-- Configuration to preserve Content-Transfer-Encoding header in each part of multipart form data -->
+    <parameter name="preserveMultipartPartContentTransferEncoding" locked="false">{{message_formatter.options.preserveMultipartPartContentTransferEncoding | default(true)}}</parameter>
+
     <!--the directory in which .aar services are deployed inside axis2 repository-->
     <parameter name="ServicesDirectory">axis2services</parameter>
 

--- a/gateway/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/axis2.xml.j2
+++ b/gateway/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/axis2.xml.j2
@@ -46,6 +46,9 @@
     <!-- Configuration to disable appending the charset parameter to each part of multipart form data -->
     <parameter name="disableSendingMultipartPartCharset" locked="false">{{message_formatter.options.disableSendingMultipartPartCharset | default(true)}}</parameter>
 
+    <!-- Configuration to preserve Content-Transfer-Encoding header in each part of multipart form data -->
+    <parameter name="preserveMultipartPartContentTransferEncoding" locked="false">{{message_formatter.options.preserveMultipartPartContentTransferEncoding | default(true)}}</parameter>
+
     <!-- Sandesha2 persistance storage manager -->
     <parameter name="Sandesha2StorageManager" locked="false">inmemory</parameter>
 

--- a/gateway/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/axis2_ControlPlane.xml.j2
+++ b/gateway/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/axis2_ControlPlane.xml.j2
@@ -46,6 +46,9 @@
     <!-- Configuration to disable appending the charset parameter to each part of multipart form data -->
     <parameter name="disableSendingMultipartPartCharset" locked="false">{{message_formatter.options.disableSendingMultipartPartCharset | default(true)}}</parameter>
 
+    <!-- Configuration to preserve Content-Transfer-Encoding header in each part of multipart form data -->
+    <parameter name="preserveMultipartPartContentTransferEncoding" locked="false">{{message_formatter.options.preserveMultipartPartContentTransferEncoding | default(true)}}</parameter>
+
     <!-- Sandesha2 persistance storage manager -->
     <parameter name="Sandesha2StorageManager" locked="false">inmemory</parameter>
 

--- a/gateway/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/axis2_KM.xml.j2
+++ b/gateway/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/axis2_KM.xml.j2
@@ -46,6 +46,9 @@
     <!-- Configuration to disable appending the charset parameter to each part of multipart form data -->
     <parameter name="disableSendingMultipartPartCharset" locked="false">{{message_formatter.options.disableSendingMultipartPartCharset | default(true)}}</parameter>
 
+    <!-- Configuration to preserve Content-Transfer-Encoding header in each part of multipart form data -->
+    <parameter name="preserveMultipartPartContentTransferEncoding" locked="false">{{message_formatter.options.preserveMultipartPartContentTransferEncoding | default(true)}}</parameter>
+
     <!-- Sandesha2 persistance storage manager -->
     <parameter name="Sandesha2StorageManager" locked="false">inmemory</parameter>
 

--- a/gateway/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/axis2_TM.xml.j2
+++ b/gateway/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/axis2_TM.xml.j2
@@ -62,6 +62,9 @@
     <!-- Configuration to disable appending the charset parameter to each part of multipart form data -->
     <parameter name="disableSendingMultipartPartCharset" locked="false">{{message_formatter.options.disableSendingMultipartPartCharset | default(true)}}</parameter>
 
+    <!-- Configuration to preserve Content-Transfer-Encoding header in each part of multipart form data -->
+    <parameter name="preserveMultipartPartContentTransferEncoding" locked="false">{{message_formatter.options.preserveMultipartPartContentTransferEncoding | default(true)}}</parameter>
+
     <parameter name="Sandesha2StorageManager">inmemory</parameter>
 
     <!-- This deployment interceptor will be called whenever before a module is initialized or

--- a/gateway/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/axis2_blocking_client.xml.j2
+++ b/gateway/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/axis2_blocking_client.xml.j2
@@ -91,6 +91,9 @@
     <!-- Configuration to disable appending the charset parameter to each part of multipart form data -->
     <parameter name="disableSendingMultipartPartCharset" locked="false">{{message_formatter.options.disableSendingMultipartPartCharset | default(true)}}</parameter>
 
+    <!-- Configuration to preserve Content-Transfer-Encoding header in each part of multipart form data -->
+    <parameter name="preserveMultipartPartContentTransferEncoding" locked="false">{{message_formatter.options.preserveMultipartPartContentTransferEncoding | default(true)}}</parameter>
+
     <!--POJO deployer , this will alow users to drop .class file and make that into a service-->
     <deployer extension=".class" directory="pojo" class="org.apache.axis2.deployment.POJODeployer"/>
 

--- a/gateway/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/axis2_client.xml.j2
+++ b/gateway/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/axis2_client.xml.j2
@@ -70,6 +70,9 @@
     <!-- Configuration to disable appending the charset parameter to each part of multipart form data -->
     <parameter name="disableSendingMultipartPartCharset" locked="false">{{message_formatter.options.disableSendingMultipartPartCharset | default(true)}}</parameter>
 
+    <!-- Configuration to preserve Content-Transfer-Encoding header in each part of multipart form data -->
+    <parameter name="preserveMultipartPartContentTransferEncoding" locked="false">{{message_formatter.options.preserveMultipartPartContentTransferEncoding | default(true)}}</parameter>
+
     <!--POJO deployer , this will alow users to drop .class file and make that into a service-->
     <deployer extension=".class" directory="pojo" class="org.apache.axis2.deployment.POJODeployer"/>
 

--- a/gateway/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/tenant-axis2.xml.j2
+++ b/gateway/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/tenant-axis2.xml.j2
@@ -49,6 +49,9 @@
     <!-- Configuration to disable appending the charset parameter to each part of multipart form data -->
     <parameter name="disableSendingMultipartPartCharset" locked="false">{{message_formatter.options.disableSendingMultipartPartCharset | default(true)}}</parameter>
 
+    <!-- Configuration to preserve Content-Transfer-Encoding header in each part of multipart form data -->
+    <parameter name="preserveMultipartPartContentTransferEncoding" locked="false">{{message_formatter.options.preserveMultipartPartContentTransferEncoding | default(true)}}</parameter>
+
     <!--the directory in which .aar services are deployed inside axis2 repository-->
     <parameter name="ServicesDirectory">axis2services</parameter>
 

--- a/gateway/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/tenant-axis2_ControlPlane.xml.j2
+++ b/gateway/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/tenant-axis2_ControlPlane.xml.j2
@@ -49,6 +49,9 @@
     <!-- Configuration to disable appending the charset parameter to each part of multipart form data -->
     <parameter name="disableSendingMultipartPartCharset" locked="false">{{message_formatter.options.disableSendingMultipartPartCharset | default(true)}}</parameter>
 
+    <!-- Configuration to preserve Content-Transfer-Encoding header in each part of multipart form data -->
+    <parameter name="preserveMultipartPartContentTransferEncoding" locked="false">{{message_formatter.options.preserveMultipartPartContentTransferEncoding | default(true)}}</parameter>
+
     <!--the directory in which .aar services are deployed inside axis2 repository-->
     <parameter name="ServicesDirectory">axis2services</parameter>
 

--- a/gateway/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/tenant-axis2_KM.xml.j2
+++ b/gateway/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/tenant-axis2_KM.xml.j2
@@ -49,6 +49,9 @@
     <!-- Configuration to disable appending the charset parameter to each part of multipart form data -->
     <parameter name="disableSendingMultipartPartCharset" locked="false">{{message_formatter.options.disableSendingMultipartPartCharset | default(true)}}</parameter>
 
+    <!-- Configuration to preserve Content-Transfer-Encoding header in each part of multipart form data -->
+    <parameter name="preserveMultipartPartContentTransferEncoding" locked="false">{{message_formatter.options.preserveMultipartPartContentTransferEncoding | default(true)}}</parameter>
+
     <!--the directory in which .aar services are deployed inside axis2 repository-->
     <parameter name="ServicesDirectory">axis2services</parameter>
 

--- a/traffic-manager/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/axis2.xml.j2
+++ b/traffic-manager/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/axis2.xml.j2
@@ -62,6 +62,9 @@
     <!-- Configuration to disable appending the charset parameter to each part of multipart form data -->
     <parameter name="disableSendingMultipartPartCharset" locked="false">{{message_formatter.options.disableSendingMultipartPartCharset | default(true)}}</parameter>
 
+    <!-- Configuration to preserve Content-Transfer-Encoding header in each part of multipart form data -->
+    <parameter name="preserveMultipartPartContentTransferEncoding" locked="false">{{message_formatter.options.preserveMultipartPartContentTransferEncoding | default(true)}}</parameter>
+
     <parameter name="Sandesha2StorageManager">inmemory</parameter>
 
     <!-- This deployment interceptor will be called whenever before a module is initialized or

--- a/traffic-manager/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/axis2_blocking_client.xml.j2
+++ b/traffic-manager/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/axis2_blocking_client.xml.j2
@@ -91,6 +91,9 @@
     <!-- Configuration to disable appending the charset parameter to each part of multipart form data -->
     <parameter name="disableSendingMultipartPartCharset" locked="false">{{message_formatter.options.disableSendingMultipartPartCharset | default(true)}}</parameter>
 
+    <!-- Configuration to preserve Content-Transfer-Encoding header in each part of multipart form data -->
+    <parameter name="preserveMultipartPartContentTransferEncoding" locked="false">{{message_formatter.options.preserveMultipartPartContentTransferEncoding | default(true)}}</parameter>
+
     <!--POJO deployer , this will alow users to drop .class file and make that into a service-->
     <deployer extension=".class" directory="pojo" class="org.apache.axis2.deployment.POJODeployer"/>
 

--- a/traffic-manager/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/axis2_client.xml.j2
+++ b/traffic-manager/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/axis2_client.xml.j2
@@ -70,6 +70,9 @@
     <!-- Configuration to disable appending the charset parameter to each part of multipart form data -->
     <parameter name="disableSendingMultipartPartCharset" locked="false">{{message_formatter.options.disableSendingMultipartPartCharset | default(true)}}</parameter>
 
+    <!-- Configuration to preserve Content-Transfer-Encoding header in each part of multipart form data -->
+    <parameter name="preserveMultipartPartContentTransferEncoding" locked="false">{{message_formatter.options.preserveMultipartPartContentTransferEncoding | default(true)}}</parameter>
+
     <!--POJO deployer , this will alow users to drop .class file and make that into a service-->
     <deployer extension=".class" directory="pojo" class="org.apache.axis2.deployment.POJODeployer"/>
 

--- a/traffic-manager/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/tenant-axis2.xml.j2
+++ b/traffic-manager/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/tenant-axis2.xml.j2
@@ -49,6 +49,9 @@
     <!-- Configuration to disable appending the charset parameter to each part of multipart form data -->
     <parameter name="disableSendingMultipartPartCharset" locked="false">{{message_formatter.options.disableSendingMultipartPartCharset | default(true)}}</parameter>
 
+    <!-- Configuration to preserve Content-Transfer-Encoding header in each part of multipart form data -->
+    <parameter name="preserveMultipartPartContentTransferEncoding" locked="false">{{message_formatter.options.preserveMultipartPartContentTransferEncoding | default(true)}}</parameter>
+
     <!--the directory in which .aar services are deployed inside axis2 repository-->
     <parameter name="ServicesDirectory">axis2services</parameter>
 


### PR DESCRIPTION
This pull request adds a new configuration option to control whether the `Content-Transfer-Encoding` header is preserved in each part of multipart form data. The change introduces this option in the main configuration file and propagates it to all relevant Axis2 configuration templates.

Related to - https://github.com/wso2/api-manager/issues/4730

New configuration for multipart form data handling:

**Message Formatter Configuration Enhancements:**

* Added `message_formatters.preserveMultipartPartContentTransferEncoding` and `message_formatters.disableSendingMultipartPartCharset` options to the `default.json` configuration files for both all-in-one APIM and API Control Plane products, enabling better control over multipart message formatting. [[1]](diffhunk://#diff-e0b9f3bc583f6fefd5cfb6086273a9f520c432f64d58d6efc57c45ba3f79a2d5R75-R76) [[2]](diffhunk://#diff-ee154602b2f15fb82562a87cf630a0771210658c9aa7494f03b4b6464f222503R75-R76)

**Axis2 Configuration Template Updates:**

* Updated all Axis2 configuration templates (including `axis2.xml.j2`, `axis2_KM.xml.j2`, `axis2_TM.xml.j2`, `axis2_blocking_client.xml.j2`, `axis2_client.xml.j2`, `tenant-axis2.xml.j2`, and their control plane/tenant variants) across all-in-one APIM, API Control Plane, and Gateway products to include the new `preserveMultipartPartContentTransferEncoding` parameter, defaulting to `true`. This ensures the Content-Transfer-Encoding header is preserved in multipart form data parts. [[1]](diffhunk://#diff-b1f36b1713f00e7cf2418cb37ef398ffd3bf38b52ddb72ef7cf62227c29dfb64R49-R51) [[2]](diffhunk://#diff-a3bee8b9d5e3172074298f91d9626d0f843fa571749b7ea9fb6f89bfb82e5f3dR49-R51) [[3]](diffhunk://#diff-2f5a02b3d3c4209a01c0bd71d922f440d9a02b4a5b998bf1d0b85245fdae9c35R49-R51) [[4]](diffhunk://#diff-290cc09b63e6ccc5eadd292914c97d989eb4039bfb255b19c82ddebadc43366aR65-R67) [[5]](diffhunk://#diff-ab3e00818dd4bbc8ff9a75545e350aaa522a8f2836c61bdd362b1b7d6b658e60R94-R96) [[6]](diffhunk://#diff-998f75a9781d1e409a5d827a348c76f919280a1f7e12a031c74aa368bbf7bcc1R73-R75) [[7]](diffhunk://#diff-ca74ce5ebf68b86d38b0d4c8d906664b30264434c3731f8994394141244b4952R52-R54) [[8]](diffhunk://#diff-275a506eae8775fb380a504e922c4108696ad3823a098e49875a5654a8c5ac0bR52-R54) [[9]](diffhunk://#diff-0375e49b627f22e0ff8c25fd5f43a3e2d9a134224e16c647dcab54faa907ce47R52-R54) [[10]](diffhunk://#diff-ce2ff4feae44a8ee52664b469174fca550eb333a81a3b4ccf9714511a0eb3ca7R52-R54)