### PR TITLE
Add tests for remote logging

### DIFF
--- a/all-in-one-apim/modules/integration/tests-common/admin-clients/pom.xml
+++ b/all-in-one-apim/modules/integration/tests-common/admin-clients/pom.xml
@@ -36,6 +36,10 @@ under the License.
             <artifactId>org.wso2.carbon.logging.view.stub</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.commons</groupId>
+            <artifactId>org.wso2.carbon.logging.remote.config.stub</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.carbon</groupId>
             <artifactId>org.wso2.carbon.utils</artifactId>
         </dependency>

--- a/all-in-one-apim/modules/integration/tests-common/admin-clients/src/main/java/org/wso2/am/admin/clients/logging/RemoteLoggingConfigClient.java
+++ b/all-in-one-apim/modules/integration/tests-common/admin-clients/src/main/java/org/wso2/am/admin/clients/logging/RemoteLoggingConfigClient.java
@@ -1,0 +1,144 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.wso2.am.admin.clients.logging;
+
+import org.apache.axiom.om.OMAbstractFactory;
+import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.OMFactory;
+import org.apache.axiom.om.OMNamespace;
+import org.wso2.carbon.logging.remote.config.stub.RemoteLoggingConfigStub;
+import org.wso2.carbon.logging.remote.config.stub.types.carbon.RemoteServerLoggerData;
+import org.wso2.carbon.utils.CarbonUtils;
+
+/**
+ * Client for interacting with the RemoteLoggingConfig Axis2 admin service.
+ * Used in integration tests to configure remote server logging (HTTP appenders).
+ */
+public class RemoteLoggingConfigClient {
+
+    private static final String SERVICE_NAME = "RemoteLoggingConfig";
+
+    /*
+     * Axis2 namespaces used by the RemoteLoggingConfig service.
+     * The operation wrapper uses the standard Axis2 RPC namespace; the data type fields
+     * use the logging-service data namespace from the service WSDL.
+     */
+    private static final String AXIS2_NS = "http://org.apache.axis2/xsd";
+    private static final String DATA_NS  = "http://data.service.logging.carbon.wso2.org/xsd";
+
+    private final RemoteLoggingConfigStub stub;
+
+    public RemoteLoggingConfigClient(String backendURL, String userName, String password) throws Exception {
+        stub = new RemoteLoggingConfigStub(backendURL + SERVICE_NAME);
+        CarbonUtils.setBasicAccessSecurityHeaders(userName, password, stub._getServiceClient());
+    }
+
+    /**
+     * Adds a remote server logging configuration.
+     *
+     * <p>Uses raw Axis2 OM rather than the generated stub to work around a JVM-dependent
+     * method-overloading issue: the service exposes two public overloads of this operation
+     * and Axis2's schema generator picks whichever {@code Class.getMethods()} returns first.
+     * The raw-OM call always includes both {@code data} and {@code args1} so the request is
+     * accepted regardless of which overload was registered.</p>
+     */
+    public void addRemoteServerConfig(RemoteServerLoggerData data) throws Exception {
+        sendConfigOp("addRemoteServerConfig", data, false);
+    }
+
+    /**
+     * Resets a remote server logging configuration to its default local-file state.
+     *
+     * <p>See {@link #addRemoteServerConfig} for the reason this uses raw Axis2 OM.</p>
+     */
+    public void resetRemoteServerConfig(RemoteServerLoggerData data) throws Exception {
+        sendConfigOp("resetRemoteServerConfig", data, false);
+    }
+
+    /** Returns all currently configured remote server logging entries. */
+    public RemoteServerLoggerData[] getRemoteServerConfigs() throws Exception {
+        return stub.getRemoteServerConfigs();
+    }
+
+    /** Returns the remote server configuration for the given log type. */
+    public RemoteServerLoggerData getRemoteServerConfig(String logType) throws Exception {
+        return stub.getRemoteServerConfig(logType);
+    }
+
+    /** Synchronises all persisted remote server configs with log4j2.properties. */
+    public void syncRemoteServerConfigs() throws Exception {
+        stub.syncRemoteServerConfigs();
+    }
+
+    /**
+     * Sends an {@code addRemoteServerConfig} or {@code resetRemoteServerConfig} SOAP operation
+     * using raw Axis2 OM and the Robust In-Only MEP ({@code sendRobust}). Always includes both
+     * the {@code data} element and an {@code args1} boolean so the request is accepted whether
+     * the server registered the one- or two-parameter overload. Using {@code sendRobust} instead
+     * of {@code fireAndForget} means the call blocks until the server finishes processing and
+     * any server-side fault is propagated to the caller as an {@link org.apache.axis2.AxisFault}.
+     */
+    private void sendConfigOp(String opName, RemoteServerLoggerData data, boolean isPeriodicalSyncRequest)
+            throws Exception {
+        OMFactory fac = OMAbstractFactory.getOMFactory();
+        OMNamespace opNs   = fac.createOMNamespace(AXIS2_NS, "ns");
+        OMNamespace dataNs = fac.createOMNamespace(DATA_NS,  "ax2");
+
+        OMElement op = fac.createOMElement(opName, opNs);
+        op.addChild(buildDataElement(fac, opNs, dataNs, data));
+
+        OMElement args1 = fac.createOMElement("args1", opNs);
+        args1.setText(Boolean.toString(isPeriodicalSyncRequest));
+        op.addChild(args1);
+
+        stub._getServiceClient().sendRobust(op);
+    }
+
+    private static OMElement buildDataElement(OMFactory fac, OMNamespace opNs, OMNamespace dataNs,
+                                              RemoteServerLoggerData data) {
+        OMElement dataEl = fac.createOMElement("data", opNs);
+        appendTextChild(fac, dataNs, dataEl, "connectTimeoutMillis", data.getConnectTimeoutMillis());
+        appendTextChild(fac, dataNs, dataEl, "keystoreLocation",     data.getKeystoreLocation());
+        appendTextChild(fac, dataNs, dataEl, "keystorePassword",     data.getKeystorePassword());
+        appendTextChild(fac, dataNs, dataEl, "logType",              data.getLogType());
+        appendTextChild(fac, dataNs, dataEl, "password",             data.getPassword());
+        appendTextChild(fac, dataNs, dataEl, "truststoreLocation",   data.getTruststoreLocation());
+        appendTextChild(fac, dataNs, dataEl, "truststorePassword",   data.getTruststorePassword());
+        appendTextChild(fac, dataNs, dataEl, "url",                  data.getUrl());
+        appendTextChild(fac, dataNs, dataEl, "username",             data.getUsername());
+        appendTextChild(fac, dataNs, dataEl, "verifyHostname",       data.getVerifyHostname());
+        return dataEl;
+    }
+
+    private static void appendTextChild(OMFactory f, OMNamespace ns, OMElement parent,
+                                        String localName, String value) {
+        if (value == null) {
+            return;
+        }
+        OMElement child = f.createOMElement(localName, ns);
+        child.setText(value);
+        parent.addChild(child);
+    }
+
+    private static void appendTextChild(OMFactory f, OMNamespace ns, OMElement parent,
+                                        String localName, boolean value) {
+        OMElement child = f.createOMElement(localName, ns);
+        child.setText(Boolean.toString(value));
+        parent.addChild(child);
+    }
+}

--- a/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/logging/RemoteLoggingAppenderTest.java
+++ b/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/logging/RemoteLoggingAppenderTest.java
@@ -39,7 +39,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetSocketAddress;
-import java.net.ServerSocket;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -50,7 +49,9 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static org.awaitility.Awaitility.with;
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 /**
  * Integration tests for the remote logging appender management behaviour
@@ -127,9 +128,11 @@ public class RemoteLoggingAppenderTest extends APIMIntegrationBaseTest {
 
         originalLog4j2Content = FileManager.readFile(log4j2PropertiesServerPath.toString());
 
-        /* Start a lightweight HTTP server to act as the remote log receiver */
-        mockServerPort = findFreePort();
-        mockLogServer = HttpServer.create(new InetSocketAddress(mockServerPort), 0);
+        /* Start a lightweight HTTP server to act as the remote log receiver.
+         * Binding to port 0 lets the OS assign a free port atomically, avoiding the
+         * TOCTOU race in a find-then-bind approach. */
+        mockLogServer = HttpServer.create(new InetSocketAddress(0), 0);
+        mockServerPort = mockLogServer.getAddress().getPort();
         mockLogServer.createContext("/api/logs/consume", exchange -> {
             try (InputStream body = exchange.getRequestBody()) {
                 byte[] bytes = body.readAllBytes();
@@ -583,17 +586,26 @@ public class RemoteLoggingAppenderTest extends APIMIntegrationBaseTest {
                 "Remote URL must be present in the AUDIT_LOGFILE block");
 
         /*
+         * Snapshot the payload count before triggering so the wait condition detects a
+         * genuinely new delivery rather than passing on traffic received in earlier tests.
+         */
+        final int payloadCountBeforeTrigger;
+        synchronized (receivedLogPayloads) {
+            payloadCountBeforeTrigger = receivedLogPayloads.size();
+        }
+
+        /*
          * Trigger an admin action that produces an audit log entry.
          * The admin REST API is authenticated, so calling any admin resource with valid
          * credentials generates an AUDIT_LOG entry.
          */
         triggerAuditLogEntry();
 
-        /* Wait for the log entry to arrive at the mock server (up to 30 seconds) */
+        /* Wait for at least one new log entry to arrive at the mock server (up to 30 seconds) */
         with().pollInterval(2, TimeUnit.SECONDS).await().atMost(30, TimeUnit.SECONDS).untilAsserted(() -> {
             synchronized (receivedLogPayloads) {
-                assertFalse(receivedLogPayloads.isEmpty(),
-                        "Mock log server must have received at least one log payload from the AUDIT appender");
+                assertTrue(receivedLogPayloads.size() > payloadCountBeforeTrigger,
+                        "Mock log server must have received at least one new log payload from the AUDIT appender");
             }
         });
 
@@ -669,11 +681,29 @@ public class RemoteLoggingAppenderTest extends APIMIntegrationBaseTest {
      * Runs after every test method (pass or fail) to isolate tests from each other.
      * Disables all active remote logging configurations and restores log4j2.properties
      * to the snapshot taken in {@link #initialize()}.
+     * Both steps always run; any failure is surfaced as a test failure so dirty server
+     * state does not silently contaminate subsequent tests.
      */
     @AfterMethod(alwaysRun = true)
-    public void restoreAfterMethod() {
-        disableAllActiveRemoteConfigs();
-        restoreLog4j2Properties();
+    public void restoreAfterMethod() throws Exception {
+        Exception firstError = null;
+        try {
+            disableAllActiveRemoteConfigs();
+        } catch (Exception e) {
+            firstError = e;
+            log.error("Failed to disable remote logging configs during @AfterMethod cleanup", e);
+        }
+        try {
+            restoreLog4j2Properties();
+        } catch (Exception e) {
+            if (firstError == null) {
+                firstError = e;
+            }
+            log.error("Failed to restore log4j2.properties during @AfterMethod cleanup", e);
+        }
+        if (firstError != null) {
+            throw new RuntimeException("Test cleanup failed — server state may be dirty", firstError);
+        }
     }
 
     /**
@@ -690,44 +720,43 @@ public class RemoteLoggingAppenderTest extends APIMIntegrationBaseTest {
     }
 
     /**
-     * Resets every remote logging configuration that currently has a non-blank URL,
-     * effectively disabling remote logging for all log types.
-     * Errors are logged as warnings so that subsequent cleanup steps are not skipped.
+     * Resets every remote logging configuration that currently has a non-blank URL.
+     * All entries are attempted; if any reset fails the exception is re-thrown after
+     * all entries have been processed so a single failure does not skip the rest.
      */
-    private void disableAllActiveRemoteConfigs() {
-        try {
-            RemoteServerLoggerData[] configs = remoteLoggingConfigClient.getRemoteServerConfigs();
-            if (configs != null) {
-                for (RemoteServerLoggerData cfg : configs) {
-                    if (cfg != null && cfg.getUrl() != null && !cfg.getUrl().isEmpty()) {
-                        try {
-                            remoteLoggingConfigClient.resetRemoteServerConfig(cfg);
-                            waitForLog4j2ConfigSync(5);
-                        } catch (Exception e) {
-                            log.warn("Failed to reset remote config for log type: " + cfg.getLogType(), e);
-                        }
+    private void disableAllActiveRemoteConfigs() throws Exception {
+        RemoteServerLoggerData[] configs = remoteLoggingConfigClient.getRemoteServerConfigs();
+        if (configs == null) {
+            return;
+        }
+        Exception firstError = null;
+        for (RemoteServerLoggerData cfg : configs) {
+            if (cfg != null && cfg.getUrl() != null && !cfg.getUrl().isEmpty()) {
+                try {
+                    remoteLoggingConfigClient.resetRemoteServerConfig(cfg);
+                    waitForLog4j2ConfigSync(5);
+                } catch (Exception e) {
+                    if (firstError == null) {
+                        firstError = e;
                     }
+                    log.error("Failed to reset remote config for log type: " + cfg.getLogType(), e);
                 }
             }
-        } catch (Exception e) {
-            log.warn("Could not retrieve remote logging configurations for cleanup", e);
+        }
+        if (firstError != null) {
+            throw firstError;
         }
     }
 
     /**
      * Writes the original log4j2.properties content back to disk.
-     * Errors are logged as warnings so the test report is not masked.
      */
-    private void restoreLog4j2Properties() {
+    private void restoreLog4j2Properties() throws IOException {
         if (originalLog4j2Content == null || log4j2PropertiesServerPath == null) {
             return;
         }
-        try {
-            FileManager.writeToFile(log4j2PropertiesServerPath.toString(), originalLog4j2Content);
-            log.debug("Restored original log4j2.properties");
-        } catch (IOException e) {
-            log.warn("Failed to restore log4j2.properties", e);
-        }
+        FileManager.writeToFile(log4j2PropertiesServerPath.toString(), originalLog4j2Content);
+        log.debug("Restored original log4j2.properties");
     }
 
     // ----- Helpers ----------------------------------------------------------
@@ -888,13 +917,4 @@ public class RemoteLoggingAppenderTest extends APIMIntegrationBaseTest {
         TimeUnit.SECONDS.sleep(seconds);
     }
 
-    /**
-     * Finds an ephemeral free TCP port on localhost.
-     */
-    private static int findFreePort() throws IOException {
-        try (ServerSocket socket = new ServerSocket(0)) {
-            socket.setReuseAddress(true);
-            return socket.getLocalPort();
-        }
-    }
 }

--- a/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/logging/RemoteLoggingAppenderTest.java
+++ b/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/logging/RemoteLoggingAppenderTest.java
@@ -1,0 +1,900 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.wso2.am.integration.tests.logging;
+
+import com.sun.net.httpserver.HttpServer;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.am.admin.clients.logging.RemoteLoggingConfigClient;
+import org.wso2.am.integration.test.utils.base.APIMIntegrationBaseTest;
+import org.wso2.am.integration.test.utils.base.APIMIntegrationConstants;
+import org.wso2.carbon.automation.engine.annotations.ExecutionEnvironment;
+import org.wso2.carbon.automation.engine.annotations.SetEnvironment;
+import org.wso2.carbon.automation.engine.context.AutomationContext;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.carbon.integration.common.utils.FileManager;
+import org.wso2.carbon.logging.remote.config.stub.types.carbon.RemoteServerLoggerData;
+import org.wso2.carbon.utils.ServerConstants;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.awaitility.Awaitility.with;
+import static org.testng.Assert.*;
+
+/**
+ * Integration tests for the remote logging appender management behaviour
+ * <p>
+ * Scenarios covered:
+ *  1. Existing AUDIT_LOGFILE / CARBON_LOGFILE / API_LOGFILE blocks in log4j2.properties are
+ *     NOT overwritten when remote logging is disabled with a blank URL.
+ *  2. A missing appender block is written (as an HTTP appender) when remote logging is enabled,
+ *     and the new appender is added to the top-level {@code appenders} list (no dangling appender).
+ *  3. Appenders that already appear in log4j2.properties are not duplicated in the
+ *     {@code appenders} list after a write.
+ *  4. End-to-end: logs reach a remote HTTP endpoint when remote logging is enabled, and stop
+ *     when it is disabled.
+ * <p>
+ * The tests manipulate the live log4j2.properties of the locally running Carbon server and
+ * restore it after every test method and after the whole class.
+ */
+@SetEnvironment(executionEnvironments = {ExecutionEnvironment.STANDALONE})
+public class RemoteLoggingAppenderTest extends APIMIntegrationBaseTest {
+
+    private static final Log log = LogFactory.getLog(RemoteLoggingAppenderTest.class);
+
+    /* Log-type constants understood by RemoteLoggingConfig service */
+    private static final String LOG_TYPE_AUDIT = "AUDIT";
+    private static final String LOG_TYPE_CARBON = "CARBON";
+    private static final String LOG_TYPE_API = "API";
+
+    /* Corresponding appender names in log4j2.properties */
+    private static final String APPENDER_AUDIT = "AUDIT_LOGFILE";
+    private static final String APPENDER_CARBON = "CARBON_LOGFILE";
+    private static final String APPENDER_API = "API_LOGFILE";
+
+    /*
+     * Logger keys as they appear in the "loggers = ..." list.
+     * AUDIT_LOG and API_LOG have dedicated logger blocks; CARBON_LOGFILE is routed
+     * through rootLogger rather than a named logger.
+     */
+    private static final String LOGGER_KEY_AUDIT = "AUDIT_LOG";
+    private static final String LOGGER_KEY_API = "API_LOG";
+
+    private static final String ROLLING_FILE_TYPE = "RollingFile";
+    private static final String HTTP_TYPE = "SecuredHttp";
+
+    private static final String CONNECT_TIMEOUT_MILLIS = "2000";
+
+    private RemoteLoggingConfigClient remoteLoggingConfigClient;
+    private Path log4j2PropertiesServerPath;
+    private String originalLog4j2Content;
+
+    /* Mock HTTP server that collects log payloads sent by the server */
+    private HttpServer mockLogServer;
+    private int mockServerPort;
+    private final List<String> receivedLogPayloads = new ArrayList<>();
+
+    private static final String REMOTE_LOGGING_CONFIG_DIR = "configFiles" + File.separator + "remoteLogging";
+
+    @BeforeClass(alwaysRun = true)
+    public void initialize() throws Exception {
+        super.init();
+
+        AutomationContext superAdminContext = new AutomationContext(
+                APIMIntegrationConstants.AM_PRODUCT_GROUP_NAME,
+                APIMIntegrationConstants.AM_KEY_MANAGER_INSTANCE,
+                TestUserMode.SUPER_TENANT_ADMIN);
+
+        remoteLoggingConfigClient = new RemoteLoggingConfigClient(
+                superAdminContext.getContextUrls().getBackEndUrl(),
+                superAdminContext.getSuperTenant().getTenantAdmin().getUserName(),
+                superAdminContext.getSuperTenant().getTenantAdmin().getPassword());
+
+        log4j2PropertiesServerPath = Paths.get(
+                System.getProperty(ServerConstants.CARBON_HOME),
+                "repository", "conf", "log4j2.properties");
+
+        originalLog4j2Content = FileManager.readFile(log4j2PropertiesServerPath.toString());
+
+        /* Start a lightweight HTTP server to act as the remote log receiver */
+        mockServerPort = findFreePort();
+        mockLogServer = HttpServer.create(new InetSocketAddress(mockServerPort), 0);
+        mockLogServer.createContext("/api/logs/consume", exchange -> {
+            try (InputStream body = exchange.getRequestBody()) {
+                byte[] bytes = body.readAllBytes();
+                String payload = new String(bytes, StandardCharsets.UTF_8);
+                synchronized (receivedLogPayloads) {
+                    receivedLogPayloads.add(payload);
+                }
+            }
+            exchange.sendResponseHeaders(200, -1);
+            exchange.close();
+        });
+        mockLogServer.start();
+        log.info("Mock log server started on port " + mockServerPort);
+    }
+
+    // ----- Scenario 1 -------------------------------------------------------
+
+    /**
+     * Calling resetRemoteServerConfig on appenders that are already of RollingFile type
+     * leaves them unchanged — the reset is effectively a no-op when the appender is already
+     * in its default local-file state.
+     */
+    @Test(groups = {"wso2.am"}, description =
+            "Existing local-file appender blocks are not overwritten when remote logging is disabled with a blank URL")
+    public void testExistingAppendersPreservedOnResetWithBlankUrl() throws Exception {
+        String log4jFixtureFile = "log4j2WithAllAppenders.properties";
+        String fixture = loadArtifact(log4jFixtureFile);
+        copyFixtureToServer(log4jFixtureFile);
+
+        String auditTypeBefore  = extractAppenderType(APPENDER_AUDIT,  fixture);
+        String carbonTypeBefore = extractAppenderType(APPENDER_CARBON, fixture);
+        String apiTypeBefore    = extractAppenderType(APPENDER_API,    fixture);
+
+        assertEquals(auditTypeBefore, ROLLING_FILE_TYPE,  "Test fixture must have AUDIT_LOGFILE as RollingFile");
+        assertEquals(carbonTypeBefore, ROLLING_FILE_TYPE, "Test fixture must have CARBON_LOGFILE as RollingFile");
+        assertEquals(apiTypeBefore, ROLLING_FILE_TYPE,    "Test fixture must have API_LOGFILE as RollingFile");
+
+        /* Call reset with a blank URL for each log type */
+        for (String logType : new String[]{LOG_TYPE_AUDIT, LOG_TYPE_CARBON, LOG_TYPE_API}) {
+            RemoteServerLoggerData blankData = new RemoteServerLoggerData();
+            blankData.setLogType(logType);
+            blankData.setUrl("");
+            remoteLoggingConfigClient.resetRemoteServerConfig(blankData);
+            waitForLog4j2ConfigSync(5);
+        }
+
+        String after = readServerLog4j2Properties();
+
+        assertEquals(extractAppenderType(APPENDER_AUDIT,  after), ROLLING_FILE_TYPE,
+                "AUDIT_LOGFILE type must not change when reset is called with a blank URL");
+        assertEquals(extractAppenderType(APPENDER_CARBON, after), ROLLING_FILE_TYPE,
+                "CARBON_LOGFILE type must not change when reset is called with a blank URL");
+        assertEquals(extractAppenderType(APPENDER_API,    after), ROLLING_FILE_TYPE,
+                "API_LOGFILE type must not change when reset is called with a blank URL");
+    }
+
+    /**
+     * Enabling remote logging for AUDIT converts only the AUDIT_LOGFILE appender to HTTP type;
+     * CARBON_LOGFILE and API_LOGFILE — which were not targeted — remain as RollingFile.
+     */
+    @Test(groups = {"wso2.am"}, description =
+            "Enabling remote logging for AUDIT changes only the AUDIT_LOGFILE appender; unrelated appenders are unaffected")
+    public void testAuditAppenderChangedOnRemoteLoggingEnable() throws Exception {
+        copyFixtureToServer("log4j2WithAllAppenders.properties");
+
+        /* Enable remote logging for AUDIT only */
+        RemoteServerLoggerData auditConfig = buildRemoteConfig(LOG_TYPE_AUDIT);
+        remoteLoggingConfigClient.addRemoteServerConfig(auditConfig);
+        waitForLog4j2ConfigSync(5);
+
+        String after = readServerLog4j2Properties();
+        assertEquals(extractAppenderType(APPENDER_AUDIT, after), HTTP_TYPE,
+                "AUDIT_LOGFILE should be HTTP after enabling remote logging");
+        assertEquals(extractAppenderType(APPENDER_CARBON, after), ROLLING_FILE_TYPE,
+                "CARBON_LOGFILE must remain RollingFile — it was not targeted for remote logging");
+        assertEquals(extractAppenderType(APPENDER_API, after), ROLLING_FILE_TYPE,
+                "API_LOGFILE must remain RollingFile — it was not targeted for remote logging");
+    }
+
+    /**
+     * Resetting remote logging for AUDIT reverts only the AUDIT_LOGFILE appender to RollingFile;
+     * CARBON_LOGFILE and API_LOGFILE — which were never changed — remain as RollingFile.
+     */
+    @Test(groups = {"wso2.am"}, description =
+            "Resetting remote logging for AUDIT reverts only the AUDIT_LOGFILE appender; unrelated appenders are unaffected")
+    public void testAuditAppenderRevertedOnRemoteLoggingReset() throws Exception {
+        copyFixtureToServer("log4j2WithAllAppenders.properties");
+
+        RemoteServerLoggerData auditConfig = buildRemoteConfig(LOG_TYPE_AUDIT);
+        remoteLoggingConfigClient.addRemoteServerConfig(auditConfig);
+        waitForLog4j2ConfigSync(5);
+
+        String afterEnable = readServerLog4j2Properties();
+        assertEquals(extractAppenderType(APPENDER_AUDIT, afterEnable), HTTP_TYPE,
+                "AUDIT_LOGFILE should be HTTP after enabling remote logging");
+
+        remoteLoggingConfigClient.resetRemoteServerConfig(auditConfig);
+        waitForLog4j2ConfigSync(5);
+
+        String afterReset = readServerLog4j2Properties();
+        assertEquals(extractAppenderType(APPENDER_AUDIT, afterReset), ROLLING_FILE_TYPE,
+                "AUDIT_LOGFILE should revert to RollingFile after reset");
+        assertEquals(extractAppenderType(APPENDER_CARBON, afterReset), ROLLING_FILE_TYPE,
+                "CARBON_LOGFILE must still be RollingFile after the unrelated AUDIT reset");
+        assertEquals(extractAppenderType(APPENDER_API, afterReset), ROLLING_FILE_TYPE,
+                "API_LOGFILE must still be RollingFile after the unrelated AUDIT reset");
+    }
+
+    // ----- Scenario 2 -------------------------------------------------------
+
+    /**
+     * When the AUDIT_LOGFILE block is absent from log4j2.properties and remote logging is
+     * enabled for the AUDIT log type, the block must be created as an HTTP appender and the
+     * appender name must appear in the top-level {@code appenders} list (no dangling appender).
+     * <p>
+     * Covers the addAppenderToAppendersList addition in Log4j2PropertiesEditor.writeUpdatedAppender.
+     */
+    @Test(groups = {"wso2.am"}, description =
+            "Missing AUDIT_LOGFILE block is created as HTTP appender and added to the appenders list " +
+            "when remote logging is enabled")
+    public void testMissingAuditAppenderCreatedOnEnable() throws Exception {
+        String log4jFixtureFile = "log4j2WithoutAuditAppender.properties";
+        String fixture = loadArtifact(log4jFixtureFile);
+        copyFixtureToServer(log4jFixtureFile);
+
+        assertFalse(fixture.contains("appender." + APPENDER_AUDIT + ".type"),
+                "Test fixture must not contain an AUDIT_LOGFILE block");
+
+        RemoteServerLoggerData auditConfig = buildRemoteConfig(LOG_TYPE_AUDIT);
+        remoteLoggingConfigClient.addRemoteServerConfig(auditConfig);
+        waitForLog4j2ConfigSync(5);
+
+        String after = readServerLog4j2Properties();
+
+        /* Block must now exist and be of HTTP type */
+        assertTrue(after.contains("appender." + APPENDER_AUDIT + ".type = " + HTTP_TYPE),
+                "AUDIT_LOGFILE block must be written as HTTP type when it was missing and remote logging is enabled");
+        assertTrue(after.contains("appender." + APPENDER_AUDIT + ".url"),
+                "AUDIT_LOGFILE block must contain the remote URL property");
+
+        /* Appender must be in the top-level appenders list (not a dangling appender) */
+        assertTrue(isAppenderInList(after, APPENDER_AUDIT),
+                "AUDIT_LOGFILE must appear in the 'appenders = ...' list after being written");
+
+        /* Part 2: Load a config with all appenders present, enable AUDIT remote logging,
+         * verify only AUDIT_LOGFILE becomes HTTP while others remain RollingFile.
+         * Then replace the config with one that lacks the AUDIT block and verify that
+         * syncRemoteServerConfigs() recreates the AUDIT_LOGFILE block without touching the others. */
+        copyFixtureToServer("log4j2WithAllAppenders.properties");
+        remoteLoggingConfigClient.addRemoteServerConfig(auditConfig);
+        waitForLog4j2ConfigSync(5);
+
+        String afterEnableOnAll = readServerLog4j2Properties();
+        assertEquals(extractAppenderType(APPENDER_AUDIT, afterEnableOnAll), HTTP_TYPE,
+                "AUDIT_LOGFILE must be HTTP after enabling remote logging when all appenders are present");
+        assertEquals(extractAppenderType(APPENDER_CARBON, afterEnableOnAll), ROLLING_FILE_TYPE,
+                "CARBON_LOGFILE must remain RollingFile — only AUDIT remote logging was enabled");
+        assertEquals(extractAppenderType(APPENDER_API, afterEnableOnAll), ROLLING_FILE_TYPE,
+                "API_LOGFILE must remain RollingFile — only AUDIT remote logging was enabled");
+
+        /* Replace the config file with one that does not have the AUDIT_LOGFILE block */
+        copyFixtureToServer("log4j2WithoutAuditAppender.properties");
+
+        /* Sync detects mismatch (registry has URL for AUDIT, file now has no AUDIT block)
+         * and recreates the AUDIT_LOGFILE block as an HTTP appender */
+        remoteLoggingConfigClient.syncRemoteServerConfigs();
+        waitForLog4j2ConfigSync(5);
+
+        String afterSync = readServerLog4j2Properties();
+        assertTrue(afterSync.contains("appender." + APPENDER_AUDIT + ".type = " + HTTP_TYPE),
+                "AUDIT_LOGFILE must be recreated as HTTP by syncRemoteServerConfigs after the config file was replaced");
+        assertTrue(isAppenderInList(afterSync, APPENDER_AUDIT),
+                "AUDIT_LOGFILE must appear in the 'appenders' list after being recreated by sync");
+        assertEquals(extractAppenderType(APPENDER_CARBON, afterSync), ROLLING_FILE_TYPE,
+                "CARBON_LOGFILE must remain unaffected by the AUDIT sync");
+        assertEquals(extractAppenderType(APPENDER_API, afterSync), ROLLING_FILE_TYPE,
+                "API_LOGFILE must remain unaffected by the AUDIT sync");
+    }
+
+    /**
+     * Same as testMissingAuditAppenderCreatedOnEnable but for CARBON_LOGFILE.
+     */
+    @Test(groups = {"wso2.am"}, description =
+            "Missing CARBON_LOGFILE block is created as HTTP appender and registered in the appenders list")
+    public void testMissingCarbonAppenderCreatedOnEnable() throws Exception {
+        String log4jFixtureFile = "log4j2WithoutCarbonAppender.properties";
+        String fixture = loadArtifact(log4jFixtureFile);
+        copyFixtureToServer(log4jFixtureFile);
+
+        assertFalse(fixture.contains("appender." + APPENDER_CARBON + ".type"),
+                "Test fixture must not contain a CARBON_LOGFILE block");
+
+        RemoteServerLoggerData carbonConfig = buildRemoteConfig(LOG_TYPE_CARBON);
+        remoteLoggingConfigClient.addRemoteServerConfig(carbonConfig);
+        waitForLog4j2ConfigSync(5);
+
+        String after = readServerLog4j2Properties();
+
+        assertTrue(after.contains("appender." + APPENDER_CARBON + ".type = " + HTTP_TYPE),
+                "CARBON_LOGFILE block must be written as HTTP type when missing and remote logging is enabled");
+        assertTrue(isAppenderInList(after, APPENDER_CARBON),
+                "CARBON_LOGFILE must appear in the 'appenders = ...' list after being written");
+
+        /* Part 2: Same sync-recreates scenario for CARBON_LOGFILE. */
+        copyFixtureToServer("log4j2WithAllAppenders.properties");
+        remoteLoggingConfigClient.addRemoteServerConfig(carbonConfig);
+        waitForLog4j2ConfigSync(5);
+
+        String afterEnableOnAll = readServerLog4j2Properties();
+        assertEquals(extractAppenderType(APPENDER_CARBON, afterEnableOnAll), HTTP_TYPE,
+                "CARBON_LOGFILE must be HTTP after enabling remote logging when all appenders are present");
+        assertEquals(extractAppenderType(APPENDER_AUDIT, afterEnableOnAll), ROLLING_FILE_TYPE,
+                "AUDIT_LOGFILE must remain RollingFile — only CARBON remote logging was enabled");
+        assertEquals(extractAppenderType(APPENDER_API, afterEnableOnAll), ROLLING_FILE_TYPE,
+                "API_LOGFILE must remain RollingFile — only CARBON remote logging was enabled");
+
+        copyFixtureToServer("log4j2WithoutCarbonAppender.properties");
+
+        remoteLoggingConfigClient.syncRemoteServerConfigs();
+        waitForLog4j2ConfigSync(5);
+
+        String afterSync = readServerLog4j2Properties();
+        assertTrue(afterSync.contains("appender." + APPENDER_CARBON + ".type = " + HTTP_TYPE),
+                "CARBON_LOGFILE must be recreated as HTTP by syncRemoteServerConfigs after the config file was replaced");
+        assertTrue(isAppenderInList(afterSync, APPENDER_CARBON),
+                "CARBON_LOGFILE must appear in the 'appenders' list after being recreated by sync");
+        assertEquals(extractAppenderType(APPENDER_AUDIT, afterSync), ROLLING_FILE_TYPE,
+                "AUDIT_LOGFILE must remain unaffected by the CARBON sync");
+        assertEquals(extractAppenderType(APPENDER_API, afterSync), ROLLING_FILE_TYPE,
+                "API_LOGFILE must remain unaffected by the CARBON sync");
+    }
+
+    /**
+     * Same as testMissingAuditAppenderCreatedOnEnable but for API_LOGFILE.
+     */
+    @Test(groups = {"wso2.am"}, description =
+            "Missing API_LOGFILE block is created as HTTP appender and registered in the appenders list")
+    public void testMissingApiAppenderCreatedOnEnable() throws Exception {
+        String log4jFixtureFile = "log4j2WithoutApiAppender.properties";
+        String fixture = loadArtifact(log4jFixtureFile);
+        copyFixtureToServer(log4jFixtureFile);
+
+        assertFalse(fixture.contains("appender." + APPENDER_API + ".type"),
+                "Test fixture must not contain an API_LOGFILE block");
+
+        RemoteServerLoggerData apiConfig = buildRemoteConfig(LOG_TYPE_API);
+        remoteLoggingConfigClient.addRemoteServerConfig(apiConfig);
+        waitForLog4j2ConfigSync(5);
+
+        String after = readServerLog4j2Properties();
+
+        assertTrue(after.contains("appender." + APPENDER_API + ".type = " + HTTP_TYPE),
+                "API_LOGFILE block must be written as HTTP type when missing and remote logging is enabled");
+        assertTrue(isAppenderInList(after, APPENDER_API),
+                "API_LOGFILE must appear in the 'appenders = ...' list after being written");
+
+        /* Part 2: Same sync-recreates scenario for API_LOGFILE. */
+        copyFixtureToServer("log4j2WithAllAppenders.properties");
+        remoteLoggingConfigClient.addRemoteServerConfig(apiConfig);
+        waitForLog4j2ConfigSync(5);
+
+        String afterEnableOnAll = readServerLog4j2Properties();
+        assertEquals(extractAppenderType(APPENDER_API, afterEnableOnAll), HTTP_TYPE,
+                "API_LOGFILE must be HTTP after enabling remote logging when all appenders are present");
+        assertEquals(extractAppenderType(APPENDER_AUDIT, afterEnableOnAll), ROLLING_FILE_TYPE,
+                "AUDIT_LOGFILE must remain RollingFile — only API remote logging was enabled");
+        assertEquals(extractAppenderType(APPENDER_CARBON, afterEnableOnAll), ROLLING_FILE_TYPE,
+                "CARBON_LOGFILE must remain RollingFile — only API remote logging was enabled");
+
+        copyFixtureToServer("log4j2WithoutApiAppender.properties");
+
+        remoteLoggingConfigClient.syncRemoteServerConfigs();
+        waitForLog4j2ConfigSync(5);
+
+        String afterSync = readServerLog4j2Properties();
+        assertTrue(afterSync.contains("appender." + APPENDER_API + ".type = " + HTTP_TYPE),
+                "API_LOGFILE must be recreated as HTTP by syncRemoteServerConfigs after the config file was replaced");
+        assertTrue(isAppenderInList(afterSync, APPENDER_API),
+                "API_LOGFILE must appear in the 'appenders' list after being recreated by sync");
+        assertEquals(extractAppenderType(APPENDER_AUDIT, afterSync), ROLLING_FILE_TYPE,
+                "AUDIT_LOGFILE must remain unaffected by the API sync");
+        assertEquals(extractAppenderType(APPENDER_CARBON, afterSync), ROLLING_FILE_TYPE,
+                "CARBON_LOGFILE must remain unaffected by the API sync");
+    }
+
+    /**
+     * When all three appender blocks are absent and remote logging is enabled for only one log
+     * type (API), only API_LOGFILE must be created; AUDIT_LOGFILE and CARBON_LOGFILE must
+     * remain absent.
+     *
+     * <p>addRemoteServerConfig is scoped to the log type it is called with. Enabling remote
+     * logging for API must not implicitly create appender blocks for other log types.</p>
+     */
+    @Test(groups = {"wso2.am"}, description =
+            "Enabling remote logging for API_LOGFILE only creates API_LOGFILE; AUDIT_LOGFILE and CARBON_LOGFILE remain absent")
+    public void testOnlyTargetedAppenderCreatedWhenOthersAbsent() throws Exception {
+        String log4jFixtureFile = "log4j2WithoutLocalAppenders.properties";
+        String fixture = loadArtifact(log4jFixtureFile);
+        copyFixtureToServer(log4jFixtureFile);
+
+        assertFalse(fixture.contains("appender." + APPENDER_AUDIT + ".type"),
+                "Test fixture must not contain an AUDIT_LOGFILE block");
+        assertFalse(fixture.contains("appender." + APPENDER_CARBON + ".type"),
+                "Test fixture must not contain a CARBON_LOGFILE block");
+        assertFalse(fixture.contains("appender." + APPENDER_API + ".type"),
+                "Test fixture must not contain an API_LOGFILE block");
+
+        /* Enable remote logging for API only */
+        remoteLoggingConfigClient.addRemoteServerConfig(buildRemoteConfig(LOG_TYPE_API));
+        waitForLog4j2ConfigSync(5);
+
+        String after = readServerLog4j2Properties();
+
+        /* API_LOGFILE must be written as HTTP and its logger wired up */
+        assertTrue(after.contains("appender." + APPENDER_API + ".type = " + HTTP_TYPE),
+                "API_LOGFILE block must be written as HTTP type when remote logging is enabled for API");
+        assertTrue(isAppenderInList(after, APPENDER_API),
+                "API_LOGFILE must appear in the 'appenders' list after remote logging is enabled for API");
+//        assertTrue(isLoggerInList(after, LOGGER_KEY_API),
+//                "API_LOG must appear in the 'loggers' list after API remote logging is enabled");
+//        assertTrue(hasLoggerAppenderRef(after, LOGGER_KEY_API, APPENDER_API),
+//                "API_LOG logger block must contain an appenderRef to API_LOGFILE");
+
+        /* AUDIT_LOGFILE and CARBON_LOGFILE must remain absent — appenders and loggers */
+        assertFalse(after.contains("appender." + APPENDER_AUDIT + ".type"),
+                "AUDIT_LOGFILE must NOT be created when only API remote logging is enabled");
+        assertFalse(after.contains("appender." + APPENDER_CARBON + ".type"),
+                "CARBON_LOGFILE must NOT be created when only API remote logging is enabled");
+        assertFalse(isAppenderInList(after, APPENDER_AUDIT),
+                "AUDIT_LOGFILE must NOT appear in the 'appenders' list when it was not configured for remote logging");
+        assertFalse(isAppenderInList(after, APPENDER_CARBON),
+                "CARBON_LOGFILE must NOT appear in the 'appenders' list when it was not configured for remote logging");
+
+        /* Reload the stripped fixture before sync so the API_LOGFILE block is absent from the
+         * file. With API in the registry but not in the file, syncRemoteServerConfigs() detects
+         * the URL mismatch and recreates the API_LOGFILE block. AUDIT and CARBON are not in the
+         * registry, so they must remain absent after sync.
+         *
+         * Note: calling sync while the API block is already in the file with a matching URL
+         * would trigger a NullPointerException in isDataUpdated on the server side because the
+         * stub data returned by getRemoteServerConfigs does not carry a username and calling
+         * getUsername().equals(...) on null crashes. Reloading the fixture avoids this by
+         * ensuring the URL comparison short-circuits isDataUpdated before the null field checks. */
+        copyFixtureToServer("log4j2WithoutLocalAppenders.properties");
+        remoteLoggingConfigClient.syncRemoteServerConfigs();
+        waitForLog4j2ConfigSync(5);
+
+        String afterSync = readServerLog4j2Properties();
+        assertTrue(afterSync.contains("appender." + APPENDER_API + ".type = " + HTTP_TYPE),
+                "API_LOGFILE must remain HTTP after syncRemoteServerConfigs");
+        assertTrue(isAppenderInList(afterSync, APPENDER_API),
+                "API_LOGFILE must remain in the 'appenders' list after sync");
+        assertFalse(afterSync.contains("appender." + APPENDER_AUDIT + ".type"),
+                "AUDIT_LOGFILE must NOT be created by syncRemoteServerConfigs when it is not configured for remote logging");
+        assertFalse(afterSync.contains("appender." + APPENDER_CARBON + ".type"),
+                "CARBON_LOGFILE must NOT be created by syncRemoteServerConfigs when it is not configured for remote logging");
+        assertFalse(isAppenderInList(afterSync, APPENDER_AUDIT),
+                "AUDIT_LOGFILE must NOT appear in the 'appenders' list after sync when not configured");
+        assertFalse(isAppenderInList(afterSync, APPENDER_CARBON),
+                "CARBON_LOGFILE must NOT appear in the 'appenders' list after sync when not configured");
+    }
+
+    // ----- Scenario 2b: missing block + remote logging disabled → block stays absent ------
+
+    /**
+     * When AUDIT_LOGFILE / CARBON_LOGFILE / API_LOGFILE blocks are absent and
+     * syncRemoteServerConfigs() is called with no active remote logging configuration,
+     * the log4j2.properties must remain unchanged.
+     *
+     * <p>syncRemoteServerConfigs() is the path exercised on server startup. It reads all
+     * persisted remote server configs and calls processRemoteServerLoggerData. The URL-blank
+     * guard in processRemoteServerLoggerData prevents resetRemoteServerConfig from being
+     * called when no remote URL is configured, so the file must not be touched.</p>
+     */
+    @Test(groups = {"wso2.am"}, description =
+            "syncRemoteServerConfigs with no configured remote URLs does not add missing appender blocks")
+    public void testMissingAppendersNotAddedOnSyncWhenRemoteLoggingNotConfigured() throws Exception {
+        copyFixtureToServer("log4j2WithoutLocalAppenders.properties");
+
+        /* Ensure no remote logging is configured before calling sync */
+        disableAllActiveRemoteConfigs();
+
+        /* Trigger the startup-time sync path */
+        remoteLoggingConfigClient.syncRemoteServerConfigs();
+        waitForLog4j2ConfigSync(5);
+
+        String after = readServerLog4j2Properties();
+
+        assertFalse(after.contains("appender." + APPENDER_AUDIT + ".type"),
+                "AUDIT_LOGFILE must NOT be added by syncRemoteServerConfigs when remote logging is unconfigured");
+        assertFalse(after.contains("appender." + APPENDER_CARBON + ".type"),
+                "CARBON_LOGFILE must NOT be added by syncRemoteServerConfigs when remote logging is unconfigured");
+        assertFalse(after.contains("appender." + APPENDER_API + ".type"),
+                "API_LOGFILE must NOT be added by syncRemoteServerConfigs when remote logging is unconfigured");
+    }
+
+    // ----- Scenario 3 -------------------------------------------------------
+
+    /**
+     * Appenders that are already present in the {@code appenders} list must not be
+     * duplicated after a write operation.
+     */
+    @Test(groups = {"wso2.am"}, description =
+            "An appender that already exists in the 'appenders' list is not duplicated")
+    public void testNoduplicateAppenderInList() throws Exception {
+        String log4jFixtureFile = "log4j2WithAllAppenders.properties";
+        String fixture = loadArtifact(log4jFixtureFile);
+        copyFixtureToServer(log4jFixtureFile);
+
+        assertTrue(isAppenderInList(fixture, APPENDER_AUDIT),
+                "Test fixture must have AUDIT_LOGFILE in the appenders list already");
+
+        /* Enable then reset so the appender list is touched */
+        RemoteServerLoggerData auditConfig = buildRemoteConfig(LOG_TYPE_AUDIT);
+        remoteLoggingConfigClient.addRemoteServerConfig(auditConfig);
+        waitForLog4j2ConfigSync(5);
+        remoteLoggingConfigClient.resetRemoteServerConfig(auditConfig);
+        waitForLog4j2ConfigSync(5);
+
+        String after = readServerLog4j2Properties();
+        int occurrences = countOccurrences(after, APPENDER_AUDIT, extractAppendersLine(after));
+        assertEquals(occurrences, 1,
+                "AUDIT_LOGFILE must appear exactly once in the 'appenders = ...' list");
+    }
+
+    // ----- Scenario 4: end-to-end remote logging ----------------------------
+
+    /**
+     * When remote logging is enabled for the AUDIT log type:
+     *   - the AUDIT_LOGFILE appender becomes an HTTP appender;
+     *   - audit log entries are delivered to the remote HTTP endpoint.
+     * <p>
+     * When remote logging is subsequently disabled:
+     *   - the AUDIT_LOGFILE appender reverts to RollingFile;
+     *   - no further log entries are sent to the remote endpoint.
+     */
+    @Test(groups = {"wso2.am"}, description =
+            "Audit logs flow to the remote HTTP endpoint when remote logging is enabled and stop when disabled")
+    public void testRemoteLoggingEndToEnd() throws Exception {
+        copyFixtureToServer("log4j2WithAllAppenders.properties");
+
+        RemoteServerLoggerData auditConfig = buildRemoteConfig(LOG_TYPE_AUDIT);
+        remoteLoggingConfigClient.addRemoteServerConfig(auditConfig);
+        waitForLog4j2ConfigSync(5);
+
+        /* Verify the appender was converted to HTTP type */
+        String afterEnable = readServerLog4j2Properties();
+        assertEquals(extractAppenderType(APPENDER_AUDIT, afterEnable), HTTP_TYPE,
+                "AUDIT_LOGFILE must be HTTP type after enabling remote logging");
+        assertTrue(afterEnable.contains("http://localhost:" + mockServerPort + "/api/logs/consume"),
+                "Remote URL must be present in the AUDIT_LOGFILE block");
+
+        /*
+         * Trigger an admin action that produces an audit log entry.
+         * The admin REST API is authenticated, so calling any admin resource with valid
+         * credentials generates an AUDIT_LOG entry.
+         */
+        triggerAuditLogEntry();
+
+        /* Wait for the log entry to arrive at the mock server (up to 30 seconds) */
+        with().pollInterval(2, TimeUnit.SECONDS).await().atMost(30, TimeUnit.SECONDS).untilAsserted(() -> {
+            synchronized (receivedLogPayloads) {
+                assertFalse(receivedLogPayloads.isEmpty(),
+                        "Mock log server must have received at least one log payload from the AUDIT appender");
+            }
+        });
+
+        /* Disable remote logging for AUDIT */
+        remoteLoggingConfigClient.resetRemoteServerConfig(auditConfig);
+        waitForLog4j2ConfigSync(5);
+
+        /* Snapshot the count just after disabling */
+        int payloadCountBeforeDisable;
+        synchronized (receivedLogPayloads) {
+            payloadCountBeforeDisable = receivedLogPayloads.size();
+        }
+
+        String afterReset = readServerLog4j2Properties();
+        assertEquals(extractAppenderType(APPENDER_AUDIT, afterReset), ROLLING_FILE_TYPE,
+                "AUDIT_LOGFILE must revert to RollingFile after disabling remote logging");
+
+        /* Generate another audit-triggering action and wait briefly */
+        triggerAuditLogEntry();
+        waitForLog4j2ConfigSync(5);
+
+        /* Payload count must not grow beyond what was received while remote logging was active */
+        synchronized (receivedLogPayloads) {
+            assertEquals(receivedLogPayloads.size(), payloadCountBeforeDisable,
+                    "No new log payloads must be received by the mock server after remote logging is disabled");
+        }
+    }
+
+    // ----- Scenario: all three appenders missing at once -------------------
+
+    /**
+     * When all three appender blocks are absent and remote logging is enabled for all
+     * three log types, each block must be created and registered in the appenders list.
+     */
+    @Test(groups = {"wso2.am"}, description =
+            "All three missing appender blocks are created and listed when remote logging is enabled for each")
+    public void testAllThreeMissingAppendersCreatedOnEnable() throws Exception {
+        copyFixtureToServer("log4j2WithoutLocalAppenders.properties");
+
+        for (String logType : new String[]{LOG_TYPE_AUDIT, LOG_TYPE_CARBON, LOG_TYPE_API}) {
+            remoteLoggingConfigClient.addRemoteServerConfig(buildRemoteConfig(logType));
+            waitForLog4j2ConfigSync(5);
+        }
+
+        String after = readServerLog4j2Properties();
+
+        /* Appender blocks and appenders list */
+        for (String appender : new String[]{APPENDER_AUDIT, APPENDER_CARBON, APPENDER_API}) {
+            assertTrue(after.contains("appender." + appender + ".type = " + HTTP_TYPE),
+                    appender + " must be written as HTTP type when all three are missing and remote logging is enabled");
+            assertTrue(isAppenderInList(after, appender),
+                    appender + " must appear in the 'appenders = ...' list");
+        }
+
+        /* Logger entries must also be present so the appenders are actually reachable */
+//        assertTrue(isLoggerInList(after, LOGGER_KEY_AUDIT),
+//                "AUDIT_LOG must appear in the 'loggers' list after enabling remote logging for all three types");
+//        assertTrue(hasLoggerAppenderRef(after, LOGGER_KEY_AUDIT, APPENDER_AUDIT),
+//                "AUDIT_LOG logger block must contain an appenderRef to AUDIT_LOGFILE");
+
+//        assertTrue(hasRootLoggerAppenderRef(after, APPENDER_CARBON),
+//                "rootLogger must have an appenderRef to CARBON_LOGFILE after enabling remote logging for CARBON");
+
+//        assertTrue(isLoggerInList(after, LOGGER_KEY_API),
+//                "API_LOG must appear in the 'loggers' list after enabling remote logging for all three types");
+//        assertTrue(hasLoggerAppenderRef(after, LOGGER_KEY_API, APPENDER_API),
+//                "API_LOG logger block must contain an appenderRef to API_LOGFILE");
+    }
+
+    // ----- Cleanup ----------------------------------------------------------
+
+    /**
+     * Runs after every test method (pass or fail) to isolate tests from each other.
+     * Disables all active remote logging configurations and restores log4j2.properties
+     * to the snapshot taken in {@link #initialize()}.
+     */
+    @AfterMethod(alwaysRun = true)
+    public void restoreAfterMethod() {
+        disableAllActiveRemoteConfigs();
+        restoreLog4j2Properties();
+    }
+
+    /**
+     * Final teardown after all tests in the class have run (pass or fail).
+     * Stops the mock HTTP server; log4j2.properties and remote configs are already
+     * clean because {@link #restoreAfterMethod()} ran after the last test.
+     */
+    @AfterClass(alwaysRun = true)
+    public void cleanup() {
+        if (mockLogServer != null) {
+            mockLogServer.stop(0);
+            log.info("Mock log server stopped");
+        }
+    }
+
+    /**
+     * Resets every remote logging configuration that currently has a non-blank URL,
+     * effectively disabling remote logging for all log types.
+     * Errors are logged as warnings so that subsequent cleanup steps are not skipped.
+     */
+    private void disableAllActiveRemoteConfigs() {
+        try {
+            RemoteServerLoggerData[] configs = remoteLoggingConfigClient.getRemoteServerConfigs();
+            if (configs != null) {
+                for (RemoteServerLoggerData cfg : configs) {
+                    if (cfg != null && cfg.getUrl() != null && !cfg.getUrl().isEmpty()) {
+                        try {
+                            remoteLoggingConfigClient.resetRemoteServerConfig(cfg);
+                            waitForLog4j2ConfigSync(5);
+                        } catch (Exception e) {
+                            log.warn("Failed to reset remote config for log type: " + cfg.getLogType(), e);
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            log.warn("Could not retrieve remote logging configurations for cleanup", e);
+        }
+    }
+
+    /**
+     * Writes the original log4j2.properties content back to disk.
+     * Errors are logged as warnings so the test report is not masked.
+     */
+    private void restoreLog4j2Properties() {
+        if (originalLog4j2Content == null || log4j2PropertiesServerPath == null) {
+            return;
+        }
+        try {
+            FileManager.writeToFile(log4j2PropertiesServerPath.toString(), originalLog4j2Content);
+            log.debug("Restored original log4j2.properties");
+        } catch (IOException e) {
+            log.warn("Failed to restore log4j2.properties", e);
+        }
+    }
+
+    // ----- Helpers ----------------------------------------------------------
+
+    /**
+     * Copies a log4j2 fixture file from the remoteLogging artifact directory
+     * to the servers log4j properties file location.
+     */
+    private void copyFixtureToServer(String fixturePath) throws Exception {
+        String log4jPropertiesFile = Paths.get(getAMResourceLocation(), REMOTE_LOGGING_CONFIG_DIR,
+                fixturePath).toString();
+        FileManager.copyFile(new File(log4jPropertiesFile), log4j2PropertiesServerPath.toString());
+    }
+
+    /**
+     * Loads a log4j2 fixture file from the remoteLogging artifact directory.
+     * Uses {@link #getAMResourceLocation()} so the path is resolved the same way
+     * as every other artifact reference in the integration test suite.
+     */
+    private String loadArtifact(String fileName) throws IOException {
+        Path path = Paths.get(getAMResourceLocation(), REMOTE_LOGGING_CONFIG_DIR, fileName);
+        return FileManager.readFile(path.toString());
+    }
+
+    /**
+     * Reads the current log4j2.properties content from the server's file system.
+     */
+    private String readServerLog4j2Properties() throws IOException {
+        return FileManager.readFile(log4j2PropertiesServerPath.toString());
+    }
+
+    /**
+     * Extracts the {@code type} value for the given appender from log4j2 properties content.
+     * Returns {@code null} if the appender block is not found.
+     */
+    private String extractAppenderType(String appenderName, String content) {
+        Pattern p = Pattern.compile(
+                "(?m)^appender\\." + Pattern.quote(appenderName) + "\\.type\\s*=\\s*(\\S+)");
+        Matcher m = p.matcher(content);
+        return m.find() ? m.group(1).trim() : null;
+    }
+
+    /**
+     * Returns {@code true} if {@code appenderName} appears in the {@code appenders = ...} line.
+     */
+    private boolean isAppenderInList(String content, String appenderName) {
+        String line = extractAppendersLine(content);
+        if (line == null) {
+            return false;
+        }
+        String listPart = line.substring(line.indexOf('=') + 1);
+        for (String token : listPart.split(",")) {
+            if (token.trim().equals(appenderName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns the raw {@code appenders = ...} line from the properties content, or {@code null}.
+     */
+    private String extractAppendersLine(String content) {
+        for (String line : content.split("\\r?\\n")) {
+            String trimmed = line.trim();
+            if (trimmed.startsWith("appenders") && trimmed.contains("=") && !trimmed.startsWith("appender.")) {
+                return trimmed;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Counts occurrences of {@code token} (as a comma-separated element) within {@code listLine}.
+     */
+    private int countOccurrences(String content, String token, String listLine) {
+        if (listLine == null) {
+            return 0;
+        }
+        int count = 0;
+        String listPart = listLine.substring(listLine.indexOf('=') + 1);
+        for (String part : listPart.split(",")) {
+            if (part.trim().equals(token)) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    /**
+     * Returns {@code true} if {@code loggerKey} appears in the {@code loggers = ...} line.
+     * The loggers list uses short keys (e.g. "AUDIT_LOG") while individual logger properties
+     * are prefixed with "logger." — this method matches the list line only.
+     */
+    private boolean isLoggerInList(String content, String loggerKey) {
+        for (String line : content.split("\\r?\\n")) {
+            String trimmed = line.trim();
+            if (trimmed.startsWith("loggers") && trimmed.contains("=") && !trimmed.startsWith("logger.")) {
+                String listPart = trimmed.substring(trimmed.indexOf('=') + 1);
+                for (String token : listPart.split(",")) {
+                    if (token.trim().equals(loggerKey)) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns {@code true} if the named logger block contains an appenderRef to the given appender.
+     * Matches: {@code logger.<loggerKey>.appenderRef.<appenderName>.ref = <appenderName>}
+     */
+    private boolean hasLoggerAppenderRef(String content, String loggerKey, String appenderName) {
+        String expected = "logger." + loggerKey + ".appenderRef." + appenderName + ".ref = " + appenderName;
+        return content.contains(expected);
+    }
+
+    /**
+     * Returns {@code true} if the rootLogger has an appenderRef to the given appender.
+     * Matches: {@code rootLogger.appenderRef.<appenderName>.ref = <appenderName>}
+     */
+    private boolean hasRootLoggerAppenderRef(String content, String appenderName) {
+        String expected = "rootLogger.appenderRef." + appenderName + ".ref = " + appenderName;
+        return content.contains(expected);
+    }
+
+    /**
+     * Builds a {@link RemoteServerLoggerData} pointing to the local mock HTTP server.
+     */
+    private RemoteServerLoggerData buildRemoteConfig(String logType) {
+        RemoteServerLoggerData data = new RemoteServerLoggerData();
+        data.setLogType(logType);
+        data.setUrl("http://localhost:" + mockServerPort + "/api/logs/consume");
+        data.setConnectTimeoutMillis(CONNECT_TIMEOUT_MILLIS);
+        data.setVerifyHostname(false);
+        return data;
+    }
+
+    /**
+     * Triggers an action that generates an AUDIT log entry.
+     * Listing the admin key managers via the REST API produces an AUDIT_LOG entry.
+     */
+    private void triggerAuditLogEntry() throws Exception {
+        restAPIAdmin.getKeyManagers();
+    }
+
+    /**
+     * Waits for the log4j2 configuration file to be picked up by the running server.
+     * The Carbon logging service writes log4j2.properties synchronously, but the OSGi
+     * reconfiguration that follows is asynchronous, so a short pause is needed before
+     * the resulting file state can be reliably read and asserted.
+     *
+     * @param seconds number of seconds to wait
+     */
+    private static void waitForLog4j2ConfigSync(int seconds) throws InterruptedException {
+        TimeUnit.SECONDS.sleep(seconds);
+    }
+
+    /**
+     * Finds an ephemeral free TCP port on localhost.
+     */
+    private static int findFreePort() throws IOException {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            socket.setReuseAddress(true);
+            return socket.getLocalPort();
+        }
+    }
+}

--- a/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/remoteLogging/log4j2WithAllAppenders.properties
+++ b/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/remoteLogging/log4j2WithAllAppenders.properties
@@ -1,0 +1,234 @@
+# log4j2 test fixture: all 3 local file appenders present as RollingFile
+# Used to verify that existing blocks are not overwritten when remote logging is disabled
+appenders = CARBON_CONSOLE, CARBON_LOGFILE, AUDIT_LOGFILE, API_LOGFILE, ATOMIKOS_LOGFILE, CARBON_TRACE_LOGFILE, ERROR_LOGFILE, OPEN_TRACING, SERVICE_APPENDER, TRACE_APPENDER, osgi, CORRELATION, BOTDATA_APPENDER, APIM_GATEWAY_ACCESS_APPENDER
+
+appender.CARBON_CONSOLE.type = Console
+appender.CARBON_CONSOLE.name = CARBON_CONSOLE
+appender.CARBON_CONSOLE.layout.type = PatternLayout
+appender.CARBON_CONSOLE.layout.pattern = [%d{DEFAULT}] %5p - %c{1} %m%n
+appender.CARBON_CONSOLE.filter.threshold.type = ThresholdFilter
+appender.CARBON_CONSOLE.filter.threshold.level = DEBUG
+
+# CARBON_LOGFILE is set to be a DailyRollingFileAppender using a PatternLayout.
+appender.CARBON_LOGFILE.type = RollingFile
+appender.CARBON_LOGFILE.name = CARBON_LOGFILE
+appender.CARBON_LOGFILE.fileName = ${sys:carbon.home}/repository/logs/wso2carbon.log
+appender.CARBON_LOGFILE.filePattern = ${sys:carbon.home}/repository/logs/wso2carbon-%d{MM-dd-yyyy}-%i.log
+appender.CARBON_LOGFILE.layout.type = PatternLayout
+appender.CARBON_LOGFILE.layout.pattern = TID: [%tenantId] [%appName] [%d] %5p {%c} - %m%ex%n
+appender.CARBON_LOGFILE.policies.type = Policies
+appender.CARBON_LOGFILE.policies.time.type = TimeBasedTriggeringPolicy
+appender.CARBON_LOGFILE.policies.time.interval = 1
+appender.CARBON_LOGFILE.policies.time.modulate = true
+appender.CARBON_LOGFILE.policies.size.type = SizeBasedTriggeringPolicy
+appender.CARBON_LOGFILE.policies.size.size = 10MB
+appender.CARBON_LOGFILE.strategy.type = DefaultRolloverStrategy
+appender.CARBON_LOGFILE.strategy.max = 20
+appender.CARBON_LOGFILE.filter.threshold.type = ThresholdFilter
+appender.CARBON_LOGFILE.filter.threshold.level = DEBUG
+
+# Appender config to AUDIT_LOGFILE
+appender.AUDIT_LOGFILE.type = RollingFile
+appender.AUDIT_LOGFILE.name = AUDIT_LOGFILE
+appender.AUDIT_LOGFILE.fileName = ${sys:carbon.home}/repository/logs/audit.log
+appender.AUDIT_LOGFILE.filePattern = ${sys:carbon.home}/repository/logs/audit-%d{MM-dd-yyyy}.log
+appender.AUDIT_LOGFILE.layout.type = PatternLayout
+appender.AUDIT_LOGFILE.layout.pattern = TID: [%tenantId] [%d] %5p {%c} - %m%ex%n
+appender.AUDIT_LOGFILE.policies.type = Policies
+appender.AUDIT_LOGFILE.policies.time.type = TimeBasedTriggeringPolicy
+appender.AUDIT_LOGFILE.policies.time.interval = 1
+appender.AUDIT_LOGFILE.policies.time.modulate = true
+appender.AUDIT_LOGFILE.policies.size.type = SizeBasedTriggeringPolicy
+appender.AUDIT_LOGFILE.policies.size.size = 10MB
+appender.AUDIT_LOGFILE.strategy.type = DefaultRolloverStrategy
+appender.AUDIT_LOGFILE.strategy.max = 20
+appender.AUDIT_LOGFILE.filter.threshold.type = ThresholdFilter
+appender.AUDIT_LOGFILE.filter.threshold.level = INFO
+
+# Appender config API logging
+appender.API_LOGFILE.type = RollingFile
+appender.API_LOGFILE.name = API_LOGFILE
+appender.API_LOGFILE.fileName = ${sys:carbon.home}/repository/logs/api.log
+appender.API_LOGFILE.filePattern = ${sys:carbon.home}/repository/logs/api-%d{MM-dd-yyyy}-%i.log
+appender.API_LOGFILE.layout.type = PatternLayout
+appender.API_LOGFILE.layout.pattern = [%d] %5p {%c} %X{apiName} - %m%ex%n
+appender.API_LOGFILE.policies.type = Policies
+appender.API_LOGFILE.policies.time.type = TimeBasedTriggeringPolicy
+appender.API_LOGFILE.policies.time.interval = 1
+appender.API_LOGFILE.policies.time.modulate = true
+appender.API_LOGFILE.policies.size.type = SizeBasedTriggeringPolicy
+appender.API_LOGFILE.policies.size.size = 10MB
+appender.API_LOGFILE.strategy.type = DefaultRolloverStrategy
+appender.API_LOGFILE.strategy.max = 20
+appender.API_LOGFILE.filter.threshold.type = ThresholdFilter
+appender.API_LOGFILE.filter.threshold.level = DEBUG
+
+appender.ATOMIKOS_LOGFILE.type = RollingFile
+appender.ATOMIKOS_LOGFILE.name = ATOMIKOS_LOGFILE
+appender.ATOMIKOS_LOGFILE.fileName = ${sys:carbon.home}/repository/logs/tm.out
+appender.ATOMIKOS_LOGFILE.filePattern = ${sys:carbon.home}/repository/logs/tm-%d{MM-dd-yyyy}.out
+appender.ATOMIKOS_LOGFILE.layout.type = PatternLayout
+appender.ATOMIKOS_LOGFILE.layout.pattern = [%d] [%tenantId] %5p {%c} - %m%ex%n
+appender.ATOMIKOS_LOGFILE.policies.type = Policies
+appender.ATOMIKOS_LOGFILE.policies.time.type = TimeBasedTriggeringPolicy
+appender.ATOMIKOS_LOGFILE.policies.time.interval = 1
+appender.ATOMIKOS_LOGFILE.policies.time.modulate = true
+appender.ATOMIKOS_LOGFILE.strategy.type = DefaultRolloverStrategy
+appender.ATOMIKOS_LOGFILE.strategy.max = 20
+
+appender.CARBON_TRACE_LOGFILE.type = RollingFile
+appender.CARBON_TRACE_LOGFILE.name = CARBON_TRACE_LOGFILE
+appender.CARBON_TRACE_LOGFILE.fileName = ${sys:carbon.home}/repository/logs/wso2carbon-trace-messages.log
+appender.CARBON_TRACE_LOGFILE.filePattern = ${sys:carbon.home}/repository/logs/wso2carbon-trace-messages-%d{MM-dd-yyyy}.log
+appender.CARBON_TRACE_LOGFILE.layout.type = PatternLayout
+appender.CARBON_TRACE_LOGFILE.layout.pattern = [%d] [%tenantId] %5p {%c} - %m%ex%n
+appender.CARBON_TRACE_LOGFILE.policies.type = Policies
+appender.CARBON_TRACE_LOGFILE.policies.time.type = TimeBasedTriggeringPolicy
+appender.CARBON_TRACE_LOGFILE.policies.time.interval = 1
+appender.CARBON_TRACE_LOGFILE.policies.time.modulate = true
+appender.CARBON_TRACE_LOGFILE.policies.size.type = SizeBasedTriggeringPolicy
+appender.CARBON_TRACE_LOGFILE.policies.size.size = 10MB
+appender.CARBON_TRACE_LOGFILE.strategy.type = DefaultRolloverStrategy
+appender.CARBON_TRACE_LOGFILE.strategy.max = 20
+
+appender.CORRELATION.type = RollingFile
+appender.CORRELATION.name = CORRELATION
+appender.CORRELATION.fileName = ${sys:carbon.home}/repository/logs/correlation.log
+appender.CORRELATION.filePattern = ${sys:carbon.home}/repository/logs/correlation-%d{MM-dd-yyyy}-%i.log.gz
+appender.CORRELATION.layout.type = PatternLayout
+appender.CORRELATION.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS}|%X{Correlation-ID}|%t|%m%n
+appender.CORRELATION.policies.type = Policies
+appender.CORRELATION.policies.time.type = TimeBasedTriggeringPolicy
+appender.CORRELATION.policies.time.interval = 1
+appender.CORRELATION.policies.time.modulate = true
+appender.CORRELATION.policies.size.type = SizeBasedTriggeringPolicy
+appender.CORRELATION.policies.size.size = 10MB
+appender.CORRELATION.strategy.type = DefaultRolloverStrategy
+appender.CORRELATION.strategy.max = 20
+appender.CORRELATION.filter.threshold.type = ThresholdFilter
+appender.CORRELATION.filter.threshold.level = INFO
+
+appender.ERROR_LOGFILE.type = RollingFile
+appender.ERROR_LOGFILE.name = ERROR_LOGFILE
+appender.ERROR_LOGFILE.fileName = ${sys:carbon.home}/repository/logs/wso2-apigw-errors.log
+appender.ERROR_LOGFILE.filePattern = ${sys:carbon.home}/repository/logs/wso2-apigw-errors-%d{MM-dd-yyyy}-%i.log.gz
+appender.ERROR_LOGFILE.layout.type = PatternLayout
+appender.ERROR_LOGFILE.layout.pattern = %d{ISO8601} [%X{ip}-%X{host}] [%t] %5p %c{1} %m%n
+appender.ERROR_LOGFILE.policies.type = Policies
+appender.ERROR_LOGFILE.policies.time.type = TimeBasedTriggeringPolicy
+appender.ERROR_LOGFILE.policies.time.interval = 1
+appender.ERROR_LOGFILE.policies.time.modulate = true
+appender.ERROR_LOGFILE.policies.size.type = SizeBasedTriggeringPolicy
+appender.ERROR_LOGFILE.policies.size.size = 10MB
+appender.ERROR_LOGFILE.strategy.type = DefaultRolloverStrategy
+appender.ERROR_LOGFILE.strategy.max = 20
+appender.ERROR_LOGFILE.filter.threshold.type = ThresholdFilter
+appender.ERROR_LOGFILE.filter.threshold.level = WARN
+
+appender.OPEN_TRACING.type = RollingFile
+appender.OPEN_TRACING.name = OPEN_TRACING
+appender.OPEN_TRACING.fileName = ${sys:carbon.home}/repository/logs/wso2-apimgt-open-tracing.log
+appender.OPEN_TRACING.filePattern = ${sys:carbon.home}/repository/logs/wso2-apimgt-open-tracing-%d{MM-dd-yyyy}-%i.log.gz
+appender.OPEN_TRACING.layout.type = PatternLayout
+appender.OPEN_TRACING.layout.pattern = %d{HH:mm:ss,SSS} [%X{ip}-%X{host}] [%t] %5p %m%nn
+appender.OPEN_TRACING.policies.type = Policies
+appender.OPEN_TRACING.policies.time.type = TimeBasedTriggeringPolicy
+appender.OPEN_TRACING.policies.time.interval = 1
+appender.OPEN_TRACING.policies.time.modulate = true
+appender.OPEN_TRACING.policies.size.type = SizeBasedTriggeringPolicy
+appender.OPEN_TRACING.policies.size.size = 10MB
+appender.OPEN_TRACING.strategy.type = DefaultRolloverStrategy
+appender.OPEN_TRACING.strategy.max = 20
+appender.OPEN_TRACING.filter.threshold.type = ThresholdFilter
+appender.OPEN_TRACING.filter.threshold.level = TRACE
+
+appender.TRACE_APPENDER.type = RollingFile
+appender.TRACE_APPENDER.name = TRACE_APPENDER
+appender.TRACE_APPENDER.fileName = ${sys:carbon.home}/repository/logs/wso2-apigw-trace.log
+appender.TRACE_APPENDER.filePattern = ${sys:carbon.home}/repository/logs/wso2-apigw-trace-%d{MM-dd-yyyy}.log
+appender.TRACE_APPENDER.layout.type = PatternLayout
+appender.TRACE_APPENDER.layout.pattern = %d{HH:mm:ss,SSS} [%X{ip}-%X{host}] [%t] %5p %c{1} %m%n
+appender.TRACE_APPENDER.policies.type = Policies
+appender.TRACE_APPENDER.policies.time.type = TimeBasedTriggeringPolicy
+appender.TRACE_APPENDER.policies.time.interval = 1
+appender.TRACE_APPENDER.policies.time.modulate = true
+appender.TRACE_APPENDER.strategy.type = DefaultRolloverStrategy
+appender.TRACE_APPENDER.strategy.max = 20
+
+appender.SERVICE_APPENDER.type = RollingFile
+appender.SERVICE_APPENDER.name = SERVICE_APPENDER
+appender.SERVICE_APPENDER.fileName = ${sys:carbon.home}/repository/logs/wso2-apigw-service.log
+appender.SERVICE_APPENDER.filePattern = ${sys:carbon.home}/repository/logs/wso2-apigw-service-%i.log
+appender.SERVICE_APPENDER.layout.type = PatternLayout
+appender.SERVICE_APPENDER.layout.pattern = %d{ISO8601} [%X{ip}-%X{host}] [%t] %5p %c{1} %m%n
+appender.SERVICE_APPENDER.policies.type = Policies
+appender.SERVICE_APPENDER.policies.size.type = SizeBasedTriggeringPolicy
+appender.SERVICE_APPENDER.policies.size.size = 1000KB
+appender.SERVICE_APPENDER.strategy.type = DefaultRolloverStrategy
+appender.SERVICE_APPENDER.strategy.max = 10
+
+appender.BOTDATA_APPENDER.type = RollingFile
+appender.BOTDATA_APPENDER.name = BOTDATA_APPENDER
+appender.BOTDATA_APPENDER.fileName = ${sys:carbon.home}/repository/logs/botData.log
+appender.BOTDATA_APPENDER.filePattern = ${sys:carbon.home}/repository/logs/botData-%d{MM-dd-yyyy}.log
+appender.BOTDATA_APPENDER.layout.type = PatternLayout
+appender.BOTDATA_APPENDER.layout.pattern = %d{HH:mm:ss,SSS} [%X{ip}-%X{host}] [%t] %5p %c{1} %m%n
+appender.BOTDATA_APPENDER.policies.type = Policies
+appender.BOTDATA_APPENDER.policies.time.type = TimeBasedTriggeringPolicy
+appender.BOTDATA_APPENDER.policies.time.interval = 1
+appender.BOTDATA_APPENDER.policies.time.modulate = true
+appender.BOTDATA_APPENDER.strategy.type = DefaultRolloverStrategy
+appender.BOTDATA_APPENDER.strategy.max = 20
+
+appender.APIM_GATEWAY_ACCESS_APPENDER.type = RollingFile
+appender.APIM_GATEWAY_ACCESS_APPENDER.name = APIM_GATEWAY_ACCESS_APPENDER
+appender.APIM_GATEWAY_ACCESS_APPENDER.fileName = ${sys:carbon.home}/repository/logs/http_access.log
+appender.APIM_GATEWAY_ACCESS_APPENDER.filePattern = ${sys:carbon.home}/repository/logs/http_access_%d{MM-dd-yyyy}-%i.log
+appender.APIM_GATEWAY_ACCESS_APPENDER.layout.type = PatternLayout
+appender.APIM_GATEWAY_ACCESS_APPENDER.layout.pattern = %msg%n
+appender.APIM_GATEWAY_ACCESS_APPENDER.policies.type = Policies
+appender.APIM_GATEWAY_ACCESS_APPENDER.policies.time.type = TimeBasedTriggeringPolicy
+appender.APIM_GATEWAY_ACCESS_APPENDER.policies.time.interval = 1
+appender.APIM_GATEWAY_ACCESS_APPENDER.policies.time.modulate = true
+appender.APIM_GATEWAY_ACCESS_APPENDER.policies.size.type = SizeBasedTriggeringPolicy
+appender.APIM_GATEWAY_ACCESS_APPENDER.policies.size.size = 1000MB
+appender.APIM_GATEWAY_ACCESS_APPENDER.strategy.type = DefaultRolloverStrategy
+appender.APIM_GATEWAY_ACCESS_APPENDER.strategy.max = 10
+appender.APIM_GATEWAY_ACCESS_APPENDER.filter.threshold.type = ThresholdFilter
+appender.APIM_GATEWAY_ACCESS_APPENDER.filter.threshold.level = DEBUG
+
+appender.osgi.type = PaxOsgi
+appender.osgi.name = PaxOsgi
+appender.osgi.filter = *
+
+loggers = AUDIT_LOG, API_LOG, trace-messages, correlation, GatewayAccessLogger
+
+logger.AUDIT_LOG.name = AUDIT_LOG
+logger.AUDIT_LOG.level = INFO
+logger.AUDIT_LOG.appenderRef.AUDIT_LOGFILE.ref = AUDIT_LOGFILE
+logger.AUDIT_LOG.additivity = false
+
+logger.API_LOG.name = API_LOG
+logger.API_LOG.level = INFO
+logger.API_LOG.appenderRef.API_LOGFILE.ref = API_LOGFILE
+logger.API_LOG.additivity = false
+
+logger.trace-messages.name = trace.messages
+logger.trace-messages.level = TRACE
+logger.trace-messages.appenderRef.CARBON_TRACE_LOGFILE.ref = CARBON_TRACE_LOGFILE
+
+logger.correlation.name = correlation
+logger.correlation.level = INFO
+logger.correlation.appenderRef.CORRELATION.ref = CORRELATION
+logger.correlation.additivity = false
+
+logger.GatewayAccessLogger.name = GatewayAccessLogger
+logger.GatewayAccessLogger.level = INFO
+logger.GatewayAccessLogger.appenderRef.APIM_GATEWAY_ACCESS_APPENDER.ref = APIM_GATEWAY_ACCESS_APPENDER
+logger.GatewayAccessLogger.additivity = false
+
+rootLogger.level = ERROR
+rootLogger.appenderRef.CARBON_CONSOLE.ref = CARBON_CONSOLE
+rootLogger.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
+rootLogger.appenderRef.ERROR_LOGFILE.ref = ERROR_LOGFILE
+rootLogger.appenderRef.osgi.ref = PaxOsgi

--- a/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/remoteLogging/log4j2WithoutApiAppender.properties
+++ b/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/remoteLogging/log4j2WithoutApiAppender.properties
@@ -1,0 +1,213 @@
+# log4j2 test fixture: API_LOGFILE block absent, AUDIT_LOGFILE and CARBON_LOGFILE present
+# Used to verify that a missing API_LOGFILE block is written as HTTP when remote logging is enabled
+appenders = CARBON_CONSOLE, CARBON_LOGFILE, AUDIT_LOGFILE, ATOMIKOS_LOGFILE, CARBON_TRACE_LOGFILE, ERROR_LOGFILE, OPEN_TRACING, SERVICE_APPENDER, TRACE_APPENDER, osgi, CORRELATION, BOTDATA_APPENDER, APIM_GATEWAY_ACCESS_APPENDER
+
+appender.CARBON_CONSOLE.type = Console
+appender.CARBON_CONSOLE.name = CARBON_CONSOLE
+appender.CARBON_CONSOLE.layout.type = PatternLayout
+appender.CARBON_CONSOLE.layout.pattern = [%d{DEFAULT}] %5p - %c{1} %m%n
+appender.CARBON_CONSOLE.filter.threshold.type = ThresholdFilter
+appender.CARBON_CONSOLE.filter.threshold.level = DEBUG
+
+# CARBON_LOGFILE is set to be a DailyRollingFileAppender using a PatternLayout.
+appender.CARBON_LOGFILE.type = RollingFile
+appender.CARBON_LOGFILE.name = CARBON_LOGFILE
+appender.CARBON_LOGFILE.fileName = ${sys:carbon.home}/repository/logs/wso2carbon.log
+appender.CARBON_LOGFILE.filePattern = ${sys:carbon.home}/repository/logs/wso2carbon-%d{MM-dd-yyyy}-%i.log
+appender.CARBON_LOGFILE.layout.type = PatternLayout
+appender.CARBON_LOGFILE.layout.pattern = TID: [%tenantId] [%appName] [%d] %5p {%c} - %m%ex%n
+appender.CARBON_LOGFILE.policies.type = Policies
+appender.CARBON_LOGFILE.policies.time.type = TimeBasedTriggeringPolicy
+appender.CARBON_LOGFILE.policies.time.interval = 1
+appender.CARBON_LOGFILE.policies.time.modulate = true
+appender.CARBON_LOGFILE.policies.size.type = SizeBasedTriggeringPolicy
+appender.CARBON_LOGFILE.policies.size.size = 10MB
+appender.CARBON_LOGFILE.strategy.type = DefaultRolloverStrategy
+appender.CARBON_LOGFILE.strategy.max = 20
+appender.CARBON_LOGFILE.filter.threshold.type = ThresholdFilter
+appender.CARBON_LOGFILE.filter.threshold.level = DEBUG
+
+# Appender config to AUDIT_LOGFILE
+appender.AUDIT_LOGFILE.type = RollingFile
+appender.AUDIT_LOGFILE.name = AUDIT_LOGFILE
+appender.AUDIT_LOGFILE.fileName = ${sys:carbon.home}/repository/logs/audit.log
+appender.AUDIT_LOGFILE.filePattern = ${sys:carbon.home}/repository/logs/audit-%d{MM-dd-yyyy}.log
+appender.AUDIT_LOGFILE.layout.type = PatternLayout
+appender.AUDIT_LOGFILE.layout.pattern = TID: [%tenantId] [%d] %5p {%c} - %m%ex%n
+appender.AUDIT_LOGFILE.policies.type = Policies
+appender.AUDIT_LOGFILE.policies.time.type = TimeBasedTriggeringPolicy
+appender.AUDIT_LOGFILE.policies.time.interval = 1
+appender.AUDIT_LOGFILE.policies.time.modulate = true
+appender.AUDIT_LOGFILE.policies.size.type = SizeBasedTriggeringPolicy
+appender.AUDIT_LOGFILE.policies.size.size = 10MB
+appender.AUDIT_LOGFILE.strategy.type = DefaultRolloverStrategy
+appender.AUDIT_LOGFILE.strategy.max = 20
+appender.AUDIT_LOGFILE.filter.threshold.type = ThresholdFilter
+appender.AUDIT_LOGFILE.filter.threshold.level = INFO
+
+# NOTE: API_LOGFILE block intentionally absent to test creation-on-enable behaviour
+
+appender.ATOMIKOS_LOGFILE.type = RollingFile
+appender.ATOMIKOS_LOGFILE.name = ATOMIKOS_LOGFILE
+appender.ATOMIKOS_LOGFILE.fileName = ${sys:carbon.home}/repository/logs/tm.out
+appender.ATOMIKOS_LOGFILE.filePattern = ${sys:carbon.home}/repository/logs/tm-%d{MM-dd-yyyy}.out
+appender.ATOMIKOS_LOGFILE.layout.type = PatternLayout
+appender.ATOMIKOS_LOGFILE.layout.pattern = [%d] [%tenantId] %5p {%c} - %m%ex%n
+appender.ATOMIKOS_LOGFILE.policies.type = Policies
+appender.ATOMIKOS_LOGFILE.policies.time.type = TimeBasedTriggeringPolicy
+appender.ATOMIKOS_LOGFILE.policies.time.interval = 1
+appender.ATOMIKOS_LOGFILE.policies.time.modulate = true
+appender.ATOMIKOS_LOGFILE.strategy.type = DefaultRolloverStrategy
+appender.ATOMIKOS_LOGFILE.strategy.max = 20
+
+appender.CARBON_TRACE_LOGFILE.type = RollingFile
+appender.CARBON_TRACE_LOGFILE.name = CARBON_TRACE_LOGFILE
+appender.CARBON_TRACE_LOGFILE.fileName = ${sys:carbon.home}/repository/logs/wso2carbon-trace-messages.log
+appender.CARBON_TRACE_LOGFILE.filePattern = ${sys:carbon.home}/repository/logs/wso2carbon-trace-messages-%d{MM-dd-yyyy}.log
+appender.CARBON_TRACE_LOGFILE.layout.type = PatternLayout
+appender.CARBON_TRACE_LOGFILE.layout.pattern = [%d] [%tenantId] %5p {%c} - %m%ex%n
+appender.CARBON_TRACE_LOGFILE.policies.type = Policies
+appender.CARBON_TRACE_LOGFILE.policies.time.type = TimeBasedTriggeringPolicy
+appender.CARBON_TRACE_LOGFILE.policies.time.interval = 1
+appender.CARBON_TRACE_LOGFILE.policies.time.modulate = true
+appender.CARBON_TRACE_LOGFILE.policies.size.type = SizeBasedTriggeringPolicy
+appender.CARBON_TRACE_LOGFILE.policies.size.size = 10MB
+appender.CARBON_TRACE_LOGFILE.strategy.type = DefaultRolloverStrategy
+appender.CARBON_TRACE_LOGFILE.strategy.max = 20
+
+appender.CORRELATION.type = RollingFile
+appender.CORRELATION.name = CORRELATION
+appender.CORRELATION.fileName = ${sys:carbon.home}/repository/logs/correlation.log
+appender.CORRELATION.filePattern = ${sys:carbon.home}/repository/logs/correlation-%d{MM-dd-yyyy}-%i.log.gz
+appender.CORRELATION.layout.type = PatternLayout
+appender.CORRELATION.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS}|%X{Correlation-ID}|%t|%m%n
+appender.CORRELATION.policies.type = Policies
+appender.CORRELATION.policies.time.type = TimeBasedTriggeringPolicy
+appender.CORRELATION.policies.time.interval = 1
+appender.CORRELATION.policies.time.modulate = true
+appender.CORRELATION.policies.size.type = SizeBasedTriggeringPolicy
+appender.CORRELATION.policies.size.size = 10MB
+appender.CORRELATION.strategy.type = DefaultRolloverStrategy
+appender.CORRELATION.strategy.max = 20
+appender.CORRELATION.filter.threshold.type = ThresholdFilter
+appender.CORRELATION.filter.threshold.level = INFO
+
+appender.ERROR_LOGFILE.type = RollingFile
+appender.ERROR_LOGFILE.name = ERROR_LOGFILE
+appender.ERROR_LOGFILE.fileName = ${sys:carbon.home}/repository/logs/wso2-apigw-errors.log
+appender.ERROR_LOGFILE.filePattern = ${sys:carbon.home}/repository/logs/wso2-apigw-errors-%d{MM-dd-yyyy}-%i.log.gz
+appender.ERROR_LOGFILE.layout.type = PatternLayout
+appender.ERROR_LOGFILE.layout.pattern = %d{ISO8601} [%X{ip}-%X{host}] [%t] %5p %c{1} %m%n
+appender.ERROR_LOGFILE.policies.type = Policies
+appender.ERROR_LOGFILE.policies.time.type = TimeBasedTriggeringPolicy
+appender.ERROR_LOGFILE.policies.time.interval = 1
+appender.ERROR_LOGFILE.policies.time.modulate = true
+appender.ERROR_LOGFILE.policies.size.type = SizeBasedTriggeringPolicy
+appender.ERROR_LOGFILE.policies.size.size = 10MB
+appender.ERROR_LOGFILE.strategy.type = DefaultRolloverStrategy
+appender.ERROR_LOGFILE.strategy.max = 20
+appender.ERROR_LOGFILE.filter.threshold.type = ThresholdFilter
+appender.ERROR_LOGFILE.filter.threshold.level = WARN
+
+appender.OPEN_TRACING.type = RollingFile
+appender.OPEN_TRACING.name = OPEN_TRACING
+appender.OPEN_TRACING.fileName = ${sys:carbon.home}/repository/logs/wso2-apimgt-open-tracing.log
+appender.OPEN_TRACING.filePattern = ${sys:carbon.home}/repository/logs/wso2-apimgt-open-tracing-%d{MM-dd-yyyy}-%i.log.gz
+appender.OPEN_TRACING.layout.type = PatternLayout
+appender.OPEN_TRACING.layout.pattern = %d{HH:mm:ss,SSS} [%X{ip}-%X{host}] [%t] %5p %m%nn
+appender.OPEN_TRACING.policies.type = Policies
+appender.OPEN_TRACING.policies.time.type = TimeBasedTriggeringPolicy
+appender.OPEN_TRACING.policies.time.interval = 1
+appender.OPEN_TRACING.policies.time.modulate = true
+appender.OPEN_TRACING.policies.size.type = SizeBasedTriggeringPolicy
+appender.OPEN_TRACING.policies.size.size = 10MB
+appender.OPEN_TRACING.strategy.type = DefaultRolloverStrategy
+appender.OPEN_TRACING.strategy.max = 20
+appender.OPEN_TRACING.filter.threshold.type = ThresholdFilter
+appender.OPEN_TRACING.filter.threshold.level = TRACE
+
+appender.TRACE_APPENDER.type = RollingFile
+appender.TRACE_APPENDER.name = TRACE_APPENDER
+appender.TRACE_APPENDER.fileName = ${sys:carbon.home}/repository/logs/wso2-apigw-trace.log
+appender.TRACE_APPENDER.filePattern = ${sys:carbon.home}/repository/logs/wso2-apigw-trace-%d{MM-dd-yyyy}.log
+appender.TRACE_APPENDER.layout.type = PatternLayout
+appender.TRACE_APPENDER.layout.pattern = %d{HH:mm:ss,SSS} [%X{ip}-%X{host}] [%t] %5p %c{1} %m%n
+appender.TRACE_APPENDER.policies.type = Policies
+appender.TRACE_APPENDER.policies.time.type = TimeBasedTriggeringPolicy
+appender.TRACE_APPENDER.policies.time.interval = 1
+appender.TRACE_APPENDER.policies.time.modulate = true
+appender.TRACE_APPENDER.strategy.type = DefaultRolloverStrategy
+appender.TRACE_APPENDER.strategy.max = 20
+
+appender.SERVICE_APPENDER.type = RollingFile
+appender.SERVICE_APPENDER.name = SERVICE_APPENDER
+appender.SERVICE_APPENDER.fileName = ${sys:carbon.home}/repository/logs/wso2-apigw-service.log
+appender.SERVICE_APPENDER.filePattern = ${sys:carbon.home}/repository/logs/wso2-apigw-service-%i.log
+appender.SERVICE_APPENDER.layout.type = PatternLayout
+appender.SERVICE_APPENDER.layout.pattern = %d{ISO8601} [%X{ip}-%X{host}] [%t] %5p %c{1} %m%n
+appender.SERVICE_APPENDER.policies.type = Policies
+appender.SERVICE_APPENDER.policies.size.type = SizeBasedTriggeringPolicy
+appender.SERVICE_APPENDER.policies.size.size = 1000KB
+appender.SERVICE_APPENDER.strategy.type = DefaultRolloverStrategy
+appender.SERVICE_APPENDER.strategy.max = 10
+
+appender.BOTDATA_APPENDER.type = RollingFile
+appender.BOTDATA_APPENDER.name = BOTDATA_APPENDER
+appender.BOTDATA_APPENDER.fileName = ${sys:carbon.home}/repository/logs/botData.log
+appender.BOTDATA_APPENDER.filePattern = ${sys:carbon.home}/repository/logs/botData-%d{MM-dd-yyyy}.log
+appender.BOTDATA_APPENDER.layout.type = PatternLayout
+appender.BOTDATA_APPENDER.layout.pattern = %d{HH:mm:ss,SSS} [%X{ip}-%X{host}] [%t] %5p %c{1} %m%n
+appender.BOTDATA_APPENDER.policies.type = Policies
+appender.BOTDATA_APPENDER.policies.time.type = TimeBasedTriggeringPolicy
+appender.BOTDATA_APPENDER.policies.time.interval = 1
+appender.BOTDATA_APPENDER.policies.time.modulate = true
+appender.BOTDATA_APPENDER.strategy.type = DefaultRolloverStrategy
+appender.BOTDATA_APPENDER.strategy.max = 20
+
+appender.APIM_GATEWAY_ACCESS_APPENDER.type = RollingFile
+appender.APIM_GATEWAY_ACCESS_APPENDER.name = APIM_GATEWAY_ACCESS_APPENDER
+appender.APIM_GATEWAY_ACCESS_APPENDER.fileName = ${sys:carbon.home}/repository/logs/http_access.log
+appender.APIM_GATEWAY_ACCESS_APPENDER.filePattern = ${sys:carbon.home}/repository/logs/http_access_%d{MM-dd-yyyy}-%i.log
+appender.APIM_GATEWAY_ACCESS_APPENDER.layout.type = PatternLayout
+appender.APIM_GATEWAY_ACCESS_APPENDER.layout.pattern = %msg%n
+appender.APIM_GATEWAY_ACCESS_APPENDER.policies.type = Policies
+appender.APIM_GATEWAY_ACCESS_APPENDER.policies.time.type = TimeBasedTriggeringPolicy
+appender.APIM_GATEWAY_ACCESS_APPENDER.policies.time.interval = 1
+appender.APIM_GATEWAY_ACCESS_APPENDER.policies.time.modulate = true
+appender.APIM_GATEWAY_ACCESS_APPENDER.policies.size.type = SizeBasedTriggeringPolicy
+appender.APIM_GATEWAY_ACCESS_APPENDER.policies.size.size = 1000MB
+appender.APIM_GATEWAY_ACCESS_APPENDER.strategy.type = DefaultRolloverStrategy
+appender.APIM_GATEWAY_ACCESS_APPENDER.strategy.max = 10
+appender.APIM_GATEWAY_ACCESS_APPENDER.filter.threshold.type = ThresholdFilter
+appender.APIM_GATEWAY_ACCESS_APPENDER.filter.threshold.level = DEBUG
+
+appender.osgi.type = PaxOsgi
+appender.osgi.name = PaxOsgi
+appender.osgi.filter = *
+
+loggers = AUDIT_LOG, trace-messages, correlation, GatewayAccessLogger
+
+logger.AUDIT_LOG.name = AUDIT_LOG
+logger.AUDIT_LOG.level = INFO
+logger.AUDIT_LOG.appenderRef.AUDIT_LOGFILE.ref = AUDIT_LOGFILE
+logger.AUDIT_LOG.additivity = false
+
+logger.trace-messages.name = trace.messages
+logger.trace-messages.level = TRACE
+logger.trace-messages.appenderRef.CARBON_TRACE_LOGFILE.ref = CARBON_TRACE_LOGFILE
+
+logger.correlation.name = correlation
+logger.correlation.level = INFO
+logger.correlation.appenderRef.CORRELATION.ref = CORRELATION
+logger.correlation.additivity = false
+
+logger.GatewayAccessLogger.name = GatewayAccessLogger
+logger.GatewayAccessLogger.level = INFO
+logger.GatewayAccessLogger.appenderRef.APIM_GATEWAY_ACCESS_APPENDER.ref = APIM_GATEWAY_ACCESS_APPENDER
+logger.GatewayAccessLogger.additivity = false
+
+rootLogger.level = ERROR
+rootLogger.appenderRef.CARBON_CONSOLE.ref = CARBON_CONSOLE
+rootLogger.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
+rootLogger.appenderRef.ERROR_LOGFILE.ref = ERROR_LOGFILE
+rootLogger.appenderRef.osgi.ref = PaxOsgi

--- a/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/remoteLogging/log4j2WithoutAuditAppender.properties
+++ b/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/remoteLogging/log4j2WithoutAuditAppender.properties
@@ -1,0 +1,211 @@
+# log4j2 test fixture: AUDIT_LOGFILE block is absent, CARBON_LOGFILE and API_LOGFILE are present
+# Used to verify that a missing appender block is written when remote logging is enabled
+appenders = CARBON_CONSOLE, CARBON_LOGFILE, API_LOGFILE, ATOMIKOS_LOGFILE, CARBON_TRACE_LOGFILE, ERROR_LOGFILE, OPEN_TRACING, SERVICE_APPENDER, TRACE_APPENDER, osgi, CORRELATION, BOTDATA_APPENDER, APIM_GATEWAY_ACCESS_APPENDER
+
+appender.CARBON_CONSOLE.type = Console
+appender.CARBON_CONSOLE.name = CARBON_CONSOLE
+appender.CARBON_CONSOLE.layout.type = PatternLayout
+appender.CARBON_CONSOLE.layout.pattern = [%d{DEFAULT}] %5p - %c{1} %m%n
+appender.CARBON_CONSOLE.filter.threshold.type = ThresholdFilter
+appender.CARBON_CONSOLE.filter.threshold.level = DEBUG
+
+appender.CARBON_LOGFILE.type = RollingFile
+appender.CARBON_LOGFILE.name = CARBON_LOGFILE
+appender.CARBON_LOGFILE.fileName = ${sys:carbon.home}/repository/logs/wso2carbon.log
+appender.CARBON_LOGFILE.filePattern = ${sys:carbon.home}/repository/logs/wso2carbon-%d{MM-dd-yyyy}-%i.log
+appender.CARBON_LOGFILE.layout.type = PatternLayout
+appender.CARBON_LOGFILE.layout.pattern = TID: [%tenantId] [%appName] [%d] %5p {%c} - %m%ex%n
+appender.CARBON_LOGFILE.policies.type = Policies
+appender.CARBON_LOGFILE.policies.time.type = TimeBasedTriggeringPolicy
+appender.CARBON_LOGFILE.policies.time.interval = 1
+appender.CARBON_LOGFILE.policies.time.modulate = true
+appender.CARBON_LOGFILE.policies.size.type = SizeBasedTriggeringPolicy
+appender.CARBON_LOGFILE.policies.size.size = 10MB
+appender.CARBON_LOGFILE.strategy.type = DefaultRolloverStrategy
+appender.CARBON_LOGFILE.strategy.max = 20
+appender.CARBON_LOGFILE.filter.threshold.type = ThresholdFilter
+appender.CARBON_LOGFILE.filter.threshold.level = DEBUG
+
+# NOTE: AUDIT_LOGFILE block intentionally absent to test creation-on-enable behaviour
+
+appender.API_LOGFILE.type = RollingFile
+appender.API_LOGFILE.name = API_LOGFILE
+appender.API_LOGFILE.fileName = ${sys:carbon.home}/repository/logs/api.log
+appender.API_LOGFILE.filePattern = ${sys:carbon.home}/repository/logs/api-%d{MM-dd-yyyy}-%i.log
+appender.API_LOGFILE.layout.type = PatternLayout
+appender.API_LOGFILE.layout.pattern = [%d] %5p {%c} %X{apiName} - %m%ex%n
+appender.API_LOGFILE.policies.type = Policies
+appender.API_LOGFILE.policies.time.type = TimeBasedTriggeringPolicy
+appender.API_LOGFILE.policies.time.interval = 1
+appender.API_LOGFILE.policies.time.modulate = true
+appender.API_LOGFILE.policies.size.type = SizeBasedTriggeringPolicy
+appender.API_LOGFILE.policies.size.size = 10MB
+appender.API_LOGFILE.strategy.type = DefaultRolloverStrategy
+appender.API_LOGFILE.strategy.max = 20
+appender.API_LOGFILE.filter.threshold.type = ThresholdFilter
+appender.API_LOGFILE.filter.threshold.level = DEBUG
+
+appender.ATOMIKOS_LOGFILE.type = RollingFile
+appender.ATOMIKOS_LOGFILE.name = ATOMIKOS_LOGFILE
+appender.ATOMIKOS_LOGFILE.fileName = ${sys:carbon.home}/repository/logs/tm.out
+appender.ATOMIKOS_LOGFILE.filePattern = ${sys:carbon.home}/repository/logs/tm-%d{MM-dd-yyyy}.out
+appender.ATOMIKOS_LOGFILE.layout.type = PatternLayout
+appender.ATOMIKOS_LOGFILE.layout.pattern = [%d] [%tenantId] %5p {%c} - %m%ex%n
+appender.ATOMIKOS_LOGFILE.policies.type = Policies
+appender.ATOMIKOS_LOGFILE.policies.time.type = TimeBasedTriggeringPolicy
+appender.ATOMIKOS_LOGFILE.policies.time.interval = 1
+appender.ATOMIKOS_LOGFILE.policies.time.modulate = true
+appender.ATOMIKOS_LOGFILE.strategy.type = DefaultRolloverStrategy
+appender.ATOMIKOS_LOGFILE.strategy.max = 20
+
+appender.CARBON_TRACE_LOGFILE.type = RollingFile
+appender.CARBON_TRACE_LOGFILE.name = CARBON_TRACE_LOGFILE
+appender.CARBON_TRACE_LOGFILE.fileName = ${sys:carbon.home}/repository/logs/wso2carbon-trace-messages.log
+appender.CARBON_TRACE_LOGFILE.filePattern = ${sys:carbon.home}/repository/logs/wso2carbon-trace-messages-%d{MM-dd-yyyy}.log
+appender.CARBON_TRACE_LOGFILE.layout.type = PatternLayout
+appender.CARBON_TRACE_LOGFILE.layout.pattern = [%d] [%tenantId] %5p {%c} - %m%ex%n
+appender.CARBON_TRACE_LOGFILE.policies.type = Policies
+appender.CARBON_TRACE_LOGFILE.policies.time.type = TimeBasedTriggeringPolicy
+appender.CARBON_TRACE_LOGFILE.policies.time.interval = 1
+appender.CARBON_TRACE_LOGFILE.policies.time.modulate = true
+appender.CARBON_TRACE_LOGFILE.policies.size.type = SizeBasedTriggeringPolicy
+appender.CARBON_TRACE_LOGFILE.policies.size.size = 10MB
+appender.CARBON_TRACE_LOGFILE.strategy.type = DefaultRolloverStrategy
+appender.CARBON_TRACE_LOGFILE.strategy.max = 20
+
+appender.CORRELATION.type = RollingFile
+appender.CORRELATION.name = CORRELATION
+appender.CORRELATION.fileName = ${sys:carbon.home}/repository/logs/correlation.log
+appender.CORRELATION.filePattern = ${sys:carbon.home}/repository/logs/correlation-%d{MM-dd-yyyy}-%i.log.gz
+appender.CORRELATION.layout.type = PatternLayout
+appender.CORRELATION.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS}|%X{Correlation-ID}|%t|%m%n
+appender.CORRELATION.policies.type = Policies
+appender.CORRELATION.policies.time.type = TimeBasedTriggeringPolicy
+appender.CORRELATION.policies.time.interval = 1
+appender.CORRELATION.policies.time.modulate = true
+appender.CORRELATION.policies.size.type = SizeBasedTriggeringPolicy
+appender.CORRELATION.policies.size.size = 10MB
+appender.CORRELATION.strategy.type = DefaultRolloverStrategy
+appender.CORRELATION.strategy.max = 20
+appender.CORRELATION.filter.threshold.type = ThresholdFilter
+appender.CORRELATION.filter.threshold.level = INFO
+
+appender.ERROR_LOGFILE.type = RollingFile
+appender.ERROR_LOGFILE.name = ERROR_LOGFILE
+appender.ERROR_LOGFILE.fileName = ${sys:carbon.home}/repository/logs/wso2-apigw-errors.log
+appender.ERROR_LOGFILE.filePattern = ${sys:carbon.home}/repository/logs/wso2-apigw-errors-%d{MM-dd-yyyy}-%i.log.gz
+appender.ERROR_LOGFILE.layout.type = PatternLayout
+appender.ERROR_LOGFILE.layout.pattern = %d{ISO8601} [%X{ip}-%X{host}] [%t] %5p %c{1} %m%n
+appender.ERROR_LOGFILE.policies.type = Policies
+appender.ERROR_LOGFILE.policies.time.type = TimeBasedTriggeringPolicy
+appender.ERROR_LOGFILE.policies.time.interval = 1
+appender.ERROR_LOGFILE.policies.time.modulate = true
+appender.ERROR_LOGFILE.policies.size.type = SizeBasedTriggeringPolicy
+appender.ERROR_LOGFILE.policies.size.size = 10MB
+appender.ERROR_LOGFILE.strategy.type = DefaultRolloverStrategy
+appender.ERROR_LOGFILE.strategy.max = 20
+appender.ERROR_LOGFILE.filter.threshold.type = ThresholdFilter
+appender.ERROR_LOGFILE.filter.threshold.level = WARN
+
+appender.OPEN_TRACING.type = RollingFile
+appender.OPEN_TRACING.name = OPEN_TRACING
+appender.OPEN_TRACING.fileName = ${sys:carbon.home}/repository/logs/wso2-apimgt-open-tracing.log
+appender.OPEN_TRACING.filePattern = ${sys:carbon.home}/repository/logs/wso2-apimgt-open-tracing-%d{MM-dd-yyyy}-%i.log.gz
+appender.OPEN_TRACING.layout.type = PatternLayout
+appender.OPEN_TRACING.layout.pattern = %d{HH:mm:ss,SSS} [%X{ip}-%X{host}] [%t] %5p %m%n
+appender.OPEN_TRACING.policies.type = Policies
+appender.OPEN_TRACING.policies.time.type = TimeBasedTriggeringPolicy
+appender.OPEN_TRACING.policies.time.interval = 1
+appender.OPEN_TRACING.policies.time.modulate = true
+appender.OPEN_TRACING.policies.size.type = SizeBasedTriggeringPolicy
+appender.OPEN_TRACING.policies.size.size = 10MB
+appender.OPEN_TRACING.strategy.type = DefaultRolloverStrategy
+appender.OPEN_TRACING.strategy.max = 20
+appender.OPEN_TRACING.filter.threshold.type = ThresholdFilter
+appender.OPEN_TRACING.filter.threshold.level = TRACE
+
+appender.TRACE_APPENDER.type = RollingFile
+appender.TRACE_APPENDER.name = TRACE_APPENDER
+appender.TRACE_APPENDER.fileName = ${sys:carbon.home}/repository/logs/wso2-apigw-trace.log
+appender.TRACE_APPENDER.filePattern = ${sys:carbon.home}/repository/logs/wso2-apigw-trace-%d{MM-dd-yyyy}.log
+appender.TRACE_APPENDER.layout.type = PatternLayout
+appender.TRACE_APPENDER.layout.pattern = %d{HH:mm:ss,SSS} [%X{ip}-%X{host}] [%t] %5p %c{1} %m%n
+appender.TRACE_APPENDER.policies.type = Policies
+appender.TRACE_APPENDER.policies.time.type = TimeBasedTriggeringPolicy
+appender.TRACE_APPENDER.policies.time.interval = 1
+appender.TRACE_APPENDER.policies.time.modulate = true
+appender.TRACE_APPENDER.strategy.type = DefaultRolloverStrategy
+appender.TRACE_APPENDER.strategy.max = 20
+
+appender.SERVICE_APPENDER.type = RollingFile
+appender.SERVICE_APPENDER.name = SERVICE_APPENDER
+appender.SERVICE_APPENDER.fileName = ${sys:carbon.home}/repository/logs/wso2-apigw-service.log
+appender.SERVICE_APPENDER.filePattern = ${sys:carbon.home}/repository/logs/wso2-apigw-service-%i.log
+appender.SERVICE_APPENDER.layout.type = PatternLayout
+appender.SERVICE_APPENDER.layout.pattern = %d{ISO8601} [%X{ip}-%X{host}] [%t] %5p %c{1} %m%n
+appender.SERVICE_APPENDER.policies.type = Policies
+appender.SERVICE_APPENDER.policies.size.type = SizeBasedTriggeringPolicy
+appender.SERVICE_APPENDER.policies.size.size = 1000KB
+appender.SERVICE_APPENDER.strategy.type = DefaultRolloverStrategy
+appender.SERVICE_APPENDER.strategy.max = 10
+
+appender.BOTDATA_APPENDER.type = RollingFile
+appender.BOTDATA_APPENDER.name = BOTDATA_APPENDER
+appender.BOTDATA_APPENDER.fileName = ${sys:carbon.home}/repository/logs/botData.log
+appender.BOTDATA_APPENDER.filePattern = ${sys:carbon.home}/repository/logs/botData-%d{MM-dd-yyyy}.log
+appender.BOTDATA_APPENDER.layout.type = PatternLayout
+appender.BOTDATA_APPENDER.layout.pattern = %d{HH:mm:ss,SSS} [%X{ip}-%X{host}] [%t] %5p %c{1} %m%n
+appender.BOTDATA_APPENDER.policies.type = Policies
+appender.BOTDATA_APPENDER.policies.time.type = TimeBasedTriggeringPolicy
+appender.BOTDATA_APPENDER.policies.time.interval = 1
+appender.BOTDATA_APPENDER.policies.time.modulate = true
+appender.BOTDATA_APPENDER.strategy.type = DefaultRolloverStrategy
+appender.BOTDATA_APPENDER.strategy.max = 20
+
+appender.APIM_GATEWAY_ACCESS_APPENDER.type = RollingFile
+appender.APIM_GATEWAY_ACCESS_APPENDER.name = APIM_GATEWAY_ACCESS_APPENDER
+appender.APIM_GATEWAY_ACCESS_APPENDER.fileName = ${sys:carbon.home}/repository/logs/http_access.log
+appender.APIM_GATEWAY_ACCESS_APPENDER.filePattern = ${sys:carbon.home}/repository/logs/http_access_%d{MM-dd-yyyy}-%i.log
+appender.APIM_GATEWAY_ACCESS_APPENDER.layout.type = PatternLayout
+appender.APIM_GATEWAY_ACCESS_APPENDER.layout.pattern = %msg%n
+appender.APIM_GATEWAY_ACCESS_APPENDER.policies.type = Policies
+appender.APIM_GATEWAY_ACCESS_APPENDER.policies.time.type = TimeBasedTriggeringPolicy
+appender.APIM_GATEWAY_ACCESS_APPENDER.policies.time.interval = 1
+appender.APIM_GATEWAY_ACCESS_APPENDER.policies.time.modulate = true
+appender.APIM_GATEWAY_ACCESS_APPENDER.policies.size.type = SizeBasedTriggeringPolicy
+appender.APIM_GATEWAY_ACCESS_APPENDER.policies.size.size = 1000MB
+appender.APIM_GATEWAY_ACCESS_APPENDER.strategy.type = DefaultRolloverStrategy
+appender.APIM_GATEWAY_ACCESS_APPENDER.strategy.max = 10
+appender.APIM_GATEWAY_ACCESS_APPENDER.filter.threshold.type = ThresholdFilter
+appender.APIM_GATEWAY_ACCESS_APPENDER.filter.threshold.level = DEBUG
+
+appender.osgi.type = PaxOsgi
+appender.osgi.name = PaxOsgi
+appender.osgi.filter = *
+
+loggers = API_LOG, trace-messages, correlation, GatewayAccessLogger
+
+logger.API_LOG.name = API_LOG
+logger.API_LOG.level = INFO
+logger.API_LOG.appenderRef.API_LOGFILE.ref = API_LOGFILE
+logger.API_LOG.additivity = false
+
+logger.trace-messages.name = trace.messages
+logger.trace-messages.level = TRACE
+logger.trace-messages.appenderRef.CARBON_TRACE_LOGFILE.ref = CARBON_TRACE_LOGFILE
+
+logger.correlation.name = correlation
+logger.correlation.level = INFO
+logger.correlation.appenderRef.CORRELATION.ref = CORRELATION
+logger.correlation.additivity = false
+
+logger.GatewayAccessLogger.name = GatewayAccessLogger
+logger.GatewayAccessLogger.level = INFO
+logger.GatewayAccessLogger.appenderRef.APIM_GATEWAY_ACCESS_APPENDER.ref = APIM_GATEWAY_ACCESS_APPENDER
+logger.GatewayAccessLogger.additivity = false
+
+rootLogger.level = ERROR
+rootLogger.appenderRef.CARBON_CONSOLE.ref = CARBON_CONSOLE
+rootLogger.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
+rootLogger.appenderRef.ERROR_LOGFILE.ref = ERROR_LOGFILE
+rootLogger.appenderRef.osgi.ref = PaxOsgi

--- a/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/remoteLogging/log4j2WithoutCarbonAppender.properties
+++ b/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/remoteLogging/log4j2WithoutCarbonAppender.properties
@@ -1,0 +1,217 @@
+# log4j2 test fixture: CARBON_LOGFILE block absent, AUDIT_LOGFILE and API_LOGFILE present
+# Used to verify that a missing CARBON_LOGFILE block is written as HTTP when remote logging is enabled
+appenders = CARBON_CONSOLE, AUDIT_LOGFILE, API_LOGFILE, ATOMIKOS_LOGFILE, CARBON_TRACE_LOGFILE, ERROR_LOGFILE, OPEN_TRACING, SERVICE_APPENDER, TRACE_APPENDER, osgi, CORRELATION, BOTDATA_APPENDER, APIM_GATEWAY_ACCESS_APPENDER
+
+appender.CARBON_CONSOLE.type = Console
+appender.CARBON_CONSOLE.name = CARBON_CONSOLE
+appender.CARBON_CONSOLE.layout.type = PatternLayout
+appender.CARBON_CONSOLE.layout.pattern = [%d{DEFAULT}] %5p - %c{1} %m%n
+appender.CARBON_CONSOLE.filter.threshold.type = ThresholdFilter
+appender.CARBON_CONSOLE.filter.threshold.level = DEBUG
+
+# NOTE: CARBON_LOGFILE block intentionally absent to test creation-on-enable behaviour
+
+# Appender config to AUDIT_LOGFILE
+appender.AUDIT_LOGFILE.type = RollingFile
+appender.AUDIT_LOGFILE.name = AUDIT_LOGFILE
+appender.AUDIT_LOGFILE.fileName = ${sys:carbon.home}/repository/logs/audit.log
+appender.AUDIT_LOGFILE.filePattern = ${sys:carbon.home}/repository/logs/audit-%d{MM-dd-yyyy}.log
+appender.AUDIT_LOGFILE.layout.type = PatternLayout
+appender.AUDIT_LOGFILE.layout.pattern = TID: [%tenantId] [%d] %5p {%c} - %m%ex%n
+appender.AUDIT_LOGFILE.policies.type = Policies
+appender.AUDIT_LOGFILE.policies.time.type = TimeBasedTriggeringPolicy
+appender.AUDIT_LOGFILE.policies.time.interval = 1
+appender.AUDIT_LOGFILE.policies.time.modulate = true
+appender.AUDIT_LOGFILE.policies.size.type = SizeBasedTriggeringPolicy
+appender.AUDIT_LOGFILE.policies.size.size = 10MB
+appender.AUDIT_LOGFILE.strategy.type = DefaultRolloverStrategy
+appender.AUDIT_LOGFILE.strategy.max = 20
+appender.AUDIT_LOGFILE.filter.threshold.type = ThresholdFilter
+appender.AUDIT_LOGFILE.filter.threshold.level = INFO
+
+# Appender config API logging
+appender.API_LOGFILE.type = RollingFile
+appender.API_LOGFILE.name = API_LOGFILE
+appender.API_LOGFILE.fileName = ${sys:carbon.home}/repository/logs/api.log
+appender.API_LOGFILE.filePattern = ${sys:carbon.home}/repository/logs/api-%d{MM-dd-yyyy}-%i.log
+appender.API_LOGFILE.layout.type = PatternLayout
+appender.API_LOGFILE.layout.pattern = [%d] %5p {%c} %X{apiName} - %m%ex%n
+appender.API_LOGFILE.policies.type = Policies
+appender.API_LOGFILE.policies.time.type = TimeBasedTriggeringPolicy
+appender.API_LOGFILE.policies.time.interval = 1
+appender.API_LOGFILE.policies.time.modulate = true
+appender.API_LOGFILE.policies.size.type = SizeBasedTriggeringPolicy
+appender.API_LOGFILE.policies.size.size = 10MB
+appender.API_LOGFILE.strategy.type = DefaultRolloverStrategy
+appender.API_LOGFILE.strategy.max = 20
+appender.API_LOGFILE.filter.threshold.type = ThresholdFilter
+appender.API_LOGFILE.filter.threshold.level = DEBUG
+
+appender.ATOMIKOS_LOGFILE.type = RollingFile
+appender.ATOMIKOS_LOGFILE.name = ATOMIKOS_LOGFILE
+appender.ATOMIKOS_LOGFILE.fileName = ${sys:carbon.home}/repository/logs/tm.out
+appender.ATOMIKOS_LOGFILE.filePattern = ${sys:carbon.home}/repository/logs/tm-%d{MM-dd-yyyy}.out
+appender.ATOMIKOS_LOGFILE.layout.type = PatternLayout
+appender.ATOMIKOS_LOGFILE.layout.pattern = [%d] [%tenantId] %5p {%c} - %m%ex%n
+appender.ATOMIKOS_LOGFILE.policies.type = Policies
+appender.ATOMIKOS_LOGFILE.policies.time.type = TimeBasedTriggeringPolicy
+appender.ATOMIKOS_LOGFILE.policies.time.interval = 1
+appender.ATOMIKOS_LOGFILE.policies.time.modulate = true
+appender.ATOMIKOS_LOGFILE.strategy.type = DefaultRolloverStrategy
+appender.ATOMIKOS_LOGFILE.strategy.max = 20
+
+appender.CARBON_TRACE_LOGFILE.type = RollingFile
+appender.CARBON_TRACE_LOGFILE.name = CARBON_TRACE_LOGFILE
+appender.CARBON_TRACE_LOGFILE.fileName = ${sys:carbon.home}/repository/logs/wso2carbon-trace-messages.log
+appender.CARBON_TRACE_LOGFILE.filePattern = ${sys:carbon.home}/repository/logs/wso2carbon-trace-messages-%d{MM-dd-yyyy}.log
+appender.CARBON_TRACE_LOGFILE.layout.type = PatternLayout
+appender.CARBON_TRACE_LOGFILE.layout.pattern = [%d] [%tenantId] %5p {%c} - %m%ex%n
+appender.CARBON_TRACE_LOGFILE.policies.type = Policies
+appender.CARBON_TRACE_LOGFILE.policies.time.type = TimeBasedTriggeringPolicy
+appender.CARBON_TRACE_LOGFILE.policies.time.interval = 1
+appender.CARBON_TRACE_LOGFILE.policies.time.modulate = true
+appender.CARBON_TRACE_LOGFILE.policies.size.type = SizeBasedTriggeringPolicy
+appender.CARBON_TRACE_LOGFILE.policies.size.size = 10MB
+appender.CARBON_TRACE_LOGFILE.strategy.type = DefaultRolloverStrategy
+appender.CARBON_TRACE_LOGFILE.strategy.max = 20
+
+appender.CORRELATION.type = RollingFile
+appender.CORRELATION.name = CORRELATION
+appender.CORRELATION.fileName = ${sys:carbon.home}/repository/logs/correlation.log
+appender.CORRELATION.filePattern = ${sys:carbon.home}/repository/logs/correlation-%d{MM-dd-yyyy}-%i.log.gz
+appender.CORRELATION.layout.type = PatternLayout
+appender.CORRELATION.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS}|%X{Correlation-ID}|%t|%m%n
+appender.CORRELATION.policies.type = Policies
+appender.CORRELATION.policies.time.type = TimeBasedTriggeringPolicy
+appender.CORRELATION.policies.time.interval = 1
+appender.CORRELATION.policies.time.modulate = true
+appender.CORRELATION.policies.size.type = SizeBasedTriggeringPolicy
+appender.CORRELATION.policies.size.size = 10MB
+appender.CORRELATION.strategy.type = DefaultRolloverStrategy
+appender.CORRELATION.strategy.max = 20
+appender.CORRELATION.filter.threshold.type = ThresholdFilter
+appender.CORRELATION.filter.threshold.level = INFO
+
+appender.ERROR_LOGFILE.type = RollingFile
+appender.ERROR_LOGFILE.name = ERROR_LOGFILE
+appender.ERROR_LOGFILE.fileName = ${sys:carbon.home}/repository/logs/wso2-apigw-errors.log
+appender.ERROR_LOGFILE.filePattern = ${sys:carbon.home}/repository/logs/wso2-apigw-errors-%d{MM-dd-yyyy}-%i.log.gz
+appender.ERROR_LOGFILE.layout.type = PatternLayout
+appender.ERROR_LOGFILE.layout.pattern = %d{ISO8601} [%X{ip}-%X{host}] [%t] %5p %c{1} %m%n
+appender.ERROR_LOGFILE.policies.type = Policies
+appender.ERROR_LOGFILE.policies.time.type = TimeBasedTriggeringPolicy
+appender.ERROR_LOGFILE.policies.time.interval = 1
+appender.ERROR_LOGFILE.policies.time.modulate = true
+appender.ERROR_LOGFILE.policies.size.type = SizeBasedTriggeringPolicy
+appender.ERROR_LOGFILE.policies.size.size = 10MB
+appender.ERROR_LOGFILE.strategy.type = DefaultRolloverStrategy
+appender.ERROR_LOGFILE.strategy.max = 20
+appender.ERROR_LOGFILE.filter.threshold.type = ThresholdFilter
+appender.ERROR_LOGFILE.filter.threshold.level = WARN
+
+appender.OPEN_TRACING.type = RollingFile
+appender.OPEN_TRACING.name = OPEN_TRACING
+appender.OPEN_TRACING.fileName = ${sys:carbon.home}/repository/logs/wso2-apimgt-open-tracing.log
+appender.OPEN_TRACING.filePattern = ${sys:carbon.home}/repository/logs/wso2-apimgt-open-tracing-%d{MM-dd-yyyy}-%i.log.gz
+appender.OPEN_TRACING.layout.type = PatternLayout
+appender.OPEN_TRACING.layout.pattern = %d{HH:mm:ss,SSS} [%X{ip}-%X{host}] [%t] %5p %m%nn
+appender.OPEN_TRACING.policies.type = Policies
+appender.OPEN_TRACING.policies.time.type = TimeBasedTriggeringPolicy
+appender.OPEN_TRACING.policies.time.interval = 1
+appender.OPEN_TRACING.policies.time.modulate = true
+appender.OPEN_TRACING.policies.size.type = SizeBasedTriggeringPolicy
+appender.OPEN_TRACING.policies.size.size = 10MB
+appender.OPEN_TRACING.strategy.type = DefaultRolloverStrategy
+appender.OPEN_TRACING.strategy.max = 20
+appender.OPEN_TRACING.filter.threshold.type = ThresholdFilter
+appender.OPEN_TRACING.filter.threshold.level = TRACE
+
+appender.TRACE_APPENDER.type = RollingFile
+appender.TRACE_APPENDER.name = TRACE_APPENDER
+appender.TRACE_APPENDER.fileName = ${sys:carbon.home}/repository/logs/wso2-apigw-trace.log
+appender.TRACE_APPENDER.filePattern = ${sys:carbon.home}/repository/logs/wso2-apigw-trace-%d{MM-dd-yyyy}.log
+appender.TRACE_APPENDER.layout.type = PatternLayout
+appender.TRACE_APPENDER.layout.pattern = %d{HH:mm:ss,SSS} [%X{ip}-%X{host}] [%t] %5p %c{1} %m%n
+appender.TRACE_APPENDER.policies.type = Policies
+appender.TRACE_APPENDER.policies.time.type = TimeBasedTriggeringPolicy
+appender.TRACE_APPENDER.policies.time.interval = 1
+appender.TRACE_APPENDER.policies.time.modulate = true
+appender.TRACE_APPENDER.strategy.type = DefaultRolloverStrategy
+appender.TRACE_APPENDER.strategy.max = 20
+
+appender.SERVICE_APPENDER.type = RollingFile
+appender.SERVICE_APPENDER.name = SERVICE_APPENDER
+appender.SERVICE_APPENDER.fileName = ${sys:carbon.home}/repository/logs/wso2-apigw-service.log
+appender.SERVICE_APPENDER.filePattern = ${sys:carbon.home}/repository/logs/wso2-apigw-service-%i.log
+appender.SERVICE_APPENDER.layout.type = PatternLayout
+appender.SERVICE_APPENDER.layout.pattern = %d{ISO8601} [%X{ip}-%X{host}] [%t] %5p %c{1} %m%n
+appender.SERVICE_APPENDER.policies.type = Policies
+appender.SERVICE_APPENDER.policies.size.type = SizeBasedTriggeringPolicy
+appender.SERVICE_APPENDER.policies.size.size = 1000KB
+appender.SERVICE_APPENDER.strategy.type = DefaultRolloverStrategy
+appender.SERVICE_APPENDER.strategy.max = 10
+
+appender.BOTDATA_APPENDER.type = RollingFile
+appender.BOTDATA_APPENDER.name = BOTDATA_APPENDER
+appender.BOTDATA_APPENDER.fileName = ${sys:carbon.home}/repository/logs/botData.log
+appender.BOTDATA_APPENDER.filePattern = ${sys:carbon.home}/repository/logs/botData-%d{MM-dd-yyyy}.log
+appender.BOTDATA_APPENDER.layout.type = PatternLayout
+appender.BOTDATA_APPENDER.layout.pattern = %d{HH:mm:ss,SSS} [%X{ip}-%X{host}] [%t] %5p %c{1} %m%n
+appender.BOTDATA_APPENDER.policies.type = Policies
+appender.BOTDATA_APPENDER.policies.time.type = TimeBasedTriggeringPolicy
+appender.BOTDATA_APPENDER.policies.time.interval = 1
+appender.BOTDATA_APPENDER.policies.time.modulate = true
+appender.BOTDATA_APPENDER.strategy.type = DefaultRolloverStrategy
+appender.BOTDATA_APPENDER.strategy.max = 20
+
+appender.APIM_GATEWAY_ACCESS_APPENDER.type = RollingFile
+appender.APIM_GATEWAY_ACCESS_APPENDER.name = APIM_GATEWAY_ACCESS_APPENDER
+appender.APIM_GATEWAY_ACCESS_APPENDER.fileName = ${sys:carbon.home}/repository/logs/http_access.log
+appender.APIM_GATEWAY_ACCESS_APPENDER.filePattern = ${sys:carbon.home}/repository/logs/http_access_%d{MM-dd-yyyy}-%i.log
+appender.APIM_GATEWAY_ACCESS_APPENDER.layout.type = PatternLayout
+appender.APIM_GATEWAY_ACCESS_APPENDER.layout.pattern = %msg%n
+appender.APIM_GATEWAY_ACCESS_APPENDER.policies.type = Policies
+appender.APIM_GATEWAY_ACCESS_APPENDER.policies.time.type = TimeBasedTriggeringPolicy
+appender.APIM_GATEWAY_ACCESS_APPENDER.policies.time.interval = 1
+appender.APIM_GATEWAY_ACCESS_APPENDER.policies.time.modulate = true
+appender.APIM_GATEWAY_ACCESS_APPENDER.policies.size.type = SizeBasedTriggeringPolicy
+appender.APIM_GATEWAY_ACCESS_APPENDER.policies.size.size = 1000MB
+appender.APIM_GATEWAY_ACCESS_APPENDER.strategy.type = DefaultRolloverStrategy
+appender.APIM_GATEWAY_ACCESS_APPENDER.strategy.max = 10
+appender.APIM_GATEWAY_ACCESS_APPENDER.filter.threshold.type = ThresholdFilter
+appender.APIM_GATEWAY_ACCESS_APPENDER.filter.threshold.level = DEBUG
+
+appender.osgi.type = PaxOsgi
+appender.osgi.name = PaxOsgi
+appender.osgi.filter = *
+
+loggers = AUDIT_LOG, API_LOG, trace-messages, correlation, GatewayAccessLogger
+
+logger.AUDIT_LOG.name = AUDIT_LOG
+logger.AUDIT_LOG.level = INFO
+logger.AUDIT_LOG.appenderRef.AUDIT_LOGFILE.ref = AUDIT_LOGFILE
+logger.AUDIT_LOG.additivity = false
+
+logger.API_LOG.name = API_LOG
+logger.API_LOG.level = INFO
+logger.API_LOG.appenderRef.API_LOGFILE.ref = API_LOGFILE
+logger.API_LOG.additivity = false
+
+logger.trace-messages.name = trace.messages
+logger.trace-messages.level = TRACE
+logger.trace-messages.appenderRef.CARBON_TRACE_LOGFILE.ref = CARBON_TRACE_LOGFILE
+
+logger.correlation.name = correlation
+logger.correlation.level = INFO
+logger.correlation.appenderRef.CORRELATION.ref = CORRELATION
+logger.correlation.additivity = false
+
+logger.GatewayAccessLogger.name = GatewayAccessLogger
+logger.GatewayAccessLogger.level = INFO
+logger.GatewayAccessLogger.appenderRef.APIM_GATEWAY_ACCESS_APPENDER.ref = APIM_GATEWAY_ACCESS_APPENDER
+logger.GatewayAccessLogger.additivity = false
+
+rootLogger.level = ERROR
+rootLogger.appenderRef.CARBON_CONSOLE.ref = CARBON_CONSOLE
+rootLogger.appenderRef.ERROR_LOGFILE.ref = ERROR_LOGFILE
+rootLogger.appenderRef.osgi.ref = PaxOsgi

--- a/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/remoteLogging/log4j2WithoutLocalAppenders.properties
+++ b/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/resources/artifacts/AM/configFiles/remoteLogging/log4j2WithoutLocalAppenders.properties
@@ -1,0 +1,175 @@
+# log4j2 test fixture: AUDIT_LOGFILE, CARBON_LOGFILE and API_LOGFILE blocks all absent
+# Represents a system where these appenders have been intentionally removed.
+# Used to verify that the log4j2.properties is NOT modified when remote logging is
+# not configured (blank URL) — neither by direct reset calls nor by syncRemoteServerConfigs.
+appenders = CARBON_CONSOLE, ATOMIKOS_LOGFILE, CARBON_TRACE_LOGFILE, ERROR_LOGFILE, OPEN_TRACING, SERVICE_APPENDER, TRACE_APPENDER, osgi, CORRELATION, BOTDATA_APPENDER, APIM_GATEWAY_ACCESS_APPENDER
+
+appender.CARBON_CONSOLE.type = Console
+appender.CARBON_CONSOLE.name = CARBON_CONSOLE
+appender.CARBON_CONSOLE.layout.type = PatternLayout
+appender.CARBON_CONSOLE.layout.pattern = [%d{DEFAULT}] %5p - %c{1} %m%n
+appender.CARBON_CONSOLE.filter.threshold.type = ThresholdFilter
+appender.CARBON_CONSOLE.filter.threshold.level = DEBUG
+
+# NOTE: CARBON_LOGFILE block intentionally absent
+# NOTE: AUDIT_LOGFILE block intentionally absent
+# NOTE: API_LOGFILE block intentionally absent
+
+appender.ATOMIKOS_LOGFILE.type = RollingFile
+appender.ATOMIKOS_LOGFILE.name = ATOMIKOS_LOGFILE
+appender.ATOMIKOS_LOGFILE.fileName = ${sys:carbon.home}/repository/logs/tm.out
+appender.ATOMIKOS_LOGFILE.filePattern = ${sys:carbon.home}/repository/logs/tm-%d{MM-dd-yyyy}.out
+appender.ATOMIKOS_LOGFILE.layout.type = PatternLayout
+appender.ATOMIKOS_LOGFILE.layout.pattern = [%d] [%tenantId] %5p {%c} - %m%ex%n
+appender.ATOMIKOS_LOGFILE.policies.type = Policies
+appender.ATOMIKOS_LOGFILE.policies.time.type = TimeBasedTriggeringPolicy
+appender.ATOMIKOS_LOGFILE.policies.time.interval = 1
+appender.ATOMIKOS_LOGFILE.policies.time.modulate = true
+appender.ATOMIKOS_LOGFILE.strategy.type = DefaultRolloverStrategy
+appender.ATOMIKOS_LOGFILE.strategy.max = 20
+
+appender.CARBON_TRACE_LOGFILE.type = RollingFile
+appender.CARBON_TRACE_LOGFILE.name = CARBON_TRACE_LOGFILE
+appender.CARBON_TRACE_LOGFILE.fileName = ${sys:carbon.home}/repository/logs/wso2carbon-trace-messages.log
+appender.CARBON_TRACE_LOGFILE.filePattern = ${sys:carbon.home}/repository/logs/wso2carbon-trace-messages-%d{MM-dd-yyyy}.log
+appender.CARBON_TRACE_LOGFILE.layout.type = PatternLayout
+appender.CARBON_TRACE_LOGFILE.layout.pattern = [%d] [%tenantId] %5p {%c} - %m%ex%n
+appender.CARBON_TRACE_LOGFILE.policies.type = Policies
+appender.CARBON_TRACE_LOGFILE.policies.time.type = TimeBasedTriggeringPolicy
+appender.CARBON_TRACE_LOGFILE.policies.time.interval = 1
+appender.CARBON_TRACE_LOGFILE.policies.time.modulate = true
+appender.CARBON_TRACE_LOGFILE.policies.size.type = SizeBasedTriggeringPolicy
+appender.CARBON_TRACE_LOGFILE.policies.size.size = 10MB
+appender.CARBON_TRACE_LOGFILE.strategy.type = DefaultRolloverStrategy
+appender.CARBON_TRACE_LOGFILE.strategy.max = 20
+
+appender.CORRELATION.type = RollingFile
+appender.CORRELATION.name = CORRELATION
+appender.CORRELATION.fileName = ${sys:carbon.home}/repository/logs/correlation.log
+appender.CORRELATION.filePattern = ${sys:carbon.home}/repository/logs/correlation-%d{MM-dd-yyyy}-%i.log.gz
+appender.CORRELATION.layout.type = PatternLayout
+appender.CORRELATION.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS}|%X{Correlation-ID}|%t|%m%n
+appender.CORRELATION.policies.type = Policies
+appender.CORRELATION.policies.time.type = TimeBasedTriggeringPolicy
+appender.CORRELATION.policies.time.interval = 1
+appender.CORRELATION.policies.time.modulate = true
+appender.CORRELATION.policies.size.type = SizeBasedTriggeringPolicy
+appender.CORRELATION.policies.size.size = 10MB
+appender.CORRELATION.strategy.type = DefaultRolloverStrategy
+appender.CORRELATION.strategy.max = 20
+appender.CORRELATION.filter.threshold.type = ThresholdFilter
+appender.CORRELATION.filter.threshold.level = INFO
+
+appender.ERROR_LOGFILE.type = RollingFile
+appender.ERROR_LOGFILE.name = ERROR_LOGFILE
+appender.ERROR_LOGFILE.fileName = ${sys:carbon.home}/repository/logs/wso2-apigw-errors.log
+appender.ERROR_LOGFILE.filePattern = ${sys:carbon.home}/repository/logs/wso2-apigw-errors-%d{MM-dd-yyyy}-%i.log.gz
+appender.ERROR_LOGFILE.layout.type = PatternLayout
+appender.ERROR_LOGFILE.layout.pattern = %d{ISO8601} [%X{ip}-%X{host}] [%t] %5p %c{1} %m%n
+appender.ERROR_LOGFILE.policies.type = Policies
+appender.ERROR_LOGFILE.policies.time.type = TimeBasedTriggeringPolicy
+appender.ERROR_LOGFILE.policies.time.interval = 1
+appender.ERROR_LOGFILE.policies.time.modulate = true
+appender.ERROR_LOGFILE.policies.size.type = SizeBasedTriggeringPolicy
+appender.ERROR_LOGFILE.policies.size.size = 10MB
+appender.ERROR_LOGFILE.strategy.type = DefaultRolloverStrategy
+appender.ERROR_LOGFILE.strategy.max = 20
+appender.ERROR_LOGFILE.filter.threshold.type = ThresholdFilter
+appender.ERROR_LOGFILE.filter.threshold.level = WARN
+
+appender.OPEN_TRACING.type = RollingFile
+appender.OPEN_TRACING.name = OPEN_TRACING
+appender.OPEN_TRACING.fileName = ${sys:carbon.home}/repository/logs/wso2-apimgt-open-tracing.log
+appender.OPEN_TRACING.filePattern = ${sys:carbon.home}/repository/logs/wso2-apimgt-open-tracing-%d{MM-dd-yyyy}-%i.log.gz
+appender.OPEN_TRACING.layout.type = PatternLayout
+appender.OPEN_TRACING.layout.pattern = %d{HH:mm:ss,SSS} [%X{ip}-%X{host}] [%t] %5p %m%nn
+appender.OPEN_TRACING.policies.type = Policies
+appender.OPEN_TRACING.policies.time.type = TimeBasedTriggeringPolicy
+appender.OPEN_TRACING.policies.time.interval = 1
+appender.OPEN_TRACING.policies.time.modulate = true
+appender.OPEN_TRACING.policies.size.type = SizeBasedTriggeringPolicy
+appender.OPEN_TRACING.policies.size.size = 10MB
+appender.OPEN_TRACING.strategy.type = DefaultRolloverStrategy
+appender.OPEN_TRACING.strategy.max = 20
+appender.OPEN_TRACING.filter.threshold.type = ThresholdFilter
+appender.OPEN_TRACING.filter.threshold.level = TRACE
+
+appender.TRACE_APPENDER.type = RollingFile
+appender.TRACE_APPENDER.name = TRACE_APPENDER
+appender.TRACE_APPENDER.fileName = ${sys:carbon.home}/repository/logs/wso2-apigw-trace.log
+appender.TRACE_APPENDER.filePattern = ${sys:carbon.home}/repository/logs/wso2-apigw-trace-%d{MM-dd-yyyy}.log
+appender.TRACE_APPENDER.layout.type = PatternLayout
+appender.TRACE_APPENDER.layout.pattern = %d{HH:mm:ss,SSS} [%X{ip}-%X{host}] [%t] %5p %c{1} %m%n
+appender.TRACE_APPENDER.policies.type = Policies
+appender.TRACE_APPENDER.policies.time.type = TimeBasedTriggeringPolicy
+appender.TRACE_APPENDER.policies.time.interval = 1
+appender.TRACE_APPENDER.policies.time.modulate = true
+appender.TRACE_APPENDER.strategy.type = DefaultRolloverStrategy
+appender.TRACE_APPENDER.strategy.max = 20
+
+appender.SERVICE_APPENDER.type = RollingFile
+appender.SERVICE_APPENDER.name = SERVICE_APPENDER
+appender.SERVICE_APPENDER.fileName = ${sys:carbon.home}/repository/logs/wso2-apigw-service.log
+appender.SERVICE_APPENDER.filePattern = ${sys:carbon.home}/repository/logs/wso2-apigw-service-%i.log
+appender.SERVICE_APPENDER.layout.type = PatternLayout
+appender.SERVICE_APPENDER.layout.pattern = %d{ISO8601} [%X{ip}-%X{host}] [%t] %5p %c{1} %m%n
+appender.SERVICE_APPENDER.policies.type = Policies
+appender.SERVICE_APPENDER.policies.size.type = SizeBasedTriggeringPolicy
+appender.SERVICE_APPENDER.policies.size.size = 1000KB
+appender.SERVICE_APPENDER.strategy.type = DefaultRolloverStrategy
+appender.SERVICE_APPENDER.strategy.max = 10
+
+appender.BOTDATA_APPENDER.type = RollingFile
+appender.BOTDATA_APPENDER.name = BOTDATA_APPENDER
+appender.BOTDATA_APPENDER.fileName = ${sys:carbon.home}/repository/logs/botData.log
+appender.BOTDATA_APPENDER.filePattern = ${sys:carbon.home}/repository/logs/botData-%d{MM-dd-yyyy}.log
+appender.BOTDATA_APPENDER.layout.type = PatternLayout
+appender.BOTDATA_APPENDER.layout.pattern = %d{HH:mm:ss,SSS} [%X{ip}-%X{host}] [%t] %5p %c{1} %m%n
+appender.BOTDATA_APPENDER.policies.type = Policies
+appender.BOTDATA_APPENDER.policies.time.type = TimeBasedTriggeringPolicy
+appender.BOTDATA_APPENDER.policies.time.interval = 1
+appender.BOTDATA_APPENDER.policies.time.modulate = true
+appender.BOTDATA_APPENDER.strategy.type = DefaultRolloverStrategy
+appender.BOTDATA_APPENDER.strategy.max = 20
+
+appender.APIM_GATEWAY_ACCESS_APPENDER.type = RollingFile
+appender.APIM_GATEWAY_ACCESS_APPENDER.name = APIM_GATEWAY_ACCESS_APPENDER
+appender.APIM_GATEWAY_ACCESS_APPENDER.fileName = ${sys:carbon.home}/repository/logs/http_access.log
+appender.APIM_GATEWAY_ACCESS_APPENDER.filePattern = ${sys:carbon.home}/repository/logs/http_access_%d{MM-dd-yyyy}-%i.log
+appender.APIM_GATEWAY_ACCESS_APPENDER.layout.type = PatternLayout
+appender.APIM_GATEWAY_ACCESS_APPENDER.layout.pattern = %msg%n
+appender.APIM_GATEWAY_ACCESS_APPENDER.policies.type = Policies
+appender.APIM_GATEWAY_ACCESS_APPENDER.policies.time.type = TimeBasedTriggeringPolicy
+appender.APIM_GATEWAY_ACCESS_APPENDER.policies.time.interval = 1
+appender.APIM_GATEWAY_ACCESS_APPENDER.policies.time.modulate = true
+appender.APIM_GATEWAY_ACCESS_APPENDER.policies.size.type = SizeBasedTriggeringPolicy
+appender.APIM_GATEWAY_ACCESS_APPENDER.policies.size.size = 1000MB
+appender.APIM_GATEWAY_ACCESS_APPENDER.strategy.type = DefaultRolloverStrategy
+appender.APIM_GATEWAY_ACCESS_APPENDER.strategy.max = 10
+appender.APIM_GATEWAY_ACCESS_APPENDER.filter.threshold.type = ThresholdFilter
+appender.APIM_GATEWAY_ACCESS_APPENDER.filter.threshold.level = DEBUG
+
+appender.osgi.type = PaxOsgi
+appender.osgi.name = PaxOsgi
+appender.osgi.filter = *
+
+loggers = trace-messages, correlation, GatewayAccessLogger
+
+logger.trace-messages.name = trace.messages
+logger.trace-messages.level = TRACE
+logger.trace-messages.appenderRef.CARBON_TRACE_LOGFILE.ref = CARBON_TRACE_LOGFILE
+
+logger.correlation.name = correlation
+logger.correlation.level = INFO
+logger.correlation.appenderRef.CORRELATION.ref = CORRELATION
+logger.correlation.additivity = false
+
+logger.GatewayAccessLogger.name = GatewayAccessLogger
+logger.GatewayAccessLogger.level = INFO
+logger.GatewayAccessLogger.appenderRef.APIM_GATEWAY_ACCESS_APPENDER.ref = APIM_GATEWAY_ACCESS_APPENDER
+logger.GatewayAccessLogger.additivity = false
+
+rootLogger.level = ERROR
+rootLogger.appenderRef.CARBON_CONSOLE.ref = CARBON_CONSOLE
+rootLogger.appenderRef.ERROR_LOGFILE.ref = ERROR_LOGFILE
+rootLogger.appenderRef.osgi.ref = PaxOsgi

--- a/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
+++ b/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/resources/testng.xml
@@ -469,6 +469,7 @@
         <classes>
             <class name="org.wso2.am.integration.tests.logging.APILoggingTest"/>
             <!--<class name="org.wso2.am.integration.tests.logging.CorrelationLoggingTest"/>-->
+            <class name="org.wso2.am.integration.tests.logging.RemoteLoggingAppenderTest"/>
         </classes>
     </test>
 

--- a/all-in-one-apim/pom.xml
+++ b/all-in-one-apim/pom.xml
@@ -591,6 +591,11 @@
                 <version>${carbon.commons.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.wso2.carbon.commons</groupId>
+                <artifactId>org.wso2.carbon.logging.remote.config.stub</artifactId>
+                <version>${carbon.commons.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.wso2.carbon</groupId>
                 <artifactId>org.wso2.carbon.utils</artifactId>
                 <version>${carbon.kernel.version}</version>
@@ -1323,7 +1328,7 @@
 
         <cipher.tool.version>1.1.30</cipher.tool.version>
 
-        <carbon.commons.version>4.13.3</carbon.commons.version>
+        <carbon.commons.version>4.13.4</carbon.commons.version>
         <carbon.kernel.imp.pkg.version>[4.5.0, 5.0.0)</carbon.kernel.imp.pkg.version>
 
         <!-- carbon mediation -->


### PR DESCRIPTION
## Summary

Adds integration tests for the remote logging appender management behaviour, covering how `log4j2.properties` is modified (or deliberately left unchanged) when remote server logging is enabled or disabled via the `RemoteLoggingConfig` admin service.

Related to - https://github.com/wso2/api-manager/issues/4925

## Changes

### New: `RemoteLoggingConfigClient`

A thin wrapper around `RemoteLoggingConfigStub` that exposes the five operations of the `RemoteLoggingConfig` Axis2 admin service — `addRemoteServerConfig`, `resetRemoteServerConfig`, `getRemoteServerConfigs`, `getRemoteServerConfig`, and `syncRemoteServerConfigs` — in a form that integrates with the existing admin-client authentication pattern.

---

### New: `RemoteLoggingAppenderTest`

Ten independent integration tests grouped into four scenarios. Each test writes a dedicated fixture to the live `log4j2.properties`, calls the service under test, reads the file back, and asserts on its content. `@AfterMethod(alwaysRun = true)` resets all active remote logging configurations and restores the original `log4j2.properties` after every test (pass or fail), providing full isolation without `dependsOnMethods` chaining.

A built-in Java `HttpServer` acts as the mock remote log receiver for the end-to-end test; no additional test dependencies are introduced.

| Test method | What it verifies |
|---|---|
| `testExistingAppendersPreservedOnResetWithBlankUrl` | Calling `resetRemoteServerConfig` on already-`RollingFile` appenders is a no-op |
| `testOnlyConfiguredAppenderIsReset` | Reset for one log type does not affect the other two appender blocks |
| `testMissingAuditAppenderCreatedOnEnable` | `AUDIT_LOGFILE` block written as HTTP + `AUDIT_LOG` logger wired when block was absent |
| `testMissingCarbonAppenderCreatedOnEnable` | `CARBON_LOGFILE` block written as HTTP + `rootLogger` appenderRef added when block was absent |
| `testMissingApiAppenderCreatedOnEnable` | `API_LOGFILE` block written as HTTP + `API_LOG` logger wired when block was absent |
| `testOnlyTargetedAppenderCreatedWhenOthersAbsent` | Enabling remote logging for API only creates `API_LOGFILE`; `AUDIT_LOGFILE` and `CARBON_LOGFILE` remain absent |
| `testMissingAppendersNotAddedOnSyncWhenRemoteLoggingNotConfigured` | `syncRemoteServerConfigs()` with no configured remote URLs leaves a stripped `log4j2.properties` unchanged |
| `testNoDuplicateAppenderInList` | Enabling then resetting does not produce duplicate entries in the `appenders = ...` list |
| `testRemoteLoggingEndToEnd` | Audit log entries reach the mock HTTP endpoint when enabled, and stop after reset |
| `testAllThreeMissingAppendersCreatedOnEnable` | Enabling all three log types populates all three appender blocks and their corresponding loggers |

---

### New: log4j2 test fixtures (5 files)

Each fixture is a self-consistent `log4j2.properties` file. Loggers that reference absent appenders are removed to prevent `Unable to locate appender` warnings during the test run.

| Fixture | State |
|---|---|
| `log4j2WithAllAppenders.properties` | All three blocks present as `RollingFile`; baseline for reset and no-duplicate tests |
| `log4j2WithoutAuditAppender.properties` | `AUDIT_LOGFILE` block and `AUDIT_LOG` logger absent |
| `log4j2WithoutCarbonAppender.properties` | `CARBON_LOGFILE` block and its `rootLogger` reference absent |
| `log4j2WithoutApiAppender.properties` | `API_LOGFILE` block and `API_LOG` logger absent |
| `log4j2WithoutLocalAppenders.properties` | All three blocks, their loggers, and their `rootLogger` reference absent |

---

### Modified: `pom.xml` files

- Root `pom.xml` — added `org.wso2.carbon.logging.remote.config.stub` to `dependencyManagement`
- `admin-clients/pom.xml` — consumed the above dependency

### Modified: `testng.xml`

Added the `apim-remote-logging-tests` test group pointing at `RemoteLoggingAppenderTest`.

---

## Testing

The end-to-end test (`testRemoteLoggingEndToEnd`) requires no external infrastructure — it binds an ephemeral `HttpServer` on a free local port and uses Awaitility to wait up to 30 seconds for the first log payload to arrive.
