### PR TITLE
Add test coverage for MCP proxy tool metadata preservation

### DIFF
--- a/all-in-one-apim/modules/integration-v2/tests-common/testcontainers/src/main/resources/nodeapps/mcp-server/server.js
+++ b/all-in-one-apim/modules/integration-v2/tests-common/testcontainers/src/main/resources/nodeapps/mcp-server/server.js
@@ -43,7 +43,17 @@ function buildServer() {
       { name: 'add', description: 'Adds two numbers',
         inputSchema: { type: 'object', properties: { a: { type: 'number' }, b: { type: 'number' } }, required: ['a', 'b'] } },
       { name: 'get_pets', description: 'Returns the list of pets',
-        inputSchema: { type: 'object', properties: {}, required: [] } }
+        inputSchema: { type: 'object', properties: {}, required: [] } },
+      // A tool that carries metadata BEYOND name/description/inputSchema (annotations, _meta, outputSchema,
+      // title): when APIM proxies this server, every one of these extra fields must survive into the gateway
+      // tools/list response.
+      // inputSchema is kept CLEAN (no $schema/additionalProperties) so the MCP feature-generator can still map
+      // it to URI templates — see the buildServer() note above.
+      { name: 'get_weather', title: 'Weather Lookup', description: 'Returns the weather for a city',
+        inputSchema: { type: 'object', properties: { city: { type: 'string' } }, required: ['city'] },
+        outputSchema: { type: 'object', properties: { tempC: { type: 'number' } }, required: ['tempC'] },
+        annotations: { title: 'Weather Lookup', readOnlyHint: true },
+        _meta: { category: 'weather' } }
     ]
   }));
   server.setRequestHandler(CallToolRequestSchema, async (req) => {
@@ -57,6 +67,9 @@ function buildServer() {
     }
     if (name === 'get_pets') {
       return { content: [{ type: 'text', text: JSON.stringify([{ id: 1, name: 'max' }]) }] };
+    }
+    if (name === 'get_weather') {
+      return { content: [{ type: 'text', text: JSON.stringify({ tempC: 21 }) }] };
     }
     return { content: [{ type: 'text', text: 'unknown tool: ' + name }], isError: true };
   });

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/MCPInvocationSteps.java
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/MCPInvocationSteps.java
@@ -29,8 +29,8 @@ import org.wso2.am.integration.cucumbertests.utils.Utils;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
-import java.net.URI;
 import java.io.IOException;
+import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
@@ -706,6 +706,86 @@ public class MCPInvocationSteps {
             names.add(tools.getJSONObject(i).optString("name"));
         }
         return names;
+    }
+
+    /**
+     * Asserts the gateway {@code tools/list} advertises {@code toolName} with its full metadata
+     * (title/annotations/_meta/outputSchema) intact, not just name/description/inputSchema. Retries to ride
+     * out warm-up.
+     */
+    @Then("the MCP tools list at gateway context {string} version {string} using access token {string} advertises "
+            + "tool {string} with preserved metadata within {int} seconds")
+    public void toolsListPreservesToolMetadata(String context, String version, String accessToken, String toolName,
+                                               int timeoutSeconds) throws Exception {
+        String mcpUrl = buildMcpUrl(context, version);
+        String token = TestContext.resolve(accessToken).toString();
+        HttpClient client = newClient();
+        AtomicReference<String> lastError = new AtomicReference<>();
+
+        // Retry the handshake through the shared envelope (rides out warm-up); a freshly published server is
+        // briefly non-routable. Returns the advertised tool object, or null once the deadline elapses.
+        JSONObject tool = Utils.retryUntil(timeoutSeconds * 1000L, () -> {
+            try {
+                HttpResponse<String> initResp = post(client, mcpUrl, token, null, INIT);
+                String sessionId = initResp.headers().firstValue("mcp-session-id").orElse(null);
+                if (initResp.statusCode() != 200 || !sseOrJson(initResp.body()).contains("serverInfo")) {
+                    lastError.set("init status=" + initResp.statusCode() + " body=" + initResp.body());
+                    return null;
+                }
+                post(client, mcpUrl, token, sessionId, INITIALIZED);
+                HttpResponse<String> listResp = post(client, mcpUrl, token, sessionId, TOOLS_LIST);
+                String listBody = sseOrJson(listResp.body());
+                if (listResp.statusCode() != 200 || !listBody.trim().startsWith("{")) {
+                    lastError.set("tools/list status=" + listResp.statusCode() + " body=" + listBody);
+                    return null;
+                }
+                JSONObject root = new JSONObject(listBody);
+                JSONArray tools = root.has("result") ? root.getJSONObject("result").optJSONArray("tools") : null;
+                if (tools != null) {
+                    for (int i = 0; i < tools.length(); i++) {
+                        if (toolName.equals(tools.getJSONObject(i).optString("name"))) {
+                            return tools.getJSONObject(i);
+                        }
+                    }
+                }
+                lastError.set("tools/list did not advertise '" + toolName + "': " + listBody);
+                return null;
+            } catch (IOException | JSONException transientDuringWarmup) {
+                lastError.set(transientDuringWarmup.getMessage());
+                return null;
+            }
+        }, result -> true);
+
+        if (tool == null) {
+            Assert.fail("tools/list did not advertise '" + toolName + "' with preserved metadata within the deadline; "
+                    + "last: " + lastError.get());
+        }
+        // Exact assertions against the mock's get_weather definition (a mismatch is a hard failure, not warm-up).
+        Assert.assertTrue(tool.has("title"), "title must be preserved for '" + toolName + "': " + tool);
+        Assert.assertEquals(tool.optString("title"), "Weather Lookup", "tool title mismatch");
+        Assert.assertTrue(tool.has("annotations"),
+                "annotations must be preserved for '" + toolName + "': " + tool);
+        Assert.assertTrue(tool.getJSONObject("annotations").optBoolean("readOnlyHint", false),
+                "annotations.readOnlyHint must be true: " + tool);
+        Assert.assertEquals(tool.getJSONObject("annotations").optString("title"), "Weather Lookup",
+                "annotations.title mismatch");
+        Assert.assertTrue(tool.has("_meta"), "_meta must be preserved for '" + toolName + "': " + tool);
+        Assert.assertEquals(tool.getJSONObject("_meta").optString("category"), "weather",
+                "_meta.category mismatch");
+        // Full schemas, not just key presence: type, the property's type, and required must all survive.
+        assertObjectSchema(tool.getJSONObject("outputSchema"), "tempC", "number", "outputSchema", tool);
+        assertObjectSchema(tool.getJSONObject("inputSchema"), "city", "string", "inputSchema", tool);
+    }
+
+    /** Asserts a complete object schema: {@code type} object, {@code prop} present with {@code propType}, and required. */
+    private void assertObjectSchema(JSONObject schema, String prop, String propType, String label, Object ctx) {
+        Assert.assertEquals(schema.optString("type"), "object", label + ".type must be object: " + ctx);
+        JSONObject props = schema.getJSONObject("properties");
+        Assert.assertEquals(props.getJSONObject(prop).optString("type"), propType,
+                label + ".properties." + prop + ".type mismatch: " + ctx);
+        JSONArray required = schema.optJSONArray("required");
+        Assert.assertTrue(required != null && required.toList().contains(prop),
+                label + ".required must contain " + prop + ": " + ctx);
     }
 
     /** Builds the gateway MCP endpoint URL: {@code <gatewayWs-less base>/<context>/<version>/mcp}. */

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/MCPServerSteps.java
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/MCPServerSteps.java
@@ -115,6 +115,50 @@ public class MCPServerSteps {
     }
 
     /**
+     * Persisted-side check: fetches the MCP server and asserts the stored operation for {@code tool} keeps the
+     * full wrapped definition (inputSchema + title/annotations/_meta/outputSchema) — proving metadata survives
+     * to storage, independent of the gateway read path.
+     */
+    @Then("the stored MCP server {string} tool {string} retains full metadata")
+    public void storedMcpServerToolRetainsMetadata(String idKey, String tool) throws IOException {
+        String id = TestContext.resolve(idKey).toString();
+        JSONObject dto = fetchMcpServerDto(id, publisherHeaders(), "before checking preserved metadata");
+
+        JSONArray ops = dto.getJSONArray("operations");
+        JSONObject op = null;
+        for (int i = 0; i < ops.length(); i++) {
+            if (tool.equals(ops.getJSONObject(i).optString("target"))) {
+                op = ops.getJSONObject(i);
+                break;
+            }
+        }
+        Assert.assertNotNull(op, "No stored operation for tool '" + tool + "': " + ops);
+
+        // Assert exact VALUES (not just key presence) against the mock's get_weather definition.
+        JSONObject schema = new JSONObject(op.getString("schemaDefinition"));
+        Assert.assertEquals(schema.optString("title"), "Weather Lookup", "stored title mismatch: " + schema);
+        JSONObject annotations = schema.getJSONObject("annotations");
+        Assert.assertTrue(annotations.optBoolean("readOnlyHint", false),
+                "stored annotations.readOnlyHint must be true: " + schema);
+        Assert.assertEquals(annotations.optString("title"), "Weather Lookup",
+                "stored annotations.title mismatch: " + schema);
+        Assert.assertEquals(schema.getJSONObject("_meta").optString("category"), "weather",
+                "stored _meta.category mismatch: " + schema);
+        assertStoredObjectSchema(schema.getJSONObject("outputSchema"), "tempC", "number", "outputSchema", schema);
+        assertStoredObjectSchema(schema.getJSONObject("inputSchema"), "city", "string", "inputSchema", schema);
+    }
+
+    /** Asserts a stored object schema: {@code type} object, {@code prop} present with {@code propType}, in required. */
+    private void assertStoredObjectSchema(JSONObject schema, String prop, String propType, String label, Object ctx) {
+        Assert.assertEquals(schema.optString("type"), "object", "stored " + label + ".type must be object: " + ctx);
+        Assert.assertEquals(schema.getJSONObject("properties").getJSONObject(prop).optString("type"), propType,
+                "stored " + label + ".properties." + prop + ".type mismatch: " + ctx);
+        JSONArray required = schema.optJSONArray("required");
+        Assert.assertTrue(required != null && required.toList().contains(prop),
+                "stored " + label + ".required must contain " + prop + ": " + ctx);
+    }
+
+    /**
      * Gates an MCP tool with a scope (PUT /mcp-servers/{id}): defines the scope on the MCP server (name +
      * role binding) and assigns it to the operation whose backend target is {@code tool}. Ports the scope half
      * of testScopesForProxySubtype. Non-asserting. After redeploy, a token WITHOUT the scope is refused (403)

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/features/gateway/mcp_invocation.feature
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/features/gateway/mcp_invocation.feature
@@ -71,6 +71,32 @@ Feature: MCP tool invocation through the gateway
       | admin             |
       | admin@tenant1.com |
 
+  # Proxying must keep the full tool definition (title/annotations/_meta/outputSchema), both in storage and
+  # in the gateway tools/list.
+  @cap:gateway @feat:mcp-invocation @rule:proxy @type:regression @dep:publisher @legacy:MCPServerTestCase
+  Scenario Outline: A proxied MCP server preserves full tool metadata in tools/list as <actor>
+    Given The system is ready
+    And I have valid access tokens as "<actor>"
+    When I create an MCP server proxy to "http://nodebackend:3020/mcp" exposing tools "get_weather" as "mcpId"
+    Then The response status code should be 201
+    When I deploy the "mcp-servers" resource with id "mcpId"
+    When I publish the "mcp-servers" resource with id "mcpId"
+    Then The response status code should be 200
+    When I retrieve the "mcp-servers" resource with id "mcpId"
+    And I extract response field "context" and store it as "mcpContext"
+    # Persisted-side: the stored operation keeps the full metadata.
+    Then the stored MCP server "mcpId" tool "get_weather" retains full metadata
+    When I have set up application with keys, subscribed to API "mcpId" with plan "Unlimited", and obtained access token for "mcpSubId"
+    Then The response status code should be 200
+    # Gateway-side: tools/list advertises get_weather with the metadata intact.
+    Then the MCP tools list at gateway context "{{mcpContext}}" version "1.0.0" using access token "generatedAccessToken" advertises tool "get_weather" with preserved metadata within 90 seconds
+    When I delete the MCP server "mcpId"
+
+    Examples:
+      | actor             |
+      | admin             |
+      | admin@tenant1.com |
+
   # Enforcement: a scope-gated MCP tool is refused (403) without the scope and allowed (200) with it.
   @cap:gateway @feat:mcp-invocation @rule:proxy @type:regression @dep:publisher @legacy:MCPServerTestCase
   Scenario Outline: A scope-gated MCP tool is enforced (200 with the scope, 403 without) as <actor>

--- a/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/mcp/MCPServerTestCase.java
+++ b/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/mcp/MCPServerTestCase.java
@@ -187,6 +187,7 @@ public class MCPServerTestCase extends APIMIntegrationBaseTest {
                     "}";
 
     private static final String EXPECTED_SCHEMA_ECHO =
+            "{ \"inputSchema\": " +
             "{\n" +
                     "  \"$schema\": \"http://json-schema.org/draft-07/schema#\",\n" +
                     "  \"additionalProperties\": false,\n" +
@@ -198,7 +199,22 @@ public class MCPServerTestCase extends APIMIntegrationBaseTest {
                     "    }\n" +
                     "  },\n" +
                     "  \"required\": [\"message\"]\n" +
-                    "}";
+                    "}," +
+                    "  \"title\": \"Echo Tool\"," +
+                    "  \"outputSchema\": {" +
+                    "    \"type\": \"object\"," +
+                    "    \"properties\": { \"echoed\": { \"type\": \"string\" } }," +
+                    "    \"required\": [\"echoed\"]" +
+                    "  }," +
+                    "  \"annotations\": {" +
+                    "    \"title\": \"Echo\"," +
+                    "    \"readOnlyHint\": true," +
+                    "    \"destructiveHint\": false," +
+                    "    \"idempotentHint\": true," +
+                    "    \"openWorldHint\": false" +
+                    "  }," +
+                    "  \"_meta\": { \"category\": \"utility\", \"source\": \"mock-mcp\" }" +
+            "}";
 
     private static final String EXPECTED_SCHEMA_DELETE_OLD_PETS =
             "{\n" +
@@ -206,7 +222,8 @@ public class MCPServerTestCase extends APIMIntegrationBaseTest {
                     "  \"properties\": {}\n" +
                     "}";
 
-    private static final String EXPECTED_SCHEMA_ORDER_PIZZA = "{\n" +
+    private static final String EXPECTED_SCHEMA_ORDER_PIZZA = "{ \"inputSchema\": " +
+            "{\n" +
             "  \"$schema\" : \"http://json-schema.org/draft-07/schema#\",\n" +
             "  \"additionalProperties\" : false,\n" +
             "  \"type\" : \"object\",\n" +
@@ -230,6 +247,7 @@ public class MCPServerTestCase extends APIMIntegrationBaseTest {
             "  },\n" +
             "  \"required\" : [ \"pizzaType\", \"quantity\", \"customerName\", \"deliveryAddress\", " +
             "\"creditCardNumber\" ]\n" +
+            "}" +
             "}";
 
     private static final String EXPECTED_ENDPOINT_CONFIG =
@@ -378,7 +396,21 @@ public class MCPServerTestCase extends APIMIntegrationBaseTest {
             "          }\n" +
             "        },\n" +
             "        \"required\" : [ \"message\" ]\n" +
-            "      }\n" +
+            "      },\n" +
+            "      \"title\" : \"Echo Tool\",\n" +
+            "      \"outputSchema\" : {\n" +
+            "        \"type\" : \"object\",\n" +
+            "        \"properties\" : { \"echoed\" : { \"type\" : \"string\" } },\n" +
+            "        \"required\" : [ \"echoed\" ]\n" +
+            "      },\n" +
+            "      \"annotations\" : {\n" +
+            "        \"title\" : \"Echo\",\n" +
+            "        \"readOnlyHint\" : true,\n" +
+            "        \"destructiveHint\" : false,\n" +
+            "        \"idempotentHint\" : true,\n" +
+            "        \"openWorldHint\" : false\n" +
+            "      },\n" +
+            "      \"_meta\" : { \"category\" : \"utility\", \"source\" : \"mock-mcp\" }\n" +
             "    }, {\n" +
             "      \"name\" : \"orderPizza\",\n" +
             "      \"description\" : \"Order a pizza from the menu. This tool allows you to place an order for a " +
@@ -1752,6 +1784,25 @@ public class MCPServerTestCase extends APIMIntegrationBaseTest {
                                     .put("required", new JSONArray().put("message"))
                                     .put("additionalProperties", false)
                                     .put("$schema", "http://json-schema.org/draft-07/schema#")
+                            )
+                            .put("title", "Echo Tool")
+                            .put("outputSchema", new JSONObject()
+                                    .put("type", "object")
+                                    .put("properties", new JSONObject()
+                                            .put("echoed", new JSONObject().put("type", "string"))
+                                    )
+                                    .put("required", new JSONArray().put("echoed"))
+                            )
+                            .put("annotations", new JSONObject()
+                                    .put("title", "Echo")
+                                    .put("readOnlyHint", true)
+                                    .put("destructiveHint", false)
+                                    .put("idempotentHint", true)
+                                    .put("openWorldHint", false)
+                            )
+                            .put("_meta", new JSONObject()
+                                    .put("category", "utility")
+                                    .put("source", "mock-mcp")
                             )
                     )
 

--- a/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/mcp/MCPServerTestCase.java
+++ b/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/mcp/MCPServerTestCase.java
@@ -187,6 +187,7 @@ public class MCPServerTestCase extends APIMIntegrationBaseTest {
                     "}";
 
     private static final String EXPECTED_SCHEMA_ECHO =
+            "{ \"inputSchema\": " +
             "{\n" +
                     "  \"$schema\": \"http://json-schema.org/draft-07/schema#\",\n" +
                     "  \"additionalProperties\": false,\n" +
@@ -198,7 +199,8 @@ public class MCPServerTestCase extends APIMIntegrationBaseTest {
                     "    }\n" +
                     "  },\n" +
                     "  \"required\": [\"message\"]\n" +
-                    "}";
+                    "}" +
+            "}";
 
     private static final String EXPECTED_SCHEMA_DELETE_OLD_PETS =
             "{\n" +
@@ -206,7 +208,8 @@ public class MCPServerTestCase extends APIMIntegrationBaseTest {
                     "  \"properties\": {}\n" +
                     "}";
 
-    private static final String EXPECTED_SCHEMA_ORDER_PIZZA = "{\n" +
+    private static final String EXPECTED_SCHEMA_ORDER_PIZZA = "{ \"inputSchema\": " +
+            "{\n" +
             "  \"$schema\" : \"http://json-schema.org/draft-07/schema#\",\n" +
             "  \"additionalProperties\" : false,\n" +
             "  \"type\" : \"object\",\n" +
@@ -230,6 +233,7 @@ public class MCPServerTestCase extends APIMIntegrationBaseTest {
             "  },\n" +
             "  \"required\" : [ \"pizzaType\", \"quantity\", \"customerName\", \"deliveryAddress\", " +
             "\"creditCardNumber\" ]\n" +
+            "}" +
             "}";
 
     private static final String EXPECTED_ENDPOINT_CONFIG =


### PR DESCRIPTION
## Description
Extends MCPServerTestCase to verify that tool metadata (title, annotations, outputSchema, _meta) is preserved when proxying a third-party MCP server through API Manager.

- Mock MCP server's `echo` tool now returns these metadata fields.
- Asserts they are preserved in the stored schema definition on creation.
- Asserts they are returned in the gateway `tools/list` response.

Related Issue : https://github.com/wso2/api-manager/issues/5120