### PR TITLE
Bind a custom SSL socket factory

### DIFF
--- a/all-in-one-apim/modules/integration-v2/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/utils/Constants.java
+++ b/all-in-one-apim/modules/integration-v2/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/utils/Constants.java
@@ -29,6 +29,8 @@ public class Constants {
     public static final String XML_AMPERSAND = "&amp;";
     public static final Pattern CONTEXT_PLACEHOLDER_PATTERN = Pattern.compile("\\{\\{([^}]+)}}");
 
+    public static final String HTTP_SCHEME = "http";
+    public static final String HTTPS_SCHEME = "https";
 
     public static final long DEPLOYMENT_WAIT_TIME = 60 * 1000;
     public static final long UNDEPLOYMENT_WAIT_TIME = 30 * 1000;

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/utils/clients/SimpleHTTPClient.java
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/utils/clients/SimpleHTTPClient.java
@@ -29,6 +29,10 @@ import org.apache.http.client.methods.HttpPatch;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.config.Registry;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.conn.socket.ConnectionSocketFactory;
+import org.apache.http.conn.socket.PlainConnectionSocketFactory;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.conn.ssl.TrustAllStrategy;
@@ -72,10 +76,17 @@ public class SimpleHTTPClient {
                     .build();
 
             // Disable hostname mismatch checks
-            SSLConnectionSocketFactory csf = new SSLConnectionSocketFactory(
-                    sslContext, NoopHostnameVerifier.INSTANCE);
+            SSLConnectionSocketFactory sslSocketFactory =
+                    new SSLConnectionSocketFactory(sslContext, NoopHostnameVerifier.INSTANCE);
 
-            PoolingHttpClientConnectionManager connManager = new PoolingHttpClientConnectionManager();
+            Registry<ConnectionSocketFactory> socketFactoryRegistry =
+                    RegistryBuilder.<ConnectionSocketFactory>create()
+                            .register(Constants.HTTP_SCHEME, PlainConnectionSocketFactory.getSocketFactory())
+                            .register(Constants.HTTPS_SCHEME, sslSocketFactory)
+                            .build();
+
+            PoolingHttpClientConnectionManager connManager =
+                    new PoolingHttpClientConnectionManager(socketFactoryRegistry);
             connManager.setMaxTotal(1000);        // total max connections
             connManager.setDefaultMaxPerRoute(100);   // max connections per route
 
@@ -85,7 +96,6 @@ public class SimpleHTTPClient {
 
             this.client = HttpClients.custom()
                     .setConnectionManager(connManager)
-                    .setSSLSocketFactory(csf)
                     .setDefaultRequestConfig(requestConfig)
                     .evictExpiredConnections()
                     .disableCookieManagement() // Disable sending or storing cookies


### PR DESCRIPTION
### Description
This PR registers a custom `SSLConnectionSocketFactory` with the HTTP client’s connection manager such that all HTTPS requests use the configured SSL context and hostname verifier.