### PR TITLE
Bump synapse version to 4.1.0-wso2v57

### DIFF
--- a/all-in-one-apim/pom.xml
+++ b/all-in-one-apim/pom.xml
@@ -1332,7 +1332,7 @@
         <carbon.kernel.imp.pkg.version>[4.5.0, 5.0.0)</carbon.kernel.imp.pkg.version>
 
         <!-- carbon mediation -->
-        <carbon.mediation.version>4.8.16</carbon.mediation.version>
+        <carbon.mediation.version>4.8.19</carbon.mediation.version>
 
         <!-- carbon identity -->
         <carbon.identity.version>5.27.21</carbon.identity.version>

--- a/all-in-one-apim/pom.xml
+++ b/all-in-one-apim/pom.xml
@@ -1375,7 +1375,7 @@
         <opencsv.version>1.8</opencsv.version>
         <poi.version>3.0-FINAL</poi.version>
         <woden.version>1.0.0.M8-wso2v1</woden.version>
-        <synapse.version>4.1.0-wso2v40</synapse.version>
+        <synapse.version>4.1.0-wso2v57</synapse.version>
         <passthru.transport.patch.version>1.0.2</passthru.transport.patch.version>
         <axis2.wso2.version>1.6.1-wso2v125</axis2.wso2.version>
         <axiom.wso2.version>1.2.11-wso2v37</axiom.wso2.version>

--- a/api-control-plane/pom.xml
+++ b/api-control-plane/pom.xml
@@ -1349,7 +1349,7 @@
         <opencsv.version>1.8</opencsv.version>
         <poi.version>3.0-FINAL</poi.version>
         <woden.version>1.0.0.M8-wso2v1</woden.version>
-        <synapse.version>4.1.0-wso2v40</synapse.version>
+        <synapse.version>4.1.0-wso2v57</synapse.version>
         <passthru.transport.patch.version>1.0.2</passthru.transport.patch.version>
         <axis2.wso2.version>1.6.1-wso2v125</axis2.wso2.version>
         <axiom.wso2.version>1.2.11-wso2v37</axiom.wso2.version>

--- a/api-control-plane/pom.xml
+++ b/api-control-plane/pom.xml
@@ -1306,7 +1306,7 @@
         <carbon.kernel.imp.pkg.version>[4.5.0, 5.0.0)</carbon.kernel.imp.pkg.version>
 
         <!-- carbon mediation -->
-        <carbon.mediation.version>4.8.16</carbon.mediation.version>
+        <carbon.mediation.version>4.8.19</carbon.mediation.version>
 
         <!-- carbon identity -->
         <carbon.identity.version>5.27.21</carbon.identity.version>

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -1349,7 +1349,7 @@
         <opencsv.version>1.8</opencsv.version>
         <poi.version>3.0-FINAL</poi.version>
         <woden.version>1.0.0.M8-wso2v1</woden.version>
-        <synapse.version>4.1.0-wso2v40</synapse.version>
+        <synapse.version>4.1.0-wso2v57</synapse.version>
         <passthru.transport.patch.version>1.0.2</passthru.transport.patch.version>
         <axis2.wso2.version>1.6.1-wso2v125</axis2.wso2.version>
         <axiom.wso2.version>1.2.11-wso2v37</axiom.wso2.version>

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -1306,7 +1306,7 @@
         <carbon.kernel.imp.pkg.version>[4.5.0, 5.0.0)</carbon.kernel.imp.pkg.version>
 
         <!-- carbon mediation -->
-        <carbon.mediation.version>4.8.16</carbon.mediation.version>
+        <carbon.mediation.version>4.8.19</carbon.mediation.version>
 
         <!-- carbon identity -->
         <carbon.identity.version>5.27.21</carbon.identity.version>

--- a/traffic-manager/pom.xml
+++ b/traffic-manager/pom.xml
@@ -1351,7 +1351,7 @@
         <opencsv.version>1.8</opencsv.version>
         <poi.version>3.0-FINAL</poi.version>
         <woden.version>1.0.0.M8-wso2v1</woden.version>
-        <synapse.version>4.1.0-wso2v40</synapse.version>
+        <synapse.version>4.1.0-wso2v57</synapse.version>
         <passthru.transport.patch.version>1.0.2</passthru.transport.patch.version>
         <axis2.wso2.version>1.6.1-wso2v125</axis2.wso2.version>
         <axiom.wso2.version>1.2.11-wso2v37</axiom.wso2.version>

--- a/traffic-manager/pom.xml
+++ b/traffic-manager/pom.xml
@@ -1308,7 +1308,7 @@
         <carbon.kernel.imp.pkg.version>[4.5.0, 5.0.0)</carbon.kernel.imp.pkg.version>
 
         <!-- carbon mediation -->
-        <carbon.mediation.version>4.8.16</carbon.mediation.version>
+        <carbon.mediation.version>4.8.19</carbon.mediation.version>
 
         <!-- carbon identity -->
         <carbon.identity.version>5.27.21</carbon.identity.version>


### PR DESCRIPTION
### Description
This pull request updates the Synapse dependency version across multiple Maven modules to ensure consistency and potentially bring in bug fixes or improvements from the newer Synapse release.

Dependency version updates:

Bumped the `synapse.version` property from `4.1.0-wso2v40` to `4.1.0-wso2v57` in the following `pom.xml` files:
  - `all-in-one-apim/pom.xml`
  - `api-control-plane/pom.xml`
  - `gateway/pom.xml`
  - `traffic-manager/pom.xml`
  

 ### Related issue: 
- https://github.com/wso2/api-manager/issues/5032
- https://github.com/wso2/api-manager/issues/5048

### Related PRs
- https://github.com/wso2/wso2-synapse/pull/2564