### PR TITLE
Fix incorrect JDK version in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@
 
 To build the WSO2 API Manager distribution from source, follow these steps:
 
-1. Install **Java SE Development Kit 11**.
+1. Install **Java SE Development Kit 21**.
 2. Install **Apache Maven 3.x.x** ([Download Maven](https://maven.apache.org/download.cgi#)).
 3. Clone the repository: `https://github.com/wso2/product-apim.git` or download the source.
 4. From the `product-apim` directory, run one of the following Maven commands:


### PR DESCRIPTION
README.md states the product supports JDK 21, but CONTRIBUTING.md instructed contributors to install JDK 11. Aligning the build instructions with the supported JDK to prevent contributor confusion.