### PR TITLE
Improve MCP tests to consider resource and tool ordering

### DIFF
--- a/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/mcp/MCPServerTestCase.java
+++ b/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/mcp/MCPServerTestCase.java
@@ -18,8 +18,6 @@
 
 package org.wso2.am.integration.tests.mcp;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.google.gson.Gson;
@@ -336,21 +334,25 @@ public class MCPServerTestCase extends APIMIntegrationBaseTest {
             "  }\n" +
             "}";
 
+    // After an update, operations are submitted as [addOp=delete_oldpets, updateOp=get_pets]. The URL mappings are
+    // (re)inserted in that submission order, so URL_MAPPING_ID follows it, and the gateway now reads the deployed
+    // revision's URL mappings ordered by URL_MAPPING_ID. The tool list is therefore [delete_oldpets, get_pets]
+    // deterministically for both the direct-backend and existing-API subtypes.
     private static final String EXPECTED_UPDATED_TOOL_LIST_RESPONSE = "{\n" +
             "  \"jsonrpc\" : \"2.0\",\n" +
             "  \"id\" : 0,\n" +
             "  \"result\" : {\n" +
             "    \"tools\" : [ {\n" +
-            "      \"name\" : \"get_pets\",\n" +
-            "      \"description\" : \"Return a list of pets\",\n" +
+            "      \"name\" : \"delete_oldpets\",\n" +
+            "      \"description\" : \"Delete all old pets\",\n" +
             "      \"inputSchema\" : {\n" +
             "        \"type\" : \"object\",\n" +
             "        \"properties\" : { },\n" +
             "        \"required\" : [ ]\n" +
             "      }\n" +
             "    }, {\n" +
-            "      \"name\" : \"delete_oldpets\",\n" +
-            "      \"description\" : \"Delete all old pets\",\n" +
+            "      \"name\" : \"get_pets\",\n" +
+            "      \"description\" : \"Return a list of pets\",\n" +
             "      \"inputSchema\" : {\n" +
             "        \"type\" : \"object\",\n" +
             "        \"properties\" : { },\n" +
@@ -507,7 +509,7 @@ public class MCPServerTestCase extends APIMIntegrationBaseTest {
         Assert.assertNotNull(mcpServer.getId(), "MCP Server ID is null (OpenAPI flow)");
         mcpServerFromOpenApiId = mcpServer.getId();
         assertNonEmpty(mcpServer.getOperations(), "No operations found in MCP Server (OpenAPI flow)");
-        assertTargets(mcpServer.getOperations(), listOf(TARGET_GET_PETS, TARGET_GET_PETS_BY_ID),
+        assertTargetsInOrder(mcpServer.getOperations(), listOf(TARGET_GET_PETS, TARGET_GET_PETS_BY_ID),
                 "OpenAPI flow: Missing expected operations");
 
         final MCPServerOperationDTO getByIdOp = getOperationByTarget(mcpServer.getOperations(), TARGET_GET_PETS_BY_ID);
@@ -629,7 +631,7 @@ public class MCPServerTestCase extends APIMIntegrationBaseTest {
         mcpServerFromApiId = mcpServer.getId();
 
         assertNonEmpty(mcpServer.getOperations(), "No operations found in MCP Server (API flow)");
-        assertTargets(mcpServer.getOperations(), listOf(TARGET_GET_PETS, TARGET_GET_PETS_BY_ID),
+        assertTargetsInOrder(mcpServer.getOperations(), listOf(TARGET_GET_PETS, TARGET_GET_PETS_BY_ID),
                 "API flow: Missing expected operations");
 
         final MCPServerOperationDTO getByIdOp =
@@ -801,7 +803,7 @@ public class MCPServerTestCase extends APIMIntegrationBaseTest {
         mcpServer.setOperations(Arrays.asList(addOp, updateOp));
 
         final MCPServerDTO updated = restAPIPublisher.updateMCPServer(mcpServerFromOpenApiId, mcpServer);
-        assertTargets(updated.getOperations(), listOf(TARGET_GET_PETS, TARGET_DELETE_OLD_PETS),
+        assertTargetsInOrder(updated.getOperations(), listOf(TARGET_DELETE_OLD_PETS, TARGET_GET_PETS),
                 "API flow: Expected operations do not match after update");
 
         final MCPServerOperationDTO deleteOldPets =
@@ -828,23 +830,10 @@ public class MCPServerTestCase extends APIMIntegrationBaseTest {
                 HTTPSClientUtils.doPost(petstoreBackendURL, requestHeaders, TOOL_LIST_REQUEST_PAYLOAD);
         assertHttpOk(toolListResponse, "Tool list call failed");
 
-        // Check whether the returned tool list contains both delete_oldpets and get_pets tools
-        ObjectMapper mapper = new ObjectMapper();
-        JsonNode root = mapper.readTree(toolListResponse.getData());
-        JsonNode tools = root.path("result").path("tools");
-        boolean hasDeleteOldPets = false;
-        boolean hasGetPets = false;
-        for (JsonNode tool : tools) {
-            if ("delete_oldpets".equals(tool.path("name").asText())) {
-                hasDeleteOldPets = true;
-            }
-            if ("get_pets".equals(tool.path("name").asText())) {
-                hasGetPets = true;
-            }
-        }
-
-        Assert.assertTrue(hasGetPets && hasDeleteOldPets, mismatch("Tool list response", "tool-list",
-                EXPECTED_UPDATED_TOOL_LIST_RESPONSE, toolListResponse.getData()));
+        // Validate the tool list, including the order of the tools (resource ordering), not just their presence.
+        Assert.assertEquals(compactJson(toolListResponse.getData()), compactJson(EXPECTED_UPDATED_TOOL_LIST_RESPONSE),
+                mismatch("Tool list response", "tool-list", EXPECTED_UPDATED_TOOL_LIST_RESPONSE,
+                        toolListResponse.getData()));
     }
 
     @Test(groups = {GROUP_WSO2_AM}, description = "Update tool operations in a MCP Server",
@@ -862,7 +851,7 @@ public class MCPServerTestCase extends APIMIntegrationBaseTest {
         mcpServer.setOperations(Arrays.asList(addOp, updateOp));
 
         final MCPServerDTO updated = restAPIPublisher.updateMCPServer(mcpServerFromApiId, mcpServer);
-        assertTargets(updated.getOperations(), listOf(TARGET_GET_PETS, TARGET_DELETE_OLD_PETS),
+        assertTargetsInOrder(updated.getOperations(), listOf(TARGET_DELETE_OLD_PETS, TARGET_GET_PETS),
                 "API flow: Expected operations do not match after update");
 
         final MCPServerOperationDTO deleteOldPets =
@@ -1437,6 +1426,28 @@ public class MCPServerTestCase extends APIMIntegrationBaseTest {
                 ", received=" + received;
 
         Assert.assertTrue(missing.isEmpty() && unexpected.isEmpty() && duplicates.isEmpty(), diag);
+    }
+
+    /**
+     * Assert that the given operations contain exactly the provided targets in the exact expected order. This
+     * validates resource/tool ordering in addition to presence, uniqueness and absence of unexpected targets.
+     *
+     * @param operations             operations to inspect
+     * @param expectedTargetsInOrder expected targets in the exact expected order
+     * @param messagePrefix          a short prefix to identify the assertion context
+     */
+    private static void assertTargetsInOrder(List<MCPServerOperationDTO> operations,
+                                             List<String> expectedTargetsInOrder, String messagePrefix) {
+
+        // First validate presence, uniqueness and that there are no unexpected targets.
+        assertTargets(operations, expectedTargetsInOrder, messagePrefix);
+
+        List<String> actualOrder = Optional.ofNullable(operations).orElse(Collections.emptyList()).stream()
+                .map(MCPServerOperationDTO::getTarget)
+                .collect(Collectors.toList());
+        Assert.assertEquals(actualOrder, expectedTargetsInOrder,
+                messagePrefix + ": operation order mismatch. Expected order=" + expectedTargetsInOrder
+                        + ", actual order=" + actualOrder);
     }
 
     /**

--- a/all-in-one-apim/pom.xml
+++ b/all-in-one-apim/pom.xml
@@ -1311,7 +1311,7 @@
         <carbon.apimgt.ui.version>9.3.194</carbon.apimgt.ui.version>
 
         <!-- APIM Component Version -->
-        <carbon.apimgt.version>9.33.145</carbon.apimgt.version>
+        <carbon.apimgt.version>9.33.147</carbon.apimgt.version>
 
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 


### PR DESCRIPTION
This pull request improves the integration tests for MCP Server by enforcing and validating the order of operations and tool lists, rather than just their presence. It introduces a new helper method to assert operation order, updates test expectations and assertions to require deterministic ordering, and cleans up redundant code. Additionally, the APIM component version is updated.

Related to - https://github.com/wso2/api-manager/issues/4821

**Test improvements for operation and tool ordering:**

* Added a new `assertTargetsInOrder` helper method to check that operations appear in the expected order, not just that they are present.
* Updated tests to use `assertTargetsInOrder` instead of `assertTargets`, ensuring that both OpenAPI and API flows validate the order of operations. [[1]](diffhunk://#diff-595705768a17bd0fd3aecdb375874ea7ac7600374712b37a2ffcfcedaf6a2108L510-R512) [[2]](diffhunk://#diff-595705768a17bd0fd3aecdb375874ea7ac7600374712b37a2ffcfcedaf6a2108L632-R634) [[3]](diffhunk://#diff-595705768a17bd0fd3aecdb375874ea7ac7600374712b37a2ffcfcedaf6a2108L804-R806) [[4]](diffhunk://#diff-595705768a17bd0fd3aecdb375874ea7ac7600374712b37a2ffcfcedaf6a2108L865-R854)
* Modified the expected tool list response to reflect the new deterministic order of tools after updates.
* Changed validation of the tool list in tests to compare the actual and expected JSON responses for both content and order, removing manual iteration and presence checks.

**Dependency update:**

* Updated `carbon.apimgt.version` to `9.33.147` in `pom.xml`.