### PR TITLE
test: assert admin app search results match query

### DIFF
--- a/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/restapi/admin/ApplicationsSearchByNameOrOwnerTestCase.java
+++ b/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/restapi/admin/ApplicationsSearchByNameOrOwnerTestCase.java
@@ -154,6 +154,7 @@ public class ApplicationsSearchByNameOrOwnerTestCase extends APIMIntegrationBase
 
             assert applicationInfoList != null;
             assertTrue(verifyApplicationSearchQueryResults(expectedApplications, applicationInfoList));
+            assertTrue(verifyAllApplicationsMatchQuery(searchQuery, applicationInfoList));
         }
     }
 
@@ -172,6 +173,7 @@ public class ApplicationsSearchByNameOrOwnerTestCase extends APIMIntegrationBase
 
             assert applicationInfoList != null;
             assertTrue(verifyApplicationSearchQueryResults(expectedApplications, applicationInfoList));
+            assertTrue(verifyAllApplicationsMatchQuery(searchQuery, applicationInfoList));
         }
     }
 
@@ -190,6 +192,7 @@ public class ApplicationsSearchByNameOrOwnerTestCase extends APIMIntegrationBase
 
             assert applicationInfoList != null;
             assertTrue(verifyApplicationSearchQueryResults(expectedApplications, applicationInfoList));
+            assertTrue(verifyAllApplicationsMatchQuery(searchQuery, applicationInfoList));
         }
     }
 
@@ -208,6 +211,7 @@ public class ApplicationsSearchByNameOrOwnerTestCase extends APIMIntegrationBase
 
             assert applicationInfoList != null;
             assertTrue(verifyApplicationSearchQueryResults(expectedApplications, applicationInfoList));
+            assertTrue(verifyAllApplicationsMatchQuery(searchQuery, applicationInfoList));
         }
     }
 
@@ -234,5 +238,23 @@ public class ApplicationsSearchByNameOrOwnerTestCase extends APIMIntegrationBase
             }
         }
         return !expectedResultSet.isEmpty();
+    }
+
+    private boolean verifyAllApplicationsMatchQuery(String query, List<ApplicationInfoDTO> applications) {
+        if (query == null || query.trim().isEmpty()) {
+            return true;
+        }
+
+        String normalizedQuery = query.toLowerCase();
+        for (ApplicationInfoDTO app : applications) {
+            String name = app.getName();
+            String owner = app.getOwner();
+            boolean matchesName = name != null && name.toLowerCase().contains(normalizedQuery);
+            boolean matchesOwner = owner != null && owner.toLowerCase().contains(normalizedQuery);
+            if (!matchesName && !matchesOwner) {
+                return false;
+            }
+        }
+        return true;
     }
 }


### PR DESCRIPTION
Purpose
Strengthen admin application search tests by asserting all returned applications match the name/owner query.

Issues
No actual fix for this have been posted

Release note
Improve admin application search test coverage to validate query filtering.

Documentation
No documentation impact. Current documentation covers the changes.

Security checks
 - Followed secure coding standards? Yes
 - Verified FindSecurityBugs report? Yes
 - Confirmed no secrets committed? Yes

Samples
N/A

Migrations (if applicable)
No migration required

Tested environments
ran mvn clean install --file all-in-one-apim/pom.xml -DskipBenchMarkTest=true -DskipRestartTests=true (no issues)
Not Tested (CI must run before merge).
Required command:
mvn clean install --file all-in-one-apim/pom.xml -DskipBenchMarkTest=true -DskipRestartTests=true