### PR TITLE
Fix intermittent test failure in APISecurityTestCase

### DIFF
--- a/all-in-one-apim/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/utils/base/APIMIntegrationBaseTest.java
+++ b/all-in-one-apim/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/utils/base/APIMIntegrationBaseTest.java
@@ -632,6 +632,7 @@ public class APIMIntegrationBaseTest {
         headerMap.put("Authorization",authorizationHeader);
         String tenantIdentifier = getTenantIdentifier(apiProvider);
 
+        boolean apiFound = false;
         while (waitTime > System.currentTimeMillis()) {
             HttpResponse response = null;
             try {
@@ -653,6 +654,7 @@ public class APIMIntegrationBaseTest {
                 if (response.getData().contains(expectedResponse)) {
                     log.info("API :" + apiName + " with version: " + apiVersion +
                              " with expected response " + expectedResponse + " found");
+                    apiFound = true;
                     break;
                 } else {
                     try {
@@ -662,6 +664,11 @@ public class APIMIntegrationBaseTest {
                     }
                 }
             }
+        }
+        if (!apiFound) {
+            throw new APIManagerIntegrationTestException("API deployment sync timed out after " + (WAIT_TIME / 1000)
+                    + " seconds for API: " + apiName + " version: " + apiVersion + " provider: " + apiProvider
+                    + " expected: " + expectedResponse);
         }
     }
 
@@ -688,6 +695,7 @@ public class APIMIntegrationBaseTest {
         String authorizationHeader = "Basic "+Base64.encodeBase64(colonSeparatedHeader.getBytes()).toString();
         Map headerMap = new HashMap();
         headerMap.put("Authorization",authorizationHeader);
+        boolean apiUndeployed = false;
         while (waitTime > System.currentTimeMillis()) {
             HttpResponse response = null;
             try{
@@ -706,6 +714,7 @@ public class APIMIntegrationBaseTest {
                 if (!response.getData().contains(expectedResponse)) {
                     log.info("API :" + apiName + " with version: " + apiVersion +
                              " with expected response " + expectedResponse + " not found");
+                    apiUndeployed = true;
                     break;
                 } else {
                     try {
@@ -715,6 +724,11 @@ public class APIMIntegrationBaseTest {
                     }
                 }
             }
+        }
+        if (!apiUndeployed) {
+            throw new APIManagerIntegrationTestException("API un-deployment sync timed out after "
+                    + (WAIT_TIME / 1000) + " seconds for API: " + apiName + " version: " + apiVersion
+                    + " provider: " + apiProvider + " unexpected response still present: " + expectedResponse);
         }
     }
 

--- a/all-in-one-apim/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/utils/base/APIManagerLifecycleBaseTest.java
+++ b/all-in-one-apim/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/utils/base/APIManagerLifecycleBaseTest.java
@@ -462,7 +462,10 @@ public class APIManagerLifecycleBaseTest extends APIMIntegrationBaseTest {
                             + getAPIIdentifierStringFromAPIRequest(apiRequest));
                     try {
                         Thread.sleep(3000);
-                    } catch (InterruptedException ignored) {
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new APIManagerIntegrationTestException(
+                                "Thread interrupted while retrying API publish status check", e);
                     }
                     HttpResponse lifecycleResponse = publisherRestClient.getLifecycleStatus(createAPIResponse.getData());
                     if (lifecycleResponse != null
@@ -607,8 +610,7 @@ public class APIManagerLifecycleBaseTest extends APIMIntegrationBaseTest {
             throws APIManagerIntegrationTestException, ApiException,
             org.wso2.am.integration.clients.store.api.ApiException, XPathExpressionException {
         APIDTO apidto = createAndPublishAPI(apiCreationRequestBean, publisherRestClient, false);
-        waitForAPIDeploymentSync(user.getUserName(), apiIdentifier.getApiName(), apiIdentifier.getVersion(),
-                APIMIntegrationConstants.IS_API_EXISTS);
+        waitForAPIDeployment();
         SubscriptionDTO httpResponseSubscribeAPI = subscribeToAPI(apidto.getId(), applicationID, tier, storeRestClient);
         log.info("API Subscribed :" + getAPIIdentifierString(apiIdentifier));
         return apidto;

--- a/all-in-one-apim/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/utils/base/APIManagerLifecycleBaseTest.java
+++ b/all-in-one-apim/modules/integration/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/utils/base/APIManagerLifecycleBaseTest.java
@@ -452,9 +452,31 @@ public class APIManagerLifecycleBaseTest extends APIMIntegrationBaseTest {
             HttpResponse publishAPIResponse = publishAPIUsingRest(createAPIResponse.getData(), publisherRestClient, isRequireReSubscription);
             if (!(publishAPIResponse.getResponseCode() == HTTP_RESPONSE_CODE_OK &&
                     APILifeCycleState.PUBLISHED.getState().equals(publishAPIResponse.getData()))) {
-                throw new APIManagerIntegrationTestException("Error in API Publishing" +
-                        getAPIIdentifierStringFromAPIRequest(apiRequest) + "Response Code:" + publishAPIResponse.getResponseCode() +
-                        " Response Data :" + publishAPIResponse.getData());
+                // Retry: lifecycle state may not have propagated yet (e.g., on MySQL due to DB read delay)
+                int retryCount = 0;
+                int maxRetries = 5;
+                boolean published = false;
+                while (retryCount < maxRetries) {
+                    log.warn("API lifecycle state not yet 'Published' (got '" + publishAPIResponse.getData()
+                            + "'). Retrying (" + (retryCount + 1) + "/" + maxRetries + ")..."
+                            + getAPIIdentifierStringFromAPIRequest(apiRequest));
+                    try {
+                        Thread.sleep(3000);
+                    } catch (InterruptedException ignored) {
+                    }
+                    HttpResponse lifecycleResponse = publisherRestClient.getLifecycleStatus(createAPIResponse.getData());
+                    if (lifecycleResponse != null
+                            && APILifeCycleState.PUBLISHED.getState().equals(lifecycleResponse.getData())) {
+                        published = true;
+                        break;
+                    }
+                    retryCount++;
+                }
+                if (!published) {
+                    throw new APIManagerIntegrationTestException("Error in API Publishing" +
+                            getAPIIdentifierStringFromAPIRequest(apiRequest) + "Response Code:" + publishAPIResponse.getResponseCode() +
+                            " Response Data :" + publishAPIResponse.getData());
+                }
             }
             log.info("API Published :" + getAPIIdentifierStringFromAPIRequest(apiRequest));
             return createAPIResponse.getData();

--- a/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/APISecurityTestCase.java
+++ b/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/APISecurityTestCase.java
@@ -461,7 +461,9 @@ public class APISecurityTestCase extends APIManagerLifecycleBaseTest {
         while (response.getResponseCode() == 404 && retries < 5) {
             try {
                 Thread.sleep(3000);
-            } catch (InterruptedException ignored) {
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
             }
             response = HttpRequestUtil.doGet(url, requestHeaders);
             retries++;

--- a/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/APISecurityTestCase.java
+++ b/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/APISecurityTestCase.java
@@ -455,7 +455,18 @@ public class APISecurityTestCase extends APIManagerLifecycleBaseTest {
         Map<String, String> requestHeaders = new HashMap<>();
         requestHeaders.put("accept", "application/json");
         requestHeaders.put("Internal-Key", internalKey);
-        return HttpRequestUtil.doGet(getAPIInvocationURLHttps(context, version) + resource, requestHeaders);
+        String url = getAPIInvocationURLHttps(context, version) + resource;
+        HttpResponse response = HttpRequestUtil.doGet(url, requestHeaders);
+        int retries = 0;
+        while (response.getResponseCode() == 404 && retries < 5) {
+            try {
+                Thread.sleep(3000);
+            } catch (InterruptedException ignored) {
+            }
+            response = HttpRequestUtil.doGet(url, requestHeaders);
+            retries++;
+        }
+        return response;
     }
 
     @Test(description = "This test case tests the behaviour of APIs that are protected with mutual SSL and OAuth2 "

--- a/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/ChangeEndPointSecurityPerTypeTestCase.java
+++ b/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/ChangeEndPointSecurityPerTypeTestCase.java
@@ -177,8 +177,8 @@ public class ChangeEndPointSecurityPerTypeTestCase extends APIManagerLifecycleBa
         APIDTO updatedAPI = restAPIPublisher.updateAPI(apidto, apiID);
         // Create Revision and Deploy to Gateway
         createAPIRevisionAndDeployUsingRest(apiID, restAPIPublisher);
-        waitForAPIDeploymentSync(user.getUserName(), API_NAME, API_VERSION_1_0_0,
-                APIMIntegrationConstants.IS_API_NOT_EXISTS);
+        // Allow time for the new revision to replace the previous one on the gateway
+        waitForAPIDeployment();
         waitForAPIDeploymentSync(user.getUserName(), API_NAME, API_VERSION_1_0_0,
                 APIMIntegrationConstants.IS_API_EXISTS);
         Map updatedEndpointConfig = (Map) updatedAPI.getEndpointConfig();
@@ -228,8 +228,8 @@ public class ChangeEndPointSecurityPerTypeTestCase extends APIManagerLifecycleBa
         APIDTO updatedAPI = restAPIPublisher.updateAPI(apidto, apiID);
         // Create Revision and Deploy to Gateway
         createAPIRevisionAndDeployUsingRest(apiID, restAPIPublisher);
-        waitForAPIDeploymentSync(user.getUserName(), API_NAME, API_VERSION_1_0_0,
-                APIMIntegrationConstants.IS_API_NOT_EXISTS);
+        // Allow time for the new revision to replace the previous one on the gateway
+        waitForAPIDeployment();
         waitForAPIDeploymentSync(user.getUserName(), API_NAME, API_VERSION_1_0_0,
                 APIMIntegrationConstants.IS_API_EXISTS);
         Map updatedEndpointConfig = (Map) updatedAPI.getEndpointConfig();
@@ -289,8 +289,8 @@ public class ChangeEndPointSecurityPerTypeTestCase extends APIManagerLifecycleBa
                 APIMIntegrationConstants.IS_API_NOT_EXISTS);
         // Create Revision and Deploy to Gateway
         createAPIRevisionAndDeployUsingRest(apiID, restAPIPublisher);
-        waitForAPIDeploymentSync(user.getUserName(), API_NAME, API_VERSION_1_0_0,
-                APIMIntegrationConstants.IS_API_NOT_EXISTS);
+        // Allow time for the new revision to replace the previous one on the gateway
+        waitForAPIDeployment();
         waitForAPIDeploymentSync(user.getUserName(), API_NAME, API_VERSION_1_0_0,
                 APIMIntegrationConstants.IS_API_EXISTS);
         Map updatedEndpointConfig = (Map) updatedAPI.getEndpointConfig();
@@ -363,8 +363,8 @@ public class ChangeEndPointSecurityPerTypeTestCase extends APIManagerLifecycleBa
                 APIMIntegrationConstants.IS_API_NOT_EXISTS);
         // Create Revision and Deploy to Gateway
         createAPIRevisionAndDeployUsingRest(apiID, restAPIPublisher);
-        waitForAPIDeploymentSync(user.getUserName(), API_NAME, API_VERSION_1_0_0,
-                APIMIntegrationConstants.IS_API_NOT_EXISTS);
+        // Allow time for the new revision to replace the previous one on the gateway
+        waitForAPIDeployment();
         waitForAPIDeploymentSync(user.getUserName(), API_NAME, API_VERSION_1_0_0,
                 APIMIntegrationConstants.IS_API_EXISTS);
         Map updatedEndpointConfig = (Map) updatedAPI.getEndpointConfig();
@@ -451,8 +451,8 @@ public class ChangeEndPointSecurityPerTypeTestCase extends APIManagerLifecycleBa
                 APIMIntegrationConstants.IS_API_NOT_EXISTS);
         // Create Revision and Deploy to Gateway
         createAPIRevisionAndDeployUsingRest(apiID, restAPIPublisher);
-        waitForAPIDeploymentSync(user.getUserName(), API_NAME, API_VERSION_1_0_0,
-                APIMIntegrationConstants.IS_API_NOT_EXISTS);
+        // Allow time for the new revision to replace the previous one on the gateway
+        waitForAPIDeployment();
         waitForAPIDeploymentSync(user.getUserName(), API_NAME, API_VERSION_1_0_0,
                 APIMIntegrationConstants.IS_API_EXISTS);
         Map updatedEndpointConfig = (Map) updatedAPI.getEndpointConfig();

--- a/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/RegistryLifeCycleInclusionTest.java
+++ b/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/api/lifecycle/RegistryLifeCycleInclusionTest.java
@@ -65,8 +65,7 @@ public class RegistryLifeCycleInclusionTest extends APIManagerLifecycleBaseTest 
 
         //Create and publish API version 1.0.0
         APIDTO apidto = createAndPublishAPI(apiCreationRequestBean, restAPIPublisher, false);
-        waitForAPIDeploymentSync(user.getUserName(), API_NAME, API_VERSION_1_0_0,
-                APIMIntegrationConstants.IS_API_EXISTS);
+        waitForAPIDeployment();
         apiID = apidto.getId();
 
         //check for LC state change buttons
@@ -126,8 +125,7 @@ public class RegistryLifeCycleInclusionTest extends APIManagerLifecycleBaseTest 
 
         restAPIPublisher.changeAPILifeCycleStatus(copyApiID, APILifeCycleAction.PUBLISH.getAction());
 
-        waitForAPIDeploymentSync(user.getUserName(), API_NAME, API_VERSION_2_0_0,
-                APIMIntegrationConstants.IS_API_EXISTS);
+        waitForAPIDeployment();
         LifecycleStateDTO stateDTO = restAPIPublisher.getLifecycleStatusDTO(copyApiID);
         Assert.assertEquals(stateDTO.getState(), APILifeCycleState.PUBLISHED.getState());
         String[] expectedStates =

--- a/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/APIScopeTestCase.java
+++ b/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/APIScopeTestCase.java
@@ -188,7 +188,6 @@ public class APIScopeTestCase extends APIManagerLifecycleBaseTest {
         // Create Revision and Deploy to Gateway
         createAPIRevisionAndDeployUsingRest(apiId, restAPIPublisher);
 
-        waitForAPIDeploymentSync(user.getUserName(), API_NAME, API_VERSION, APIMIntegrationConstants.IS_API_NOT_EXISTS);
         waitForAPIDeploymentSync(user.getUserName(), API_NAME, API_VERSION, APIMIntegrationConstants.IS_API_EXISTS);
 
         // For Admin user
@@ -410,16 +409,13 @@ public class APIScopeTestCase extends APIManagerLifecycleBaseTest {
         // Create Revision and Deploy to Gateway
         createAPIRevisionAndDeployUsingRest(apiIdWithScope, restAPIPublisher);
         waitForAPIDeploymentSync(user.getUserName(), API_NAME_WITH_SCOPE, API_VERSION_WITH_SCOPE,
-                APIMIntegrationConstants.IS_API_NOT_EXISTS);
-        waitForAPIDeploymentSync(user.getUserName(), API_NAME_WITH_SCOPE, API_VERSION_WITH_SCOPE,
                 APIMIntegrationConstants.IS_API_EXISTS);
 
         //copy published api
         HttpResponse newVersionResponse = restAPIPublisher.copyAPI(API_VERSION_WITH_SCOPE_COPY, apiIdWithScope, null);
         assertEquals(newVersionResponse.getResponseCode(), HttpStatus.SC_OK, "Response Code Mismatch");
         copyApiId = newVersionResponse.getData();
-        waitForAPIDeploymentSync(user.getUserName(), API_NAME_WITH_SCOPE, API_VERSION_WITH_SCOPE_COPY,
-                APIMIntegrationConstants.IS_API_EXISTS);
+        waitForAPIDeployment();
 
     }
 

--- a/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/DAOTestCase.java
+++ b/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/DAOTestCase.java
@@ -122,8 +122,7 @@ public class DAOTestCase extends APIMIntegrationBaseTest {
                         null, grantTypes);
         assertNotNull(applicationKeyDTO.getToken().getAccessToken());
 
-        waitForAPIDeploymentSync(apiRequest.getProvider(), apiRequest.getName(), apiRequest.getVersion(),
-                                 APIMIntegrationConstants.IS_API_EXISTS);
+        waitForAPIDeployment();
 
     }
 

--- a/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/SoapToRestTestCase.java
+++ b/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/SoapToRestTestCase.java
@@ -249,10 +249,10 @@ public class SoapToRestTestCase extends APIManagerLifecycleBaseTest {
         apidto.setIsDefaultVersion(true);
         APIDTO updatedAPI = restAPIPublisher.updateAPI(apidto, soapToRestAPIId);
         createAPIRevisionAndDeployUsingRest(updatedAPI.getId(), restAPIPublisher);
+        // Allow time for the new revision to replace the previous one on the gateway
+        waitForAPIDeployment();
         waitForAPIDeploymentSync(user.getUserName(), SOAPTOREST_API_NAME, API_VERSION_1_0_0,
-                APIMIntegrationConstants.IS_API_NOT_EXISTS);
-        waitForAPIDeploymentSync(user.getUserName(), SOAPTOREST_API_NAME, API_VERSION_1_0_0,
-                APIMIntegrationConstants.IS_API_NOT_EXISTS);
+                APIMIntegrationConstants.IS_API_EXISTS);
 
         String soapToRestAppName = "PhoneVerificationDefaultApp";
         testAppId1 = createSoapToRestAppAndSubscribeToAPI(soapToRestAppName, "OAUTH", soapToRestAPIId);
@@ -279,8 +279,10 @@ public class SoapToRestTestCase extends APIManagerLifecycleBaseTest {
             dependsOnMethods = {"testValidateCreatedResources"})
     public void testRevisionedAPIInvocation() throws Exception {
         createAPIRevisionAndDeployUsingRest(soapToRestAPIId, restAPIPublisher);
+        // Allow time for the new revision to replace the previous one on the gateway
+        waitForAPIDeployment();
         waitForAPIDeploymentSync(user.getUserName(), SOAPTOREST_API_NAME, API_VERSION_1_0_0,
-                APIMIntegrationConstants.IS_API_NOT_EXISTS);
+                APIMIntegrationConstants.IS_API_EXISTS);
 
         String soapToRestAppName = "PhoneVerificationRevisionedApp";
         testAppId2 = createSoapToRestAppAndSubscribeToAPI(soapToRestAppName, "OAUTH", soapToRestAPIId);
@@ -374,10 +376,6 @@ public class SoapToRestTestCase extends APIManagerLifecycleBaseTest {
         apidto.setScopes(apiScopeList);
         APIDTO updatedAPI = restAPIPublisher.updateAPI(apidto, soapToRestAPIId);
         createAPIRevisionAndDeployUsingRest(soapToRestAPIId, restAPIPublisher);
-        waitForAPIDeploymentSync(user.getUserName(), SOAPTOREST_API_NAME, API_VERSION_1_0_0,
-                APIMIntegrationConstants.IS_API_NOT_EXISTS);
-        waitForAPIDeploymentSync(user.getUserName(), SOAPTOREST_API_NAME, API_VERSION_1_0_0,
-                APIMIntegrationConstants.IS_API_NOT_EXISTS);
 
         ArrayList scope = new ArrayList();
         scope.add("subscriber");
@@ -396,10 +394,6 @@ public class SoapToRestTestCase extends APIManagerLifecycleBaseTest {
         waitForAPIDeploymentSync(user.getUserName(), SOAPTOREST_API_NAME, API_VERSION_1_0_0,
                 APIMIntegrationConstants.IS_API_NOT_EXISTS);
         createAPIRevisionAndDeployUsingRest(soapToRestAPIId, restAPIPublisher);
-        waitForAPIDeploymentSync(user.getUserName(), SOAPTOREST_API_NAME, API_VERSION_1_0_0,
-                APIMIntegrationConstants.IS_API_NOT_EXISTS);
-        waitForAPIDeploymentSync(user.getUserName(), SOAPTOREST_API_NAME, API_VERSION_1_0_0,
-                APIMIntegrationConstants.IS_API_NOT_EXISTS);
 
         testAppId5 = createSoapToRestAppAndSubscribeToAPI("testOperationalLevelOAuthScopesForSoapToRest", "OAUTH",
                 soapToRestAPIId);
@@ -474,8 +468,6 @@ public class SoapToRestTestCase extends APIManagerLifecycleBaseTest {
         waitForAPIDeploymentSync(user.getUserName(), SOAPTOREST_API_NAME, API_VERSION_1_0_0,
                 APIMIntegrationConstants.IS_API_NOT_EXISTS);
         createAPIRevisionAndDeployUsingRest(soapToRestAPIId, restAPIPublisher);
-        waitForAPIDeploymentSync(user.getUserName(), SOAPTOREST_API_NAME, API_VERSION_1_0_0,
-                APIMIntegrationConstants.IS_API_NOT_EXISTS);
         waitForAPIDeploymentSync(user.getUserName(), SOAPTOREST_API_NAME, API_VERSION_1_0_0,
                 APIMIntegrationConstants.IS_API_EXISTS);
 

--- a/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/search/DevPortalSearchTest.java
+++ b/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/search/DevPortalSearchTest.java
@@ -99,8 +99,6 @@ public class DevPortalSearchTest extends APIMIntegrationBaseTest {
         createAPIRevisionAndDeployUsingRest(api1Id, restAPIPublisher);
         restAPIPublisher.changeAPILifeCycleStatusToPublish(api1Id, false);
         waitForAPIDeploymentSync(apiRequest.getProvider(), apiRequest.getName(), apiRequest.getVersion(),
-                APIMIntegrationConstants.IS_API_NOT_EXISTS);
-        waitForAPIDeploymentSync(apiRequest.getProvider(), apiRequest.getName(), apiRequest.getVersion(),
                 APIMIntegrationConstants.IS_API_EXISTS);
 
         /* Create API_PIZZA */
@@ -127,8 +125,6 @@ public class DevPortalSearchTest extends APIMIntegrationBaseTest {
         createAPIRevisionAndDeployUsingRest(api2Id, restAPIPublisher);
         restAPIPublisher.changeAPILifeCycleStatusToPublish(api2Id, false);
         waitForAPIDeploymentSync(apiRequest.getProvider(), apiRequest.getName(), apiRequest.getVersion(),
-                APIMIntegrationConstants.IS_API_NOT_EXISTS);
-        waitForAPIDeploymentSync(apiRequest.getProvider(), apiRequest.getName(), apiRequest.getVersion(),
                 APIMIntegrationConstants.IS_API_EXISTS);
 
         /* Create API_OTHER */
@@ -154,8 +150,6 @@ public class DevPortalSearchTest extends APIMIntegrationBaseTest {
         // Create Revision and Deploy to Gateway
         createAPIRevisionAndDeployUsingRest(api3Id, restAPIPublisher);
         restAPIPublisher.changeAPILifeCycleStatusToPublish(api3Id, false);
-        waitForAPIDeploymentSync(apiRequest.getProvider(), apiRequest.getName(), apiRequest.getVersion(),
-                APIMIntegrationConstants.IS_API_NOT_EXISTS);
         waitForAPIDeploymentSync(apiRequest.getProvider(), apiRequest.getName(), apiRequest.getVersion(),
                 APIMIntegrationConstants.IS_API_EXISTS);
     }

--- a/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/throttling/JWTBandwidthThrottlingTestCase.java
+++ b/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/throttling/JWTBandwidthThrottlingTestCase.java
@@ -254,8 +254,8 @@ public class JWTBandwidthThrottlingTestCase extends APIMIntegrationBaseTest {
         // Create Revision and Deploy to Gateway
         createAPIRevisionAndDeployUsingRest(apiId, restAPIPublisher);
 
-        waitForAPIDeploymentSync(apidto.getProvider(), apidto.getName(), apidto.getVersion(),
-                APIMIntegrationConstants.IS_API_NOT_EXISTS);
+        // Allow time for the new revision to replace the previous one on the gateway
+        waitForAPIDeployment();
         waitForAPIDeploymentSync(apidto.getProvider(), apidto.getName(), apidto.getVersion(),
                 APIMIntegrationConstants.IS_API_EXISTS);
         ApplicationDTO applicationDTO = restAPIStore.addApplication("NormalAPP",

--- a/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/throttling/JWTRequestCountThrottlingTestCase.java
+++ b/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/throttling/JWTRequestCountThrottlingTestCase.java
@@ -357,8 +357,8 @@ public class JWTRequestCountThrottlingTestCase extends APIMIntegrationBaseTest {
                 "API tier not updated.");
         // Create Revision and Deploy to Gateway
         createAPIRevisionAndDeployUsingRest(apiId, restAPIPublisher);
-        waitForAPIDeploymentSync(user.getUserName(), apidto.getName(), apidto.getVersion(),
-                APIMIntegrationConstants.IS_API_NOT_EXISTS);
+        // Allow time for the new revision to replace the previous one on the gateway
+        waitForAPIDeployment();
         waitForAPIDeploymentSync(user.getUserName(), apidto.getName(), apidto.getVersion(),
                 APIMIntegrationConstants.IS_API_EXISTS);
         Assert.assertNotNull(applicationKeyDTOOfAPILevelTest.getToken());
@@ -379,8 +379,8 @@ public class JWTRequestCountThrottlingTestCase extends APIMIntegrationBaseTest {
                 "Unlimited");
         // Create Revision and Deploy to Gateway
         createAPIRevisionAndDeployUsingRest(apiId, restAPIPublisher);
-        waitForAPIDeploymentSync(user.getUserName(), apidto.getName(), apidto.getVersion(),
-                APIMIntegrationConstants.IS_API_NOT_EXISTS);
+        // Allow time for the new revision to replace the previous one on the gateway
+        waitForAPIDeployment();
         waitForAPIDeploymentSync(user.getUserName(), apidto.getName(), apidto.getVersion(),
                 APIMIntegrationConstants.IS_API_EXISTS);
         Assert.assertTrue(isThrottled(requestHeaders, null,7), "Request not need to throttle since policy was updated");

--- a/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/websocket/APIMANAGER5869WSGayewatURLTestCase.java
+++ b/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/websocket/APIMANAGER5869WSGayewatURLTestCase.java
@@ -111,8 +111,7 @@ public class APIMANAGER5869WSGayewatURLTestCase extends APIMIntegrationBaseTest 
         restAPIId = serviceResponse.getData();
         restAPIPublisher.changeAPILifeCycleStatus(restAPIId, APILifeCycleAction.PUBLISH.getAction(), null);
 
-        //publish the api
-        waitForAPIDeploymentSync(user.getUserName(), API_NAME, API_VERSION, APIMIntegrationConstants.IS_API_EXISTS);
+        waitForAPIDeployment();
     }
 
     @Test(description = "Publish WebSocket API", dependsOnMethods = "testAPICreation")

--- a/all-in-one-apim/modules/integration/tests-integration/tests-restart/src/test/java/org/wso2/am/integration/tests/server/restart/JWTBandwidthThrottlingServerRestartTestCase.java
+++ b/all-in-one-apim/modules/integration/tests-integration/tests-restart/src/test/java/org/wso2/am/integration/tests/server/restart/JWTBandwidthThrottlingServerRestartTestCase.java
@@ -163,8 +163,8 @@ public class JWTBandwidthThrottlingServerRestartTestCase extends APIMIntegration
         // Create Revision and Deploy to Gateway
         createAPIRevisionAndDeployUsingRest(jwtBandwidthApiId, restAPIPublisher);
 
-        waitForAPIDeploymentSync(apidto.getProvider(), apidto.getName(), apidto.getVersion(),
-                APIMIntegrationConstants.IS_API_NOT_EXISTS);
+        // Allow time for the new revision to replace the previous one on the gateway
+        waitForAPIDeployment();
         waitForAPIDeploymentSync(apidto.getProvider(), apidto.getName(), apidto.getVersion(),
                 APIMIntegrationConstants.IS_API_EXISTS);
         ApplicationDTO applicationDTO = restAPIStore.addApplication("NormalAPP",


### PR DESCRIPTION
## Description
This PR introduces the following improvements:
  - Adds an API-found state to waitForAPIDeploymentSync and throws an error if all retries fail.
  - Adds retry logic to createAndPublishAPIUsingRest.
  - Adds retry logic to invokeApiWithInternalKey.
  - Replaces fragile IS_API_NOT_EXISTS deployment sync checks with appropriate alternatives based on context.
  - Fixes stale test data issue in APIMANAGER5834APICreationWithInvalidInputsTestCase.

| # | File / Test Class | Method / Location | Previous Behavior | Fix Applied | Reason |
|---|---|---|---|---|---|
| — | `APIMIntegrationBaseTest` | `waitForAPIDeploymentSync()` (~line 669) | Silently returned after 60s timeout; tests continued as if deployment succeeded | Now throws `APIManagerIntegrationTestException` on timeout | Enables fail-fast behavior instead of masking deployment failures |
| — | `APIMIntegrationBaseTest` | `waitForAPIUnDeploymentSync()` (~line 729) | Silently returned after 60s timeout | Now throws `APIManagerIntegrationTestException` on timeout | Prevents undeployment failures from being silently ignored |
| — | `APISecurityTestCase` | `invokeApiWithInternalKey()` | Single invocation attempt; failed with 404 if gateway had not fully loaded the API | Retries up to 5 times with 3s sleep on 404 | Handles gateway propagation delay after deployment |
| — | `APIManagerLifecycleBaseTest` | `createAndPublishAPIUsingRest()` | Single publish status check; failed if lifecycle state had not propagated yet | Retries up to 5 times with 3s sleep to verify publish status | Handles DB read delay (e.g., on MySQL) for lifecycle state propagation |
| 1 | `APIMANAGER5869WSGayewatURLTestCase` | `testAPICreation()` | Called `waitForAPIDeploymentSync(IS_API_EXISTS)` after `changeAPILifeCycleStatus(PUBLISH)` even though no revision was deployed; always timed out silently | Replaced with `waitForAPIDeployment()` | This test never deploys a revision |
| 2 | `APIManagerLifecycleBaseTest` | `createPublishAndSubscribeToAPI()` | Called `waitForAPIDeploymentSync(IS_API_EXISTS)` after `createAndPublishAPI()` even though revision creation is commented out | Replaced with `waitForAPIDeployment()` | No revision deployment occurs in `createAndPublishAPI()` |
| 3 | `RegistryLifeCycleInclusionTest` | `testAPIInfoLifecycleTabForPublishedAPI()` | Called `waitForAPIDeploymentSync(IS_API_EXISTS)` after `createAndPublishAPI()` even though no revision was deployed | Replaced with `waitForAPIDeployment()` | No revision deployment occurs |
| 4 | `RegistryLifeCycleInclusionTest` | `testLCStateChangeVisibility()` | Called `waitForAPIDeploymentSync(IS_API_EXISTS)` after publishing a copied API without deploying a revision | Replaced with `waitForAPIDeployment()` | `copyAPI()` + `changeAPILifeCycleStatus(PUBLISH)` does not deploy a revision |
| 5 | `DAOTestCase` | `testDAOTestCase()` | Called `waitForAPIDeploymentSync(IS_API_EXISTS)` after `changeAPILifeCycleStatus(PUBLISH)` without deploying a revision | Replaced with `waitForAPIDeployment()` | No revision deployment occurs |
| 6 | `APIScopeTestCase` | `testCopyApiWithScopes()` (after `copyAPI`) | Called `waitForAPIDeploymentSync(IS_API_EXISTS)` after `copyAPI()` which does not deploy a revision | Replaced with `waitForAPIDeployment()` | `copyAPI()` does not deploy a revision |
| 7 | `APIScopeTestCase` | `testSetScopeToResourceTestCase()` | Waited for `IS_API_NOT_EXISTS` then `IS_API_EXISTS` after first revision deployment | Removed `IS_API_NOT_EXISTS`; kept only `IS_API_EXISTS` | First deployment — no previous revision to observe as transiently absent |
| 8 | `APIScopeTestCase` | `testCopyApiWithScopes()` (after deploy) | Waited for `IS_API_NOT_EXISTS` then `IS_API_EXISTS` after first revision deployment | Removed `IS_API_NOT_EXISTS`; kept only `IS_API_EXISTS` | First deployment — no previous revision to observe as transiently absent |
| 9–11 | `DevPortalSearchTest` | `setEnvironment()` (3 occurrences) | Used `IS_API_NOT_EXISTS → IS_API_EXISTS` after each first-time deploy | Removed all `IS_API_NOT_EXISTS` waits; kept only `IS_API_EXISTS` | First deployments — no previous revision to observe as transiently absent |
| 12–16 | `ChangeEndPointSecurityPerTypeTestCase` | 5 test methods | Waited for `IS_API_NOT_EXISTS` then `IS_API_EXISTS` after deploying updated revisions | Replaced `IS_API_NOT_EXISTS` with `waitForAPIDeployment()` before `IS_API_EXISTS` | Previous revision is still active, so `IS_API_EXISTS` passes instantly; `waitForAPIDeployment()` gives the gateway time to swap revisions |
| 17 | `SoapToRestTestCase` | `testDefaultAPIInvocation()` | Had 2× `IS_API_NOT_EXISTS` waits and no `IS_API_EXISTS` wait after re-deployment | Replaced with `waitForAPIDeployment()` + `IS_API_EXISTS` | Previous revision is active; `IS_API_EXISTS` would pass instantly without the sleep |
| 18 | `SoapToRestTestCase` | `testRevisionedAPIInvocation()` | Waited for `IS_API_NOT_EXISTS` after re-deployment | Replaced with `waitForAPIDeployment()` + `IS_API_EXISTS` | Previous revision is active; `IS_API_EXISTS` would pass instantly without the sleep |
| 19 | `SoapToRestTestCase` | `testOperationalLevelOAuthScopesForSoapToRest()` (1st deploy) | Had 2× `IS_API_NOT_EXISTS` waits after deploy, no `IS_API_EXISTS` | Removed both `IS_API_NOT_EXISTS` waits | No API invocation occurs before the subsequent undeploy; synchronization is handled by the undeploy + `IS_API_NOT_EXISTS` that follows |
| 20 | `SoapToRestTestCase` | `testOperationalLevelOAuthScopesForSoapToRest()` (2nd deploy, after undeploy) | Had 2× `IS_API_NOT_EXISTS` waits after re-deploy | Removed post-deploy `IS_API_NOT_EXISTS`; kept `IS_API_EXISTS` and existing `Thread.sleep(10000)` | Old revision already confirmed removed by prior `IS_API_NOT_EXISTS` after undeploy |
| 21 | `SoapToRestTestCase` | `testOperationalLevelSecurityForSoapToRest()` | Had `IS_API_NOT_EXISTS` wait after re-deploy following undeploy | Removed post-deploy `IS_API_NOT_EXISTS`; kept `IS_API_EXISTS` | Old revision already confirmed removed by prior `IS_API_NOT_EXISTS` after undeploy |
| 22 | `JWTBandwidthThrottlingTestCase` | `testAPILevelThrottling()` | Waited for `IS_API_NOT_EXISTS` then `IS_API_EXISTS` after deploying updated revision | Replaced `IS_API_NOT_EXISTS` with `waitForAPIDeployment()` before `IS_API_EXISTS` | Previous revision is active; `IS_API_EXISTS` would pass instantly without the sleep |
| 23–24 | `JWTRequestCountThrottlingTestCase` | `testAPILevelThrottlingWithIpCondition()` (2 deploy cycles) | Each cycle used `IS_API_NOT_EXISTS → IS_API_EXISTS` | Replaced `IS_API_NOT_EXISTS` with `waitForAPIDeployment()` before `IS_API_EXISTS` | Previous revision is active; `IS_API_EXISTS` would pass instantly without the sleep |
| 25 | `JWTBandwidthThrottlingServerRestartTestCase` | `testAPILevelThrottling()` | Waited for `IS_API_NOT_EXISTS` then `IS_API_EXISTS` after deploying updated revision | Replaced `IS_API_NOT_EXISTS` with `waitForAPIDeployment()` before `IS_API_EXISTS` | Previous revision is active; `IS_API_EXISTS` would pass instantly without the sleep |
| 26 | `APIMANAGER5834APICreationWithInvalidInputsTestCase` | `testAPICreationWithInvalidContext()` + `@BeforeClass` + `@AfterClass` | Used `expectedExceptions` which masked stale API state; no cleanup of accidentally-created APIs; stale APIs from previous runs caused `testContextMatchesPreviousAPIVersions` to NPE | Added stale API cleanup in `@BeforeClass`; converted to try-catch with explicit cleanup tracking; `@AfterClass` now deletes both test APIs | Prevents stale APIs from previous failed runs from causing "Duplicate API name" conflicts |

### Fix Categories

| Category    | Rows   | Description |
|------------|--------|-------------|
| Core Fix   | —      | `waitForAPIDeploymentSync()` and `waitForAPIUnDeploymentSync()` now fail fast by throwing exceptions instead of silently continuing |
| Retry Logic| —      | `invokeApiWithInternalKey()` retries on 404; `createAndPublishAPIUsingRest()` retries on publish status check |
| Category A  | 1–6    | Tests that never deployed revisions. Replaced `waitForAPIDeploymentSync()` with `waitForAPIDeployment()` |
| Category B  | 7–11   | First-time deployments that relied on fragile `IS_API_NOT_EXISTS` waits. Removed `IS_API_NOT_EXISTS` and retained only `IS_API_EXISTS` — no previous revision exists on the gateway, so there is no transient absence to observe |
| Category C  | 12–25  | Re-deployments where a previous revision is already active on the gateway. Replaced `IS_API_NOT_EXISTS` with `waitForAPIDeployment()` (15s sleep) before `IS_API_EXISTS` — because `IS_API_EXISTS` passes instantly when the old revision is still serving, the sleep gives the gateway time to swap to the new revision |
| Category D  | 19–21  | Deployment sync waits removed entirely where no API invocation occurs before a subsequent undeploy, or where the old revision was already confirmed removed by a prior `IS_API_NOT_EXISTS` after `undeployAndDeleteAPIRevisionsUsingRest` |
| Stale Data Fix | 26  | `APIMANAGER5834APICreationWithInvalidInputsTestCase` — cleaned up stale API lifecycle and prevented leftover test data from causing cross-run failures |