### PR TITLE
Bump carbon.apimgt.ui.version

### DIFF
--- a/all-in-one-apim/pom.xml
+++ b/all-in-one-apim/pom.xml
@@ -1303,7 +1303,7 @@
         <carbon.analytics.common.version>5.4.9</carbon.analytics.common.version>
 
         <!-- APIM Portals Component Version -->
-        <carbon.apimgt.ui.version>9.3.189</carbon.apimgt.ui.version>
+        <carbon.apimgt.ui.version>9.3.190</carbon.apimgt.ui.version>
 
         <!-- APIM Component Version -->
         <carbon.apimgt.version>9.33.118</carbon.apimgt.version>

--- a/api-control-plane/pom.xml
+++ b/api-control-plane/pom.xml
@@ -1282,7 +1282,7 @@
         <carbon.analytics.common.version>5.4.9</carbon.analytics.common.version>
 
         <!-- APIM Portals Component Version -->
-         <carbon.apimgt.ui.version>9.3.189</carbon.apimgt.ui.version>
+         <carbon.apimgt.ui.version>9.3.190</carbon.apimgt.ui.version>
 
         <!-- APIM Component Version -->
         <carbon.apimgt.version>9.33.118</carbon.apimgt.version>

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -1282,7 +1282,7 @@
         <carbon.analytics.common.version>5.4.9</carbon.analytics.common.version>
 
         <!-- APIM Portals Component Version -->
-        <carbon.apimgt.ui.version>9.3.189</carbon.apimgt.ui.version>
+        <carbon.apimgt.ui.version>9.3.190</carbon.apimgt.ui.version>
 
         <!-- APIM Component Version -->
         <carbon.apimgt.version>9.33.118</carbon.apimgt.version>

--- a/traffic-manager/pom.xml
+++ b/traffic-manager/pom.xml
@@ -1284,7 +1284,7 @@
         <carbon.analytics.common.version>5.4.9</carbon.analytics.common.version>
 
         <!-- APIM Portals Component Version -->
-        <carbon.apimgt.ui.version>9.3.189</carbon.apimgt.ui.version>
+        <carbon.apimgt.ui.version>9.3.190</carbon.apimgt.ui.version>
 
         <!-- APIM Component Version -->
         <carbon.apimgt.version>9.33.118</carbon.apimgt.version>


### PR DESCRIPTION
This pull request updates the APIM Portals Component version across multiple modules to ensure consistency and include the latest features and fixes.

Version updates:

* Bumped the `carbon.apimgt.ui.version` from `9.3.189` to `9.3.190` in the following `pom.xml` files:
  - `all-in-one-apim/pom.xml`
  - `api-control-plane/pom.xml`
  - `gateway/pom.xml`
  - `traffic-manager/pom.xml`