### PR TITLE
Add disableSendingMultipartPartCharset config default value

### DIFF
--- a/all-in-one-apim/modules/distribution/product/src/main/resources/conf/default.json
+++ b/all-in-one-apim/modules/distribution/product/src/main/resources/conf/default.json
@@ -72,6 +72,7 @@
   "message_formatter.json": "org.apache.synapse.commons.json.JsonStreamFormatter",
   "message_formatter.json_badgerfish": "org.apache.axis2.json.JSONBadgerfishMessageFormatter",
   "message_formatter.text_javascript": "org.apache.axis2.json.JSONMessageFormatter",
+  "message_formatters.disableSendingMultipartPartCharset": true,
   "message_formatter.text_plain": "org.apache.axis2.format.PlainTextFormatter",
   "message_formatter.text_eventstream": "org.apache.axis2.format.PlainTextFormatter",
   "message_formatter.text_html": "org.apache.axis2.transport.http.ApplicationXMLFormatter",

--- a/api-control-plane/modules/distribution/product/src/main/resources/conf/default.json
+++ b/api-control-plane/modules/distribution/product/src/main/resources/conf/default.json
@@ -72,6 +72,7 @@
   "message_formatter.json": "org.apache.synapse.commons.json.JsonStreamFormatter",
   "message_formatter.json_badgerfish": "org.apache.axis2.json.JSONBadgerfishMessageFormatter",
   "message_formatter.text_javascript": "org.apache.axis2.json.JSONMessageFormatter",
+  "message_formatters.disableSendingMultipartPartCharset": true,
   "message_formatter.text_plain": "org.apache.axis2.format.PlainTextFormatter",
   "message_formatter.text_eventstream": "org.apache.axis2.format.PlainTextFormatter",
   "message_formatter.text_html": "org.apache.axis2.transport.http.ApplicationXMLFormatter",

--- a/gateway/modules/distribution/product/src/main/resources/conf/default.json
+++ b/gateway/modules/distribution/product/src/main/resources/conf/default.json
@@ -87,6 +87,7 @@
   "message_formatter.json": "org.apache.synapse.commons.json.JsonStreamFormatter",
   "message_formatter.json_badgerfish": "org.apache.axis2.json.JSONBadgerfishMessageFormatter",
   "message_formatter.text_javascript": "org.apache.axis2.json.JSONMessageFormatter",
+  "message_formatters.disableSendingMultipartPartCharset": true,
   "message_formatter.text_plain": "org.apache.axis2.format.PlainTextFormatter",
   "message_formatter.text_eventstream": "org.apache.axis2.format.PlainTextFormatter",
   "message_formatter.text_html": "org.apache.axis2.transport.http.ApplicationXMLFormatter",

--- a/traffic-manager/modules/distribution/product/src/main/resources/conf/default.json
+++ b/traffic-manager/modules/distribution/product/src/main/resources/conf/default.json
@@ -87,6 +87,7 @@
   "message_formatter.json": "org.apache.synapse.commons.json.JsonStreamFormatter",
   "message_formatter.json_badgerfish": "org.apache.axis2.json.JSONBadgerfishMessageFormatter",
   "message_formatter.text_javascript": "org.apache.axis2.json.JSONMessageFormatter",
+  "message_formatters.disableSendingMultipartPartCharset": true,
   "message_formatter.text_plain": "org.apache.axis2.format.PlainTextFormatter",
   "message_formatter.text_eventstream": "org.apache.axis2.format.PlainTextFormatter",
   "message_formatter.text_html": "org.apache.axis2.transport.http.ApplicationXMLFormatter",


### PR DESCRIPTION
This pull request introduces the default value of the `disableSendingMultipartPartCharset` configuration.

Related to - https://github.com/wso2/api-manager/issues/4488

Configuration updates for message formatting:

* Added `"message_formatters.disableSendingMultipartPartCharset": true` to the `default.json` configuration files in both `all-in-one-apim` and `api-control-plane` modules to prevent the charset from being sent in multipart message parts. [[1]](diffhunk://#diff-e0b9f3bc583f6fefd5cfb6086273a9f520c432f64d58d6efc57c45ba3f79a2d5R75) [[2]](diffhunk://#diff-ee154602b2f15fb82562a87cf630a0771210658c9aa7494f03b4b6464f222503R75)