### PR TITLE
Bump azure.gwmanager.feature.version to 1.1.3

### DIFF
--- a/all-in-one-apim/pom.xml
+++ b/all-in-one-apim/pom.xml
@@ -1519,7 +1519,7 @@
 
         <!-- External Gateway Agent Versions -->
         <aws.gwmanager.feature.version>1.5.0</aws.gwmanager.feature.version>
-        <azure.gwmanager.feature.version>1.1.1</azure.gwmanager.feature.version>
+        <azure.gwmanager.feature.version>1.1.3</azure.gwmanager.feature.version>
         <kong.gwmanager.feature.version>1.1.0</kong.gwmanager.feature.version>
         <envoy.gwmanager.feature.version>1.1.0</envoy.gwmanager.feature.version>
 

--- a/api-control-plane/pom.xml
+++ b/api-control-plane/pom.xml
@@ -1497,7 +1497,7 @@
 
         <!-- External Gateway Agent Versions -->
         <aws.gwmanager.feature.version>1.5.0</aws.gwmanager.feature.version>
-        <azure.gwmanager.feature.version>1.1.1</azure.gwmanager.feature.version>
+        <azure.gwmanager.feature.version>1.1.3</azure.gwmanager.feature.version>
         <kong.gwmanager.feature.version>1.1.0</kong.gwmanager.feature.version>
         <envoy.gwmanager.feature.version>1.1.0</envoy.gwmanager.feature.version>
 


### PR DESCRIPTION
### Description
This pull request updates the Azure gateway manager feature version in both the `all-in-one-apim` and `api-control-plane` modules. The version is incremented from `1.1.1` to `1.1.3` to ensure both modules use the latest Azure gateway manager features and fixes.

Dependency version updates:

* Updated the `<azure.gwmanager.feature.version>` property from `1.1.1` to `1.1.3` in `all-in-one-apim/pom.xml`
* Updated the `<azure.gwmanager.feature.version>` property from `1.1.1` to `1.1.3` in `api-control-plane/pom.xml`