### PR TITLE
Refactor migrated API scope update tests to validate only the scopes 

### DIFF
--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/pom.xml
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/pom.xml
@@ -40,6 +40,10 @@
             <version>${json.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.skyscreamer</groupId>
+            <artifactId>jsonassert</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.cucumber</groupId>
             <artifactId>cucumber-java</artifactId>
             <version>${cucumber.version}</version>

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/BaseSteps.java
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/BaseSteps.java
@@ -310,6 +310,37 @@ public class BaseSteps {
     }
 
     /**
+     * Extracts a field or JSONPath value from a JSON payload stored in TestContext
+     * and stores the extracted value back in TestContext.
+     *
+     * @param sourceContextKey context key containing the source JSON payload
+     * @param fieldPath field name or JSONPath to extract from the stored payload
+     * @param targetContextKey context key under which the extracted value should be stored
+     * @throws IOException if the source payload is missing or the field is not found
+     */
+    @And("I extract field {string} from json payload {string} and store it as {string}")
+    public void iExtractFieldFromJsonPayloadAndStoreItAs(String fieldPath, String sourceContextKey,
+                                                         String targetContextKey) throws IOException {
+
+        Object sourceValue = Utils.resolveFromContext(sourceContextKey);
+
+        Object value = Utils.extractValueFromPayload(String.valueOf(sourceValue), fieldPath);
+        if (value == null) {
+            throw new IOException("No value found in payload for field: " + fieldPath);
+        }
+
+        if (value instanceof net.minidev.json.JSONArray) {
+            value = new JSONArray(value.toString());
+        } else if (value instanceof net.minidev.json.JSONObject) {
+            value = new JSONObject(value.toString());
+        }
+
+        TestContext.set(Utils.normalizeContextKey(targetContextKey), value);
+        System.out.println("Extracted value for field '" + fieldPath + "' from payload '"
+                + sourceContextKey + "': " + value);
+    }
+
+    /**
      * Extracts a field value from a JSONObject stored in TestContext and stores it under another key.
      *
      * @param sourceKey TestContext key containing the JSONObject
@@ -697,5 +728,18 @@ public class BaseSteps {
 
         JSONObject matchedObject = Utils.findMatchingJsonObjectInArray(jsonArray, expectedProperties);
         TestContext.set(Utils.normalizeContextKey(outputKey), matchedObject);
+    }
+
+    /**
+     * Verifies that the actual value stored in context matches the expected value.
+     *
+     * @param actualKey TestContext key containing the actual value
+     * @param expectedValue expected value as a string
+     */
+    @Then("the actual value of {string} should match the expected value:")
+    public void theActualValueShouldMatchTheExpectedValue(String actualKey, String expectedValue) {
+
+        Object actualValue = Utils.resolveFromContext(actualKey);
+        Utils.assertConfigValueMatchesExpectedValue(actualValue, expectedValue);
     }
 }

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/utils/Utils.java
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/utils/Utils.java
@@ -35,6 +35,8 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import org.apache.commons.lang3.StringUtils;
 import org.json.JSONTokener;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.testng.Assert;
 import org.wso2.am.integration.test.utils.Constants;
 import org.wso2.carbon.automation.engine.context.beans.Tenant;
@@ -146,7 +148,7 @@ public class Utils {
         return baseUrl + Constants.DEFAULT_DEVPORTAL + "subscriptions/" + subscriptionId;
     }
 
-    public static String getAllSubscriptionsURL(String baseUrl,String apiId, String applicationId, String groupId,
+    public static String getAllSubscriptionsURL(String baseUrl, String apiId, String applicationId, String groupId,
                                                 Integer offset, Integer limit) {
 
         if (StringUtils.isBlank(apiId) && StringUtils.isBlank(applicationId)) {
@@ -183,11 +185,11 @@ public class Utils {
         return baseUrl + Constants.DEFAULT_DEVPORTAL + "applications";
     }
 
-    public static String getApplicationSearchURL(String baseUrl, String applicationName ) {
+    public static String getApplicationSearchURL(String baseUrl, String applicationName) {
         return baseUrl + Constants.DEFAULT_DEVPORTAL + "applications?query=" + URLEncoder.encode(applicationName, StandardCharsets.UTF_8);
     }
 
-    public static String getApiSearchURL(String baseUrl, String query ) {
+    public static String getApiSearchURL(String baseUrl, String query) {
         return baseUrl + Constants.DEFAULT_DEVPORTAL + "apis?query=" + URLEncoder.encode(query, StandardCharsets.UTF_8);
     }
 
@@ -208,7 +210,7 @@ public class Utils {
     }
 
     public static String getApplicationAllKeys(String baseUrl, String applicationId) {
-        return baseUrl + Constants.DEFAULT_DEVPORTAL + "applications/" + applicationId + "/oauth-keys" ;
+        return baseUrl + Constants.DEFAULT_DEVPORTAL + "applications/" + applicationId + "/oauth-keys";
     }
 
     public static String getGenerateApplicationSecretURL(String baseUrl, String applicationId, String keyMappingId) {
@@ -232,7 +234,7 @@ public class Utils {
     }
 
     public static String getGenerateAPIKeyURL(String baseUrl, String applicationId) {
-        return baseUrl + Constants.DEFAULT_DEVPORTAL + "applications/" + applicationId + "/api-keys/PRODUCTION/generate" ;
+        return baseUrl + Constants.DEFAULT_DEVPORTAL + "applications/" + applicationId + "/api-keys/PRODUCTION/generate";
     }
 
     public static String getUpdateKey(String baseUrl, String applicationId, String keyMappingId) {
@@ -328,7 +330,7 @@ public class Utils {
         return baseUrl + Constants.DEFAULT_APIM_API_DEPLOYER + "apis/import-graphql-schema";
     }
 
-    public static String getAPIProvider(String baseUrl,String apiId, String providerName ) {
+    public static String getAPIProvider(String baseUrl, String apiId, String providerName) {
         return baseUrl + Constants.DEFAULT_APIM_ADMIN + "apis/" + apiId + "/change-provider?provider=" + providerName;
     }
 
@@ -550,9 +552,8 @@ public class Utils {
      * Evaluates the given XPath on the SOAP/XML string and returns the text of all
      * matched elements.
      *
-     *
-     * @param soapXml         XML content
-     * @param axiomXPathExpr  XPath expression selecting elements
+     * @param soapXml        XML content
+     * @param axiomXPathExpr XPath expression selecting elements
      * @return list of text values from matched elements
      * @throws JaxenException if the XPath is invalid or evaluation fails
      */
@@ -594,7 +595,7 @@ public class Utils {
      *
      * @param value the JSON value as a string
      * @return the parsed value as a JSONObject, JSONArray, String,
-     *         Number, Boolean, or JSONObject.NULL
+     * Number, Boolean, or JSONObject.NULL
      * @throws IllegalArgumentException if the input is null, blank, or invalid JSON
      */
     public static Object parseConfigValue(String value) {
@@ -614,14 +615,6 @@ public class Utils {
      * @param key      key to look up in the JSON content
      * @return value associated with the key
      * @throws Exception if the file is missing, unreadable, or the key is not found
-     */
-    /**
-     * Reads a key-value file from the classpath and returns the value for the given key.
-     *
-     * @param filePath path to the file
-     * @param key lookup key
-     * @return value mapped to the key as Object
-     * @throws Exception if the file is missing or the key is not found
      */
     public static Object getValueFromFileByKey(String filePath, String key) throws Exception {
         InputStream inputStream = Utils.class.getClassLoader().getResourceAsStream(filePath);
@@ -698,7 +691,7 @@ public class Utils {
     /**
      * Returns the first JSON object in the given array that matches all provided key-value pairs.
      *
-     * @param list the JSON array containing objects to search
+     * @param list     the JSON array containing objects to search
      * @param criteria map of field names and expected values to match
      * @return the matching JSON object
      * @throws AssertionError if no matching object is found
@@ -724,5 +717,55 @@ public class Utils {
             }
         }
         throw new AssertionError("No matching resource found for criteria: " + criteria);
+    }
+
+    /**
+     * Asserts that the actual configuration value matches the expected value.
+     * Supports booleans, numbers, JSON arrays, JSON objects, and strings.
+     *
+     * @param actualValue   the actual value to compare
+     * @param expectedValue the expected value as a string
+     * @throws AssertionError if values do not match
+     */
+    public static void assertConfigValueMatchesExpectedValue(Object actualValue, String expectedValue) {
+
+        if (StringUtils.isBlank(expectedValue)) {
+            Assert.assertNull(actualValue, "Expected null/empty but got: " + actualValue);
+            return;
+        }
+
+        if (actualValue == null) {
+            Assert.fail("Expected value '" + expectedValue + "' but got null");
+        }
+
+        try {
+            switch (actualValue) {
+                case Boolean b -> {
+                    Assert.assertEquals(String.valueOf(actualValue), expectedValue, "Boolean values do not match");
+                    return;
+                }
+                case Number number -> {
+                    Assert.assertEquals(String.valueOf(actualValue), expectedValue, "Numeric values do not match");
+                    return;
+                }
+                case JSONArray actualArray -> {
+                    JSONArray expectedArray = new JSONArray(expectedValue);
+                    JSONAssert.assertEquals(expectedArray, actualArray, JSONCompareMode.LENIENT);
+                    return;
+                }
+                case JSONObject actualObject -> {
+                    JSONObject expectedObject = new JSONObject(expectedValue);
+                    JSONAssert.assertEquals(expectedObject, actualObject, JSONCompareMode.LENIENT);
+                    return;
+                }
+                default -> {
+                }
+            }
+
+            Assert.assertEquals(String.valueOf(actualValue), expectedValue, "String values do not match");
+        } catch (Exception e) {
+            log.error("Error comparing values. Actual: " + actualValue + ", Expected: " + expectedValue, e);
+            throw new AssertionError("Comparison failed: " + e.getMessage(), e);
+        }
     }
 }

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/features/migration/migrated_api_update.feature
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/features/migration/migrated_api_update.feature
@@ -72,23 +72,33 @@ Feature: Migrated API Updates
     When I retrieve the "apis" resource with id "<apiID>"
     And I put the response payload in context as "<apiUpdatePayload>"
     # Extract the current operations array from the payload
-    And I get the value from json payload "<apiUpdatePayload>" at path "<configType>" and store it as "<updatedConfigValue>"
+    And I get the value from json payload "<apiUpdatePayload>" at path "operations" and store it as "<operationArray>"
     # Append the new resource to the extracted operations array
-    And I append the following value to the json array "<updatedConfigValue>":
+    And I append the following value to the json array "<operationArray>":
       """
       <configValue>
       """
     # Update the API payload with the modified operations array
-    When I update the "apis" resource "<apiID>" and "<apiUpdatePayload>" with configuration type "<configType>" and value from context "<updatedConfigValue>"
+    When I update the "apis" resource "<apiID>" and "<apiUpdatePayload>" with configuration type "operations" and value from context "<operationArray>"
     Then The response status code should be 200
-    When I retrieve the "apis" resource with id "<apiID>"
-    And The "apis" resource should reflect the updated "<configType>" as value from context "<updatedConfigValue>"
 
-# Modify Rest APIs with existing scopes
+    # Validate the added resource and scopes in the response
+    When I retrieve the "apis" resource with id "<apiID>"
+    And I put the response payload in context as "<apiResponsePayload>"
+    And I extract response field "operations" and store it as "<responseOperationArray>"
+    Then I find the resource with following properties in "<responseOperationArray>" as "<newlyAddedResourceInResponse>"
+      | verb   | <expectedVerb>   |
+      | target | <expectedTarget> |
+    And I extract field "scopes" from json payload "<newlyAddedResourceInResponse>" and store it as "<newlyAddedScopes>"
+    And the actual value of "<newlyAddedScopes>" should match the expected value:
+      """
+      <scopes>
+      """
+
     Examples:
-      | apiID            |  apiUpdatePayload      | configType   | updatedConfigValue    | configValue                                                                                           |
-      | RestApiId        | ADPRestAPIPayload      | operations   | operationArray        | {"payloadSchema":null,"operationPolicies":{"request":[],"response":[],"fault":[]},"verb":"POST","uriMapping":null,"throttlingPolicy":"Unlimited","target":"/newlyAddedResource","amznResourceContentEncode":null,"usedProductIds":[],"amznResourceName":null,"id":"","scopes":["adp-local-scope-without-roles"],"amznResourceTimeout":null,"authType":"Application & Application User","operationHubPolicies":[]}    |
-      | GraphQLApiId     | ADPGraphQLAPIPayload   | operations   | operationArray        | {"payloadSchema":null,"operationPolicies":{"request":[],"response":[],"fault":[]},"verb":"QUERY","uriMapping":null,"throttlingPolicy":"Unlimited","target":"/newlyAddedResource","amznResourceContentEncode":null,"usedProductIds":[],"amznResourceName":null,"id":"","scopes":["adp-admin","adp-film-subscriber"],"amznResourceTimeout":null,"authType":"Application & Application User","operationHubPolicies":[]}   |
+      | apiID        | apiUpdatePayload     | expectedVerb | expectedTarget      | scopes                               | configValue |
+      | RestApiId    | ADPRestAPIPayload    | POST         | newlyAddedResource  | ["adp-local-scope-without-roles"]    | {"payloadSchema":null,"operationPolicies":{"request":[],"response":[],"fault":[]},"verb":"POST","uriMapping":null,"throttlingPolicy":"Unlimited","target":"newlyAddedResource","amznResourceContentEncode":null,"usedProductIds":[],"amznResourceName":null,"id":"","scopes":["adp-local-scope-without-roles"],"amznResourceTimeout":null,"authType":"Application & Application User","operationHubPolicies":[]} |
+      | GraphQLApiId | ADPGraphQLAPIPayload | QUERY        | newlyAddedResource  | ["adp-admin","adp-film-subscriber"]  | {"payloadSchema":null,"operationPolicies":{"request":[],"response":[],"fault":[]},"verb":"QUERY","uriMapping":null,"throttlingPolicy":"Unlimited","target":"newlyAddedResource","amznResourceContentEncode":null,"usedProductIds":[],"amznResourceName":null,"id":"","scopes":["adp-admin","adp-film-subscriber"],"amznResourceTimeout":null,"authType":"Application & Application User","operationHubPolicies":[]} |
 
 
 # Step 5: Custom properties (refer artifacts/payloads/MigratedAPIs for existing configs)

--- a/all-in-one-apim/pom.xml
+++ b/all-in-one-apim/pom.xml
@@ -798,6 +798,11 @@
                 <version>${org.slf4j.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.skyscreamer</groupId>
+                <artifactId>jsonassert</artifactId>
+                <version>${org.skyscreamer.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.ws.security.wso2</groupId>
                 <artifactId>wss4j</artifactId>
                 <version>${wss4j.version}</version>
@@ -1599,6 +1604,7 @@
 
         <slf4j.version>1.7.36</slf4j.version>
         <logback.version>1.2.11</logback.version>
+        <org.skyscreamer.version>1.5.0</org.skyscreamer.version>
     </properties>
 
 </project>


### PR DESCRIPTION
### Description

This PR updates the `migrated API scope update` test scenario to validate only the scopes of the newly added resource instead of comparing the entire operations array. Previously, the test performed a full array comparison, which made it sensitive to differences in ordering and unrelated fields within the operations payload.

In addition, this PR introduces a helper method `assertConfigValueMatchesExpectedValue(...)` to handle comparisons across different data types such as JSON objects, arrays, booleans, numbers, and strings. The method uses `JSONAssert` with `JSONCompareMode.LENIENT` for both JSON arrays and objects, allowing order-insensitive and flexible comparisons.