### PR TITLE
Add AzureUMIMediator support for UMI auth in AI API endpoint seq template

### DIFF
--- a/all-in-one-apim/modules/distribution/resources/api_templates/ai_api_endpoints_seq_template.xml
+++ b/all-in-one-apim/modules/distribution/resources/api_templates/ai_api_endpoints_seq_template.xml
@@ -47,6 +47,9 @@
 #end
 </class>
         #end
+        #if( $endpoint.authenticationType == "umi" || $endpoint.authenticationType == "UMI")
+<class name="org.wso2.carbon.apimgt.gateway.mediators.AzureUMIMediator"/>
+        #end
         #end
 
         #if( $endpoint && $endpoint.endpointUuid )

--- a/api-control-plane/modules/distribution/resources/api_templates/ai_api_endpoints_seq_template.xml
+++ b/api-control-plane/modules/distribution/resources/api_templates/ai_api_endpoints_seq_template.xml
@@ -47,6 +47,9 @@
 #end
 </class>
         #end
+        #if( $endpoint.authenticationType == "umi" || $endpoint.authenticationType == "UMI")
+<class name="org.wso2.carbon.apimgt.gateway.mediators.AzureUMIMediator"/>
+        #end
         #end
 
         #if( $endpoint && $endpoint.endpointUuid )


### PR DESCRIPTION
## Description

Adds the update artifact file for the Velocity template `ai_api_endpoints_seq_template.xml` that generates Synapse endpoint sequences to inject `AzureUMIMediator` when the endpoint authentication type is `umi`.

## Related Issue

-  https://github.com/wso2/api-manager/issues/5043

## What's changed

- Added a conditional block in the endpoint sequence template: when
  `endpoint.authenticationType` is `umi` (case-insensitive), the
  `org.wso2.carbon.apimgt.gateway.mediators.AzureUMIMediator` class mediator is inserted
  into the generated sequence
- The mediator acquires an Azure Workload Identity Bearer token and injects it as the
  `Authorization` header on every outbound request to the backend

## Backward compatibility

The new block is fully conditional — existing `apikey`, `aws`, and `none` authentication
types are unaffected.
