### PR TITLE
Add integration-v2 cucumber tests: shared foundation + gateway capabilities

### DIFF
--- a/all-in-one-apim/modules/integration-v2/docs/devs/capability-map.yml
+++ b/all-in-one-apim/modules/integration-v2/docs/devs/capability-map.yml
@@ -12,7 +12,7 @@ capabilities:
   publisher:
     name: Publisher — API authoring & lifecycle
     features:
-      api-lifecycle:     { name: Create / deploy / publish / retire / delete }
+      api-lifecycle:     { name: Create / deploy / publish / prototype / retire / delete }
       api-config:        { name: Runtime config, endpoints, custom properties, resources, CORS }
       operation-policies: { name: Operation policy CRUD (common & API-specific) }
       scopes:            { name: API scopes & shared scopes (assignment) }
@@ -26,13 +26,14 @@ capabilities:
       streaming-design:  { name: Streaming (WebSocket/WebSub/Async) API design }
       soap-design:       { name: SOAP (passthrough) API design }
       service-catalog:   { name: Service catalog }
+      mcp-servers:       { name: MCP server authoring (create proxy/from-OpenAPI/from-API, CRUD, backends) }
 
   devportal:
     name: DevPortal — discovery & consumption
     features:
-      search:                  { name: Search & discovery }
-      browse:                  { name: Browse / catalog view / tags }
+      discovery:               { name: Search & browse }
       applications:            { name: Application CRUD }
+      application-attributes:  { name: Custom application attributes (store + JWT claim) }
       subscribe:               { name: Subscribe / unsubscribe }
       subscription-management: { name: Subscription update / blocking }
       comments:                { name: Comments }
@@ -54,18 +55,29 @@ capabilities:
       throttling-enforcement: { name: Runtime throttling enforcement }
       security-enforcement:   { name: Token / scope / mutual-SSL enforcement }
       custom-auth-header:     { name: Custom authorization header }
+      schema-validation:      { name: Request / response schema validation }
+      mcp-invocation:         { name: MCP tool invocation (proxy / from-OpenAPI / from-API) }
 
   admin:
-    name: Admin — governance, policies & configuration
+    name: Admin — policies & configuration
     features:
       throttling-policies: { name: Throttling policy CRUD }
-      governance:          { name: Governance policies }
-      compliance:          { name: Compliance checks }
       workflows:           { name: Approval workflows }
       key-manager-config:  { name: Key manager registration & config }
       environments:        { name: Gateway environments }
       tenants-orgs:        { name: Tenants & organizations }
+      application-management: { name: Admin application search & management }
       bot-detection:       { name: Bot detection }
+      role-scope-mapping:  { name: System scope role-alias mapping }
+
+  # API Governance is a distinct product API (/api/am/governance/v1) with its own token scopes (apim:gov_*),
+  # so it is a top-level capability — not folded under admin (whose contract is /api/am/admin/v4).
+  governance:
+    name: API Governance — rulesets, policies & compliance
+    features:
+      rulesets:   { name: Governance ruleset CRUD (spectral rules) }
+      policies:   { name: Governance policy CRUD (ruleset attachment) }
+      compliance: { name: Artifact compliance evaluation }
 
   key-manager:
     name: Key Manager — keys, tokens & OAuth
@@ -73,6 +85,7 @@ capabilities:
       oauth-keys:              { name: OAuth application key generation }
       api-key:                 { name: API key management }
       multiple-client-secrets: { name: Multiple client secrets }
+      map-application-keys:    { name: Map pre-existing (BYO) OAuth client keys }
       token-issuance:          { name: Token issuance (access / refresh / sandbox) }
       token-revocation:        { name: Token revocation }
       token-persistence:       { name: Token state persistence across server restart }
@@ -83,5 +96,6 @@ capabilities:
     name: Analytics — logging & observability
     features:
       request-logging:  { name: Request / access logging }
+      remote-logging:   { name: Remote server log publishing }
       analytics-events: { name: Analytics events }
       alerts:           { name: Alerts }

--- a/all-in-one-apim/modules/integration-v2/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/utils/Constants.java
+++ b/all-in-one-apim/modules/integration-v2/tests-common/integration-test-utils/src/main/java/org/wso2/am/integration/test/utils/Constants.java
@@ -52,6 +52,10 @@ public class Constants {
     public static final int HTTP_PORT = 9763;
     public static final int GATEWAY_HTTPS_PORT = 8243;
     public static final int GATEWAY_HTTP_PORT = 8280;
+    /** Gateway WebSocket inbound port (apim.ws.port). Used by WebSocket-API invocation tests. */
+    public static final int GATEWAY_WS_PORT = 9099;
+    /** Gateway SECURE WebSocket inbound port (apim.wss.port, enabled by default). Used by wss:// invocation tests. */
+    public static final int GATEWAY_WSS_PORT = 8099;
 
     public static final String MIGRATION_PROFILE = "migration";
     public  static final String DEFAULT_PROFILE = "default";
@@ -95,6 +99,7 @@ public class Constants {
     public static final String DEFAULT_APIM_API_DEPLOYER = "api/am/publisher/v4/";
     public static final String DEFAULT_DEVPORTAL = "api/am/devportal/v3/";
     public static final String DEFAULT_APIM_ADMIN = "api/am/admin/v4/";
+    public static final String DEFAULT_APIM_GOVERNANCE = "api/am/governance/v1/";
     public static final String GATEWAY = "api/am/gateway/v2/";
     public static final String DEFAULT_APIM_TOKEN_EP = "oauth2/token";
     public static final String DEFAULT_DCR_EP = "client-registration/v0.17/register";
@@ -134,6 +139,12 @@ public class Constants {
     public static final String CREATED_SUBSCRIPTION_POLICY_IDS = "createdSubscriptionPolicyIds";
     public static final String CREATED_ADVANCED_POLICY_IDS = "createdAdvancedPolicyIds";
     public static final String CREATED_CUSTOM_POLICY_IDS = "createdCustomPolicyIds";
+    public static final String CREATED_API_PRODUCT_IDS = "createdApiProductIds";
+    public static final String CREATED_ENVIRONMENT_IDS = "createdEnvironmentIds";
+    public static final String CREATED_GOVERNANCE_RULESET_IDS = "createdGovernanceRulesetIds";
+    public static final String CREATED_GOVERNANCE_POLICY_IDS = "createdGovernancePolicyIds";
+    public static final String CREATED_KEY_MANAGER_IDS = "createdKeyManagerIds";
+    public static final String CREATED_DENY_POLICY_IDS = "createdDenyPolicyIds";
 
     public static class REQUEST_HEADERS {
 

--- a/all-in-one-apim/modules/integration-v2/tests-common/testcontainers/src/main/java/org/wso2/am/testcontainers/DynamicApimContainer.java
+++ b/all-in-one-apim/modules/integration-v2/tests-common/testcontainers/src/main/java/org/wso2/am/testcontainers/DynamicApimContainer.java
@@ -54,8 +54,11 @@ public class DynamicApimContainer extends GenericContainer<DynamicApimContainer>
         logger.info("SHARED DB URL: {}", sharedDbUrl);
 
         // Expose canonical ports; Docker assigns ephemeral host ports resolved via getMappedPort.
+        // GATEWAY_WS_PORT (9099) is the gateway WebSocket inbound; GATEWAY_WSS_PORT (8099) is the SECURE WebSocket
+        // inbound — both needed by WebSocket-API invocation tests (ws:// and wss://).
         withExposedPorts(Constants.HTTPS_PORT, Constants.HTTP_PORT,
-                Constants.GATEWAY_HTTPS_PORT, Constants.GATEWAY_HTTP_PORT);
+                Constants.GATEWAY_HTTPS_PORT, Constants.GATEWAY_HTTP_PORT, Constants.GATEWAY_WS_PORT,
+                Constants.GATEWAY_WSS_PORT);
 
         // Env vars for APIMGT_DB
         withEnv(Constants.API_MANAGER_DATABASE_TYPE, System.getenv(Constants.API_MANAGER_DATABASE_TYPE));
@@ -177,8 +180,53 @@ public class DynamicApimContainer extends GenericContainer<DynamicApimContainer>
         return String.format("http://%s:%d/", getHost(), getMappedPort(Constants.GATEWAY_HTTP_PORT));
     }
 
+    /** Gateway WebSocket base URL (ws://host:mappedWsPort/) for WebSocket-API invocation. */
+    public String getGatewayWsUrl() {
+        return String.format("ws://%s:%d/", getHost(), getMappedPort(Constants.GATEWAY_WS_PORT));
+    }
+
+    /** Gateway SECURE WebSocket base URL (wss://host:mappedWssPort/) for wss:// WebSocket-API invocation. */
+    public String getGatewayWssUrl() {
+        return String.format("wss://%s:%d/", getHost(), getMappedPort(Constants.GATEWAY_WSS_PORT));
+    }
+
+    /**
+     * The container's docker-network GATEWAY IP — the source IP the gateway observes for a host→published-port
+     * connection (verified: a WS client on the host is seen by APIM as this address). Used to pin an api-key
+     * {@code permittedIP} to the test client's effective IP so the api-key IP-restriction POSITIVE case can be
+     * asserted (matching IP → allowed). Read from the live container inspect, so it adapts per environment.
+     */
+    public String getGatewayClientIp() {
+        var networks = getContainerInfo().getNetworkSettings().getNetworks();
+        for (com.github.dockerjava.api.model.ContainerNetwork net : networks.values()) {
+            if (net.getGateway() != null && !net.getGateway().isEmpty()) {
+                return net.getGateway();
+            }
+        }
+        throw new IllegalStateException("Could not determine the container network gateway IP");
+    }
+
     public String getContainerTomlPath() {
         return Constants.APIM_CONTAINER_USER_HOME + "/" + System.getProperty("apim.server.name") +
                 Constants.DEPLOYMENT_TOML_PATH;
+    }
+
+    /** In-container path of the running server's {@code log4j2.properties} (for remote-logging appender checks). */
+    public String getContainerLog4j2Path() {
+        return Constants.APIM_CONTAINER_USER_HOME + "/" + System.getProperty("apim.server.name") +
+                "/repository/conf/log4j2.properties";
+    }
+
+    /**
+     * Reads a file's content from inside the running container as UTF-8. Used by the remote-logging tests to
+     * assert how the server rewrote {@code log4j2.properties} (e.g. an appender flipped to a SecuredHttp type).
+     */
+    public String readContainerFile(String containerPath) {
+        try {
+            return copyFileFromContainer(containerPath,
+                    is -> new String(is.readAllBytes(), java.nio.charset.StandardCharsets.UTF_8));
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to read container file: " + containerPath, e);
+        }
     }
 }

--- a/all-in-one-apim/modules/integration-v2/tests-common/testcontainers/src/main/resources/nodeapps/Dockerfile
+++ b/all-in-one-apim/modules/integration-v2/tests-common/testcontainers/src/main/resources/nodeapps/Dockerfile
@@ -27,6 +27,7 @@ COPY name-checkThree/package*.json ./name-checkThree/
 COPY wildcard/package*.json ./wildcard/
 COPY node-people-service/package*.json ./node-people-service/
 COPY soap-stub/package*.json ./soap-stub/
+COPY mcp-server/package*.json ./mcp-server/
 
 # 4. Install dependencies + pm2 in a single layer, then drop the npm cache so it
 #    is not baked into the image.
@@ -34,7 +35,7 @@ RUN for d in node-coffee-service node-customer-service am-auditApi-sample \
         am-graphQL-sample BPMNProcessServerApp-1.0.0 duplicate-header-backend \
         etcdmock jaxrs_basic name-check1 name-check1_SB name-check2 name-check2_SB \
         name-check3 name-check3_SB name-checkOne name-checkTwo name-checkThree \
-        wildcard node-people-service soap-stub; do \
+        wildcard node-people-service soap-stub mcp-server; do \
         (cd "$d" && npm install) || exit 1; \
     done \
     && npm install -g pm2 \
@@ -61,6 +62,7 @@ COPY name-checkThree ./name-checkThree
 COPY wildcard ./wildcard
 COPY node-people-service ./node-people-service
 COPY soap-stub ./soap-stub
+COPY mcp-server ./mcp-server
 
 # 6. Copy PM2 ecosystem config file
 COPY ecosystem.config.js .

--- a/all-in-one-apim/modules/integration-v2/tests-common/testcontainers/src/main/resources/nodeapps/am-graphQL-sample/package-lock.json
+++ b/all-in-one-apim/modules/integration-v2/tests-common/testcontainers/src/main/resources/nodeapps/am-graphQL-sample/package-lock.json
@@ -1,0 +1,934 @@
+{
+  "name": "am-graphQL-sample",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "am-graphQL-sample",
+      "version": "1.0.0",
+      "dependencies": {
+        "@graphql-tools/schema": "^10.0.34",
+        "express": "^4.18.2",
+        "graphql": "^16.14.2",
+        "subscriptions-transport-ws": "^0.11.0",
+        "ws": "^8.21.0"
+      }
+    },
+    "node_modules/@graphql-tools/merge": {
+      "version": "9.1.10",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.1.10.tgz",
+      "integrity": "sha512-CsUCcPXv/HMWpPZ/xoOioSWFuAaAsGGPIdqQbjDv9X1sHGs0muQRW5FK7vUBN4OH/D7aPqpiHvKmRsrHz+ScuQ==",
+      "dependencies": {
+        "@graphql-tools/utils": "^11.1.1",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/schema": {
+      "version": "10.0.34",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.34.tgz",
+      "integrity": "sha512-wGCiUuwqDtlXtDvQ00CI+4u0pd3yd/xGGYOiwc9L63KJZwSXdrUv8ajpJ5lMalawc0mpjcCB0ljEQSeUhajuag==",
+      "dependencies": {
+        "@graphql-tools/merge": "^9.1.10",
+        "@graphql-tools/utils": "^11.1.1",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/utils": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-11.1.1.tgz",
+      "integrity": "sha512-MuWwacINZZV6mX1ZSk6CcV4XVQLsbKBG/hLd0QPhe4GHxjqr2ATjKsnnwlB0TKI+QQvj2U8ewu8WeAzz9kC2Xg==",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "@whatwg-node/promise-helpers": "^1.0.0",
+        "cross-inspect": "1.0.1",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-typed-document-node/core": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@whatwg-node/promise-helpers": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/promise-helpers/-/promise-helpers-1.3.2.tgz",
+      "integrity": "sha512-Nst5JdK47VIl9UcGwtv2Rcgyn5lWtZ0/mhRQ4G8NN2isxpq2TO30iqHzmwoJycjWuyUfg3GFXqP/gFHXeV57IA==",
+      "dependencies": {
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
+    },
+    "node_modules/backo2": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+      "integrity": "sha512-zj6Z6M7Eq+PBZ7PQxl5NT665MvJdAkzp0f60nAJ+sLaSCBPMwVak5ZegFbgVCzFcCJTKFoMizvM5Ld7+JrRJHA=="
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA=="
+    },
+    "node_modules/cross-inspect": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cross-inspect/-/cross-inspect-1.0.1.tgz",
+      "integrity": "sha512-Pcw1JTvZLSJH83iiGWt6fRcT+BjZlCDRVwYLbUcHzv/CRpB7r0MlSrGbIyQvVSNyGnbt7G4AXuyCiDR3POvZ1A==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
+    },
+    "node_modules/express": {
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.5",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.15.1",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graphql": {
+      "version": "16.14.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.2.tgz",
+      "integrity": "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/iterall": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
+      "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg=="
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA=="
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/subscriptions-transport-ws": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.11.0.tgz",
+      "integrity": "sha512-8D4C6DIH5tGiAIpp5I0wD/xRlNiZAPGHygzCe7VzyzUoxHtawzjNAY9SUTXU05/EY2NMY9/9GF0ycizkXr1CWQ==",
+      "deprecated": "The `subscriptions-transport-ws` package is no longer maintained. We recommend you use `graphql-ws` instead. For help migrating Apollo software to `graphql-ws`, see https://www.apollographql.com/docs/apollo-server/data/subscriptions/#switching-from-subscriptions-transport-ws    For general help using `graphql-ws`, see https://github.com/enisdenjo/graphql-ws/blob/master/README.md",
+      "dependencies": {
+        "backo2": "^1.0.2",
+        "eventemitter3": "^3.1.0",
+        "iterall": "^1.2.1",
+        "symbol-observable": "^1.0.4",
+        "ws": "^5.2.0 || ^6.0.0 || ^7.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^15.7.2 || ^16.0.0"
+      }
+    },
+    "node_modules/subscriptions-transport-ws/node_modules/ws": {
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/symbol-observable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/all-in-one-apim/modules/integration-v2/tests-common/testcontainers/src/main/resources/nodeapps/am-graphQL-sample/package.json
+++ b/all-in-one-apim/modules/integration-v2/tests-common/testcontainers/src/main/resources/nodeapps/am-graphQL-sample/package.json
@@ -7,6 +7,10 @@
     "start": "node server.js"
   },
   "dependencies": {
-    "express": "^4.18.2"
+    "@graphql-tools/schema": "^10.0.34",
+    "express": "^4.18.2",
+    "graphql": "^16.14.2",
+    "subscriptions-transport-ws": "^0.11.0",
+    "ws": "^8.21.0"
   }
 }

--- a/all-in-one-apim/modules/integration-v2/tests-common/testcontainers/src/main/resources/nodeapps/am-graphQL-sample/server.js
+++ b/all-in-one-apim/modules/integration-v2/tests-common/testcontainers/src/main/resources/nodeapps/am-graphQL-sample/server.js
@@ -16,6 +16,10 @@
  */
 
  const express = require('express');
+const { WebSocketServer } = require('ws');
+const { execute, subscribe, graphql } = require('graphql');
+const { SubscriptionServer } = require('subscriptions-transport-ws');
+const { makeExecutableSchema } = require('@graphql-tools/schema');
 const languageRoutes = require('./routes/languageRoutes');
 
 const app = express();
@@ -25,6 +29,71 @@ app.use(express.json());
 
 app.use('/graphql', languageRoutes);
 
-app.listen(port, () => {
+// --- Real, introspection-capable GraphQL endpoint (for "create GraphQL API from endpoint via introspection")
+// The default /graphql above is a hand-rolled POST handler with NO introspection, so APIM's introspection query
+// cannot derive a schema from it. /graphql-full is a proper graphql() handler over the languages schema, so it
+// answers the standard __schema introspection query the publisher sends.
+const languagesTypeDefs = `type Language { code: String name: String }\n`
+  + `type Query { languages: [Language] language(code: String): Language }`;
+const languagesSchema = makeExecutableSchema({
+  typeDefs: languagesTypeDefs,
+  resolvers: {
+    Query: {
+      languages: () => [{ code: 'en', name: 'English' }, { code: 'fr', name: 'French' }],
+      language: (_root, args) => ({ code: args.code || 'en', name: 'English' })
+    }
+  }
+});
+app.post('/graphql-full', async (req, res) => {
+  const body = req.body || {};
+  const result = await graphql({ schema: languagesSchema, source: body.query || '', variableValues: body.variables });
+  res.json(result);
+});
+
+// --- Raw SDL served at a URL (for "create GraphQL API from an SDL URL" — APIM fetches the SDL text).
+app.get('/sdl', (req, res) => {
+  res.type('text/plain').send(languagesTypeDefs);
+});
+
+// --- Auth-protected GraphQL endpoint (for GraphQL endpoint-security: the gateway must inject the credential).
+// Requires `Authorization: Bearer graphql-secret`; otherwise 401. Behind the check it reuses the languages POST
+// handler, so an authorised (gateway-injected) request returns the languages data.
+app.use('/graphql-secured', (req, res, next) => {
+  if (req.headers['authorization'] !== 'Bearer graphql-secret') {
+    return res.status(401).json({ errors: [{ message: 'Unauthorized: missing or invalid backend credential' }] });
+  }
+  next();
+}, languageRoutes);
+
+const server = app.listen(port, () => {
   console.log(`AM GraphQL Server running at http://nodebackend:${port}`);
 });
+
+// --- GraphQL subscription endpoint for the gateway GraphQL-subscription invocation tests
+// (GraphqlSubscriptionTestCase), built on the official `subscriptions-transport-ws` library over `ws`. This is
+// the library that implements the `graphql-ws` SUBPROTOCOL (connection_init/connection_ack, start/data) that the
+// APIM 4.7.0 gateway speaks — the newer npm `graphql-ws` package implements a DIFFERENT subprotocol
+// (graphql-transport-ws) which the gateway does not negotiate (verified: it rejects the legacy subprotocol).
+// Exposes a real executable schema whose `liftStatusChange` subscription emits one Lift event
+// ({name:"Astra Express"}), matching the legacy SubscriptionWSServerImpl contract.
+const typeDefs = `
+  type Lift { id: ID! name: String! }
+  type Query { _empty: String }
+  type Subscription { liftStatusChange: Lift! }
+`;
+const resolvers = {
+  Subscription: {
+    liftStatusChange: {
+      subscribe: async function* () {
+        yield { liftStatusChange: { id: '1', name: 'Astra Express' } };
+      }
+    }
+  }
+};
+const schema = makeExecutableSchema({ typeDefs, resolvers });
+
+// Attach to a ws server bound to the http.Server (all upgrade paths on 3003), so the gateway's subscription
+// proxy reaches it regardless of the upgrade path.
+const wsServer = new WebSocketServer({ server });
+SubscriptionServer.create({ schema, execute, subscribe }, wsServer);
+console.log('----subscriptions-transport-ws (official lib) subscription server attached on port ' + port);

--- a/all-in-one-apim/modules/integration-v2/tests-common/testcontainers/src/main/resources/nodeapps/ecosystem.config.js
+++ b/all-in-one-apim/modules/integration-v2/tests-common/testcontainers/src/main/resources/nodeapps/ecosystem.config.js
@@ -159,6 +159,14 @@ module.exports = {
         env: {
           PORT: 3019
     }
+  },
+  {
+    name: "mcp-server",
+    script: "./mcp-server/server.js",
+    cwd: "./",
+    env: {
+      PORT: 3020
+    }
   }
   ]
 };

--- a/all-in-one-apim/modules/integration-v2/tests-common/testcontainers/src/main/resources/nodeapps/mcp-server/package-lock.json
+++ b/all-in-one-apim/modules/integration-v2/tests-common/testcontainers/src/main/resources/nodeapps/mcp-server/package-lock.json
@@ -1,0 +1,1435 @@
+{
+  "name": "mcp-server",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mcp-server",
+      "version": "1.0.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "express": "^4.19.2",
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/body-parser/node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA=="
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.5",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.15.1",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ]
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.27",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
+      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA=="
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/router/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/router/node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/all-in-one-apim/modules/integration-v2/tests-common/testcontainers/src/main/resources/nodeapps/mcp-server/package.json
+++ b/all-in-one-apim/modules/integration-v2/tests-common/testcontainers/src/main/resources/nodeapps/mcp-server/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "mcp-server",
+  "version": "1.0.0",
+  "description": "Mock MCP server (official @modelcontextprotocol/sdk) for gateway MCP proxy tests",
+  "main": "server.js",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "express": "^4.19.2",
+    "zod": "^3.23.8"
+  }
+}

--- a/all-in-one-apim/modules/integration-v2/tests-common/testcontainers/src/main/resources/nodeapps/mcp-server/server.js
+++ b/all-in-one-apim/modules/integration-v2/tests-common/testcontainers/src/main/resources/nodeapps/mcp-server/server.js
@@ -1,0 +1,122 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+// A REAL mock MCP server built on the official @modelcontextprotocol/sdk (Streamable HTTP transport). It backs
+// the gateway MCP-server PROXY-mode invocation tests (MCPServerTestCase): the APIM gateway proxies a client's
+// MCP JSON-RPC (initialize / tools/list / tools/call) to this server. Exposes three real tools (echo, add,
+// get_pets) with actual dispatch — more faithful than the legacy WireMock canned stubs.
+const express = require('express');
+const { randomUUID } = require('crypto');
+const { Server } = require('@modelcontextprotocol/sdk/server/index.js');
+const { StreamableHTTPServerTransport } = require('@modelcontextprotocol/sdk/server/streamableHttp.js');
+const { isInitializeRequest, ListToolsRequestSchema, CallToolRequestSchema } =
+    require('@modelcontextprotocol/sdk/types.js');
+
+const app = express();
+const port = 3020;
+app.use(express.json());
+
+// Uses the SDK's LOW-LEVEL Server (McpServer is a thin wrapper over it) so the tools/list wire shape is exactly
+// what we return — a CLEAN inputSchema (no $schema / additionalProperties) and NO `execution` field. McpServer's
+// registerTool auto-injects those (newer MCP spec), which APIM 4.7.0's MCP feature-generator cannot map to URI
+// templates ("no URI templates were produced" → 500). Matching the legacy tool shape keeps the gateway happy.
+function buildServer() {
+  const server = new Server({ name: 'wso2-mock-mcp', version: '1.0.0' }, { capabilities: { tools: {} } });
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: [
+      { name: 'echo', description: 'Echoes the provided message',
+        inputSchema: { type: 'object', properties: { message: { type: 'string' } }, required: ['message'] } },
+      { name: 'add', description: 'Adds two numbers',
+        inputSchema: { type: 'object', properties: { a: { type: 'number' }, b: { type: 'number' } }, required: ['a', 'b'] } },
+      { name: 'get_pets', description: 'Returns the list of pets',
+        inputSchema: { type: 'object', properties: {}, required: [] } }
+    ]
+  }));
+  server.setRequestHandler(CallToolRequestSchema, async (req) => {
+    const name = req.params.name;
+    const args = req.params.arguments || {};
+    if (name === 'echo') {
+      return { content: [{ type: 'text', text: String(args.message) }] };
+    }
+    if (name === 'add') {
+      return { content: [{ type: 'text', text: String(args.a + args.b) }] };
+    }
+    if (name === 'get_pets') {
+      return { content: [{ type: 'text', text: JSON.stringify([{ id: 1, name: 'max' }]) }] };
+    }
+    return { content: [{ type: 'text', text: 'unknown tool: ' + name }], isError: true };
+  });
+  return server;
+}
+
+// Session-keyed transports (stateful Streamable HTTP — the documented SDK pattern).
+const transports = {};
+
+app.post('/mcp', async (req, res) => {
+  try {
+    console.log('----MCP req method=' + (req.body && req.body.method) + ' sid=' + (req.headers['mcp-session-id'] || 'none'));
+    const sessionId = req.headers['mcp-session-id'];
+    let transport;
+    if (sessionId && transports[sessionId]) {
+      transport = transports[sessionId];
+    } else if (!sessionId && isInitializeRequest(req.body)) {
+      transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: () => randomUUID(),
+        // Return plain application/json responses (not SSE). Session semantics (Mcp-Session-Id) are preserved;
+        // only the framing changes — APIM's MCP proxy/discovery consumes JSON (the legacy WireMock also
+        // returned JSON), so SSE-framed responses break it.
+        enableJsonResponse: true,
+        onsessioninitialized: (sid) => { transports[sid] = transport; }
+      });
+      transport.onclose = () => {
+        if (transport.sessionId) {
+          delete transports[transport.sessionId];
+        }
+      };
+      await buildServer().connect(transport);
+    } else {
+      res.status(400).json({
+        jsonrpc: '2.0',
+        error: { code: -32000, message: 'Bad Request: No valid session ID provided' },
+        id: null
+      });
+      return;
+    }
+    await transport.handleRequest(req, res, req.body);
+  } catch (e) {
+    console.error('----MCP handler error:', e);
+    if (!res.headersSent) {
+      res.status(500).json({ jsonrpc: '2.0', error: { code: -32603, message: 'Internal error' }, id: null });
+    }
+  }
+});
+
+// GET (server->client SSE stream) and DELETE (session teardown) for the Streamable HTTP transport.
+async function handleSessionRequest(req, res) {
+  const sessionId = req.headers['mcp-session-id'];
+  if (!sessionId || !transports[sessionId]) {
+    res.status(400).send('Invalid or missing session ID');
+    return;
+  }
+  await transports[sessionId].handleRequest(req, res);
+}
+app.get('/mcp', handleSessionRequest);
+app.delete('/mcp', handleSessionRequest);
+
+app.listen(port, () => {
+  console.log(`Mock MCP server (official SDK) running at http://nodebackend:${port}/mcp`);
+});

--- a/all-in-one-apim/modules/integration-v2/tests-common/testcontainers/src/main/resources/nodeapps/node-customer-service/package-lock.json
+++ b/all-in-one-apim/modules/integration-v2/tests-common/testcontainers/src/main/resources/nodeapps/node-customer-service/package-lock.json
@@ -1,0 +1,782 @@
+{
+  "name": "node-customer-service",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "node-customer-service",
+      "version": "1.0.0",
+      "dependencies": {
+        "body-parser": "^1.20.2",
+        "express": "^4.18.2",
+        "ws": "^8.21.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA=="
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.5",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.15.1",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA=="
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/all-in-one-apim/modules/integration-v2/tests-common/testcontainers/src/main/resources/nodeapps/node-customer-service/package.json
+++ b/all-in-one-apim/modules/integration-v2/tests-common/testcontainers/src/main/resources/nodeapps/node-customer-service/package.json
@@ -7,7 +7,8 @@
     "start": "node server.js"
   },
   "dependencies": {
+    "body-parser": "^1.20.2",
     "express": "^4.18.2",
-    "body-parser": "^1.20.2"
+    "ws": "^8.21.0"
   }
 }

--- a/all-in-one-apim/modules/integration-v2/tests-common/testcontainers/src/main/resources/nodeapps/node-customer-service/routes/customerRoutes.js
+++ b/all-in-one-apim/modules/integration-v2/tests-common/testcontainers/src/main/resources/nodeapps/node-customer-service/routes/customerRoutes.js
@@ -115,4 +115,121 @@ router.delete('/customers/:id', (req, res) => {
   }
 });
 
+// GET /echo/... — wildcard echo: returns the raw sub-path it received (any number of segments), echoing
+// req.originalUrl. Used to verify the gateway forwards an encoded URI path segment to the backend when the API
+// uses a uri-template resource + a {uri.var.x} templated endpoint (which double-appends: /echo/sub<val>/<val>,
+// as the legacy Synapse backend expected). Scoped to /echo so it does not mask other routes.
+router.get('/echo/*', (req, res) => {
+  console.log(`----invoking echo, received: ${req.originalUrl}`);
+  res.status(200).json({ received: req.originalUrl });
+});
+
+// GET /reflect-headers — reflects the request headers the backend received back in the response body, so a
+// test can assert on headers the gateway injects towards the backend (e.g. the X-JWT-Assertion backend JWT
+// carrying application-attribute claims). The legacy ApplicationAttributesTestCase used a header-echoing
+// backend (jwt_backend) for exactly this. Scoped to /reflect-headers so it does not mask other routes.
+router.get('/reflect-headers', (req, res) => {
+  res.status(200).json({ headers: req.headers });
+});
+
+// POST /reflect-body — echoes the raw request body the backend received straight back in the response, so a
+// test can assert on a gateway request-flow transformation (e.g. the jsonToXML operation policy converting a
+// JSON request body to XML — content-type application/xml — before it reaches the backend). A route-level
+// catch-all text parser captures the raw body for ANY content-type (the app-level parsers only cover
+// text/plain, text/xml and json, so application/xml would otherwise arrive unparsed as {}). Scoped to
+// /reflect-body so it does not mask other routes.
+router.all('/reflect-body', express.text({ type: () => true }), (req, res) => {
+  const body = typeof req.body === 'string' ? req.body : JSON.stringify(req.body);
+  res.status(200).send(body);
+});
+
+// --- Petstore routes for the gateway schema-validation tests (SchemaValidationTestCase) ---
+// The gateway validates requests/responses against the imported petstore OpenAPI when the API has
+// enableSchemaValidation=true. These routes return schema-shaped bodies so the SAME resources drive both
+// the pass and the response-validation-fail outcomes. Request-validation failures (malformed body / missing
+// required header) are rejected at the gateway BEFORE reaching the backend, so they need no branch here.
+
+// GET /pets → a schema-valid Pets array. The gateway rejects the call earlier if the required X-Request-ID
+// header is absent; when present, this valid array passes response validation → 200.
+router.get('/pets', (req, res) => {
+  res.status(200).json([{ id: 1, name: 'max' }]);
+});
+
+// POST /pets → a schema-valid Pet (id + name). A schema-valid request body therefore yields 200; an invalid
+// body (missing required name) is rejected at the gateway before it reaches here.
+router.post('/pets', (req, res) => {
+  res.status(200).json({ id: 1, name: 'max' });
+});
+
+// GET /pets/:petId → branch on isAvailable so one resource covers both response-validation outcomes: with the
+// query param it returns a schema-valid Pet (id+name → 200); without it returns a body missing the required
+// `id`, so the gateway's RESPONSE schema validation fails (→ 500). Mirrors the petstore backend the legacy
+// SchemaValidationTestCase drove.
+router.get('/pets/:petId', (req, res) => {
+  if (req.query.isAvailable !== undefined) {
+    res.status(200).json({ id: parseInt(req.params.petId) || 1, name: 'max' });
+  } else {
+    res.status(200).json({ name: 'max' });
+  }
+});
+
+// GET /pet/findByStatus → unsecured resource (x-auth-type None in the OAS). The negative case calls it without
+// the required `status` query param, so the gateway rejects it before the backend; this valid array covers the
+// (unused) valid path for completeness.
+router.get('/pet/findByStatus', (req, res) => {
+  res.status(200).json([{ id: 1, name: 'max' }]);
+});
+
+// --- Mock LLM (Mistral-style) endpoint for the gateway AI-API invocation tests (AIAPITestCase) ---
+// An AI API's backend endpoint points here; the gateway proxies POST /chat/completions to it. Returns a
+// Mistral-shaped chat-completion response (200) including the token-usage fields the AI provider extracts
+// ($.model, $.usage.*). Mounted under /no-auth (the unsecured AI API's backend path) so the gateway-appended
+// resource /v1/chat/completions resolves to /no-auth/v1/chat/completions.
+function chatCompletion(req, res) {
+  console.log('----invoking mock LLM chat/completions');
+  const model = (req.body && req.body.model) ? req.body.model : 'mistral-small-latest';
+  res.status(200).json({
+    id: 'f821a1dd4df2492382ec9676b59ddcd3',
+    object: 'chat.completion',
+    created: 1727259070,
+    model: model,
+    choices: [
+      {
+        index: 0,
+        message: { role: 'assistant', content: 'Claude Monet is among the most renowned French painters.', tool_calls: null },
+        finish_reason: 'stop',
+        logprobs: null
+      }
+    ],
+    usage: { prompt_tokens: 12, total_tokens: 358, completion_tokens: 346 }
+  });
+}
+router.post('/no-auth/v1/chat/completions', chatCompletion);
+router.post('/v1/chat/completions', chatCompletion);
+
+// Secured AI backend: requires the Authorization header the AI service provider injects on the backend leg
+// (the provider's authenticationConfiguration is apikey/header "Authorization"; the API's endpoint_security
+// carries the credential "Bearer 123"). A 200 through the gateway therefore PROVES APIM injected the configured
+// backend credential — without it the backend rejects with 401. Mounted under /with-auth (the secured AI API's
+// backend path), so the gateway-appended /v1/chat/completions resolves to /with-auth/v1/chat/completions.
+function securedChatCompletion(req, res) {
+  const auth = req.header('Authorization');
+  if (auth !== 'Bearer 123') {
+    console.log('----secured mock LLM rejected: Authorization header not injected (got: ' + auth + ')');
+    return res.status(401).json({ error: 'unauthorized: backend credential not injected by the gateway' });
+  }
+  console.log('----secured mock LLM: Authorization header present, returning chat/completions');
+  return chatCompletion(req, res);
+}
+router.post('/with-auth/v1/chat/completions', securedChatCompletion);
+
+// Always-failing AI backend route — the FAILOVER TARGET for the modelFailover policy test. Returns 429 (the
+// exact signal the legacy WireMock failover stub returned) so the gateway's failover policy abandons the target
+// model/endpoint and retries the fallback model on the default (echoing) endpoint. A fallback-model response
+// therefore PROVES failover kicked in.
+router.post('/failover-target/v1/chat/completions', (req, res) => {
+  console.log('----failover-target route hit → returning 429 to trigger failover');
+  res.status(429).json({ error: 'model endpoint rate-limited (failover target)' });
+});
+
 module.exports = router;

--- a/all-in-one-apim/modules/integration-v2/tests-common/testcontainers/src/main/resources/nodeapps/node-customer-service/server.js
+++ b/all-in-one-apim/modules/integration-v2/tests-common/testcontainers/src/main/resources/nodeapps/node-customer-service/server.js
@@ -17,6 +17,7 @@
 
  const express = require('express');
 const bodyParser = require('body-parser');
+const { WebSocketServer } = require('ws');
 const customerRoutes = require('./routes/customerRoutes');
 const orderRoutes = require('./routes/orderRoutes');
 
@@ -30,6 +31,23 @@ app.use(bodyParser.json());
 app.use('/jaxrs_basic/services/customers/customerservice', customerRoutes);
 app.use('/jaxrs_basic/services/customers/customerservice', orderRoutes);
 
-app.listen(port, () => {
+const server = app.listen(port, () => {
   console.log(`Customer Service API running at http://nodebackend:${port}`);
+});
+
+// --- WebSocket echo endpoint for the gateway WebSocket-API invocation tests (WebSocketAPITestCase) ---
+// Built on the official `ws` library. The gateway's WebsocketHandler (apim.ws.port=9099) upgrades a client WS
+// connection and proxies it here (the WS API's ws:// endpoint points at this server). It ECHOES each text
+// message back UPPERCASED — the exact contract the legacy Jetty WebSocketServerImpl used (client asserts
+// response == message.toUpperCase()). Attached to the same http.Server (port 3001), so any upgrade path is
+// accepted (the gateway strips the API context before proxying).
+const wss = new WebSocketServer({ server });
+wss.on('connection', (socket) => {
+  console.log('----WS connection accepted (ws lib)');
+  socket.on('message', (data) => {
+    const msg = data.toString();
+    console.log('----WS echo, received: ' + msg);
+    socket.send(msg.toUpperCase());
+  });
+  socket.on('error', () => { /* ignore transient socket errors */ });
 });

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/CLAUDE.md
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/CLAUDE.md
@@ -66,6 +66,22 @@ mutable.**
     across the runner's later scenarios, **leave the feature untagged** and rely on `BaseBlockRunner`'s
     `@AfterClass` sweep, which deletes once after all the runner's scenarios. A per-scenario `@cleanup` here
     would delete the shared fixture out from under the scenarios that follow.
+- **Introducing a NEW top-level resource type? `register(...)` alone is NOT enough — wire the sweep too.**
+  `ResourceCleanup.register(key, id)` only enqueues an id; it is deleted only if
+  `ResourceCleanup.deleteRegisteredResources()` actually sweeps that list. Registering to a list nothing sweeps
+  leaks **silently** — no error, just residue. So for a new resource kind, do all four: (1) add a
+  `CREATED_<X>_IDS` list constant; (2) `register(...)` it on every successful create; (3) add a
+  `deleteResources(CREATED_<X>_IDS, <owner-token>, <delete-URL>)` call in **FK-safe order** (a resource another
+  one references must be deleted first — e.g. applications before APIs, API products before APIs, an AI
+  provider after the APIs binding it); and (4) add the list to **both** the early-return guard and the
+  `finally` block. Only child/sub-resources that vanish with their parent (a subscription with its app, a
+  document/revision/endpoint with its API) need no separate registration.
+    - **Don't assume a bearer-token REST delete exists — and verify the sweep actually deletes.** Some
+      resources have no REST delete or don't use a bearer token, so `deleteResources(...)` doesn't fit and they
+      need a **bespoke sweep** (see `deleteDcrClients`: a DCR-registered OAuth client has no working REST delete
+      and isn't removed by app deletion, so it is deregistered via the `OAuthAdminService` SOAP admin service as
+      its owner). Whatever the mechanism, **prove it against a container** — a delete that silently 404s/faults
+      and is treated as "already gone" looks green while leaking. Log a WARN on any non-2xx so a real leak is visible.
 - Leave zero residue (APIs, apps, subscriptions, tenants, keys).
 
 ## 6. Gherkin style
@@ -79,6 +95,18 @@ mutable.**
 ## 7. Step definitions (glue)
 - **Reuse** existing steps. If one doesn't quite fit, **extend it** to cover the new need — never add
   a near-duplicate step. Search the glue before writing.
+- **Reading from context — one class, `TestContext`, three intents.** Don't reach for a `utils` helper:
+  - `TestContext.resolve(key)` — a **required** value. Strips an optional `<...>` reference wrapper and
+    **throws** `IllegalArgumentException` if absent. Use this for a caller-supplied `{string}` key (an id /
+    token / payload key a step receives) so a missing/typo'd key fails **fast** with a clear message instead
+    of a downstream NPE. This is the default for step arguments.
+  - `TestContext.get(key)` — the **nullable** primitive (returns `null` if absent, no `<>` handling). Use
+    only for a framework-managed key you null-check yourself (`"baseUrl"`, `"httpResponse"`,
+    `"blockApimContainer"`) or where absence is a legitimate branch.
+  - `TestContext.contains(key)` — presence check.
+
+  (There is no `Utils.resolveFromContext` — it was consolidated into `TestContext.resolve`. Picking the
+  method IS the statement of intent; don't fold them into one flagged call.)
 - **The `httpResponse` contract.** A request-making step publishes its result to the shared context key
   `"httpResponse"`; the generic assertion steps (`Then The response status code should be N`,
   `The response should contain …`) read it back. This decoupling has a **stale-response trap**: if your
@@ -90,8 +118,22 @@ mutable.**
   exactly this (clear → call → set → **return** the response). Add new invocation variants by calling
   `execute`, not by hand-writing another `TestContext.set("httpResponse", client.doX(...))` (that
   re-introduces the stale-response trap and the ~15-way duplication it replaced).
+- **Management-plane requests funnel through `Requests.*`** (`utils/Requests`) — the counterpart of
+  `execute` for non-invocation calls (create/update/delete/import, GET/POST/PUT/DELETE **and** multipart).
+  Each method does clear → call → set(`httpResponse`) → **return** in one place, so you never hand-write the
+  `remove`/`set` dance. Call a `Requests.*` method for **the one request whose response the step publishes
+  for the following assertion** (the "response under test").
+- **Use `SimpleHTTPClient.*` directly ONLY for an intermediate read** whose body is consumed locally within
+  the same step and is NOT the asserted response — e.g. a GET-then-mutate-then-PUT round trip: `HttpResponse
+  dtoResp = SimpleHTTPClient.getInstance().doGet(...)` into a **local variable** to build the payload, then
+  `Requests.put(...)` the result (that PUT is what publishes). Such a read must **not** touch `httpResponse`.
+  Do **not** try to route it through the funnel with a "don't publish" flag: `SimpleHTTPClient` *is* the raw
+  HTTP chokepoint that `Requests` wraps, so a non-publishing funnel call collapses to exactly the raw client
+  call — there is nothing to centralize. The layering is deliberate: `SimpleHTTPClient` = raw HTTP (all calls
+  go through it; the home for cross-cutting HTTP concerns); `Requests` = the thin layer that additionally
+  publishes the response as the step's assertion target.
 - **Retry-until-status loops:** catch only `IOException` (transient gateway warm-up — retry), so a bad
-  token/payload context key (`IllegalArgumentException` from `Utils.resolveFromContext`) fails **fast**
+  token/payload context key (`IllegalArgumentException` from `TestContext.resolve`) fails **fast**
   instead of being masked as a timeout. Keep the last *returned* response in a **local** variable and
   **assert after the loop** (`assertNotNull` then `assertEquals` on the expected status) — the step must
   fail on its own, never rely on a following `Then` to notice a persistent failure. See

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/CLAUDE.md
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/CLAUDE.md
@@ -114,6 +114,14 @@ mutable.**
   following assertion can pass against the **wrong** call (a false pass). So a step that makes a request
   must **clear `httpResponse` before the call** (`TestContext.remove("httpResponse")`), so a throw leaves
   it *absent* rather than stale — then set it only on a real response.
+- **Guard a response before parsing its body.** Before `new JSONObject(resp.getData())` (or drilling into
+  fields), assert the call **succeeded with a body** — otherwise a failed/empty response throws an opaque
+  `JSONException`/NPE instead of a clear failure. Use
+  `Assert.assertTrue(resp != null && resp.getResponseCode() >= 200 && resp.getResponseCode() < 300 &&
+  resp.getData() != null && !resp.getData().isEmpty(), "<what failed, incl. the id and got=<code>/<body>>")`.
+  This applies to **intermediate reads too** — the GET half of a GET-then-mutate-then-PUT (e.g.
+  `buildApiProductPayload`, `fetchSharedScopeByName`), where the response isn't published to `httpResponse`
+  but is still parsed locally.
 - **Invocation steps funnel through `APIInvocationSteps.execute(...)`** — the single primitive that does
   exactly this (clear → call → set → **return** the response). Add new invocation variants by calling
   `execute`, not by hand-writing another `TestContext.set("httpResponse", client.doX(...))` (that

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/CLAUDE.md
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/CLAUDE.md
@@ -202,6 +202,15 @@ tenants (`carbon.super` and `tenant1.com`) on boot — pick the one with the lea
   can't be reused for negatives — use the non-asserting **`I attempt to …`** variants (create API / new
   version / shared scope / application / subscribe) and assert the status in the feature. Add a negative only
   where enforcement is real; skip hollow ones (e.g. "search rejected", "key-gen rejected").
+- **Assert the EXACT expected value — never relax an assertion to make a test pass.** If two cases return
+  different codes, assert each one's exact value in its own scenario/row; do not widen the check to accept
+  several (e.g. `status == 401 || status == 403`). A permissive assertion passes today but silently swallows a
+  future regression — including an actual security bypass that returns a *different but still-4xx* code.
+  Example: an invalid token at the MCP `tools/call` is rejected with **401** for the *proxy* subtype but **403**
+  for the *DirectBackend (OpenAPI)* subtype. The right fix is two strict assertions (`gateway/mcp_proxy_invocation`
+  asserts 401, `gateway/mcp_openapi_invocation` asserts 403), each pinning its subtype's real behaviour — NOT a
+  step that accepts either. When you discover such a per-case difference, record it (backlog/comment) and encode
+  it as separate exact assertions.
 
 ## 13. Container config & TOML overlays
 Each block boots a container whose `deployment.toml` is resolved by `BlockLifecycleListener`. Most blocks need

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/runners/block/DevPortalApplicationAttributesRunner.java
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/runners/block/DevPortalApplicationAttributesRunner.java
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.wso2.am.integration.cucumbertests.runners.block;
+
+import io.cucumber.testng.CucumberOptions;
+
+/**
+ * Runner for custom application attributes — the port of the legacy ApplicationAttributesTestCase. Runs in the
+ * IntegrationV2-ApplicationAttributes block, which needs a feature-specific TOML overlay (backend JWT
+ * generation + the declared application attribute) and a backend (the header-reflecting /reflect-headers
+ * route), so the attribute can be verified both stored on the application and surfaced in the X-JWT-Assertion
+ * backend JWT claim.
+ */
+@CucumberOptions(
+        features = {
+                "src/test/resources/features/devportal/application_attributes.feature"
+        },
+        glue = {
+                "org.wso2.am.integration.cucumbertests.stepdefinitions"
+        },
+        plugin = {"pretty", "html:target/cucumber-report/devportal-application-attributes.html"}
+)
+public class DevPortalApplicationAttributesRunner extends BaseBlockRunner {
+}

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/runners/block/GatewayAiApiInvocationRunner.java
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/runners/block/GatewayAiApiInvocationRunner.java
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.wso2.am.integration.cucumbertests.runners.block;
+
+import io.cucumber.testng.CucumberOptions;
+
+/**
+ * Runner for gateway AI-API invocation — the core port of AIAPITestCase. Registers a no-auth AI service
+ * provider, imports an AIAPI-subtype API backed by the node mock LLM, and asserts the gateway proxies a
+ * chat-completions call to it. Runs in a gateway-invoking block (needs the node backend).
+ */
+@CucumberOptions(
+        features = {
+                "src/test/resources/features/gateway/ai_api_invocation.feature"
+        },
+        glue = {
+                "org.wso2.am.integration.cucumbertests.stepdefinitions"
+        },
+        plugin = {"pretty", "html:target/cucumber-report/gateway-ai-api-invocation.html"}
+)
+public class GatewayAiApiInvocationRunner extends BaseBlockRunner {
+}

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/runners/block/GatewayApiProductInvocationRunner.java
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/runners/block/GatewayApiProductInvocationRunner.java
@@ -1,0 +1,29 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.wso2.am.integration.cucumbertests.runners.block;
+
+import io.cucumber.testng.CucumberOptions;
+
+/** Runner for Gateway API Product invocation + lifecycle-stage. Parallel-safe (own uniquely-named product/API/app). */
+@CucumberOptions(
+        features = {"src/test/resources/features/gateway/api_product_invocation.feature"},
+        glue = {"org.wso2.am.integration.cucumbertests.stepdefinitions"},
+        plugin = {"pretty", "html:target/cucumber-report/gateway-api-product-invocation.html"}
+)
+public class GatewayApiProductInvocationRunner extends BaseBlockRunner {
+}

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/runners/block/GatewayGraphqlEndpointSecurityRunner.java
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/runners/block/GatewayGraphqlEndpointSecurityRunner.java
@@ -1,0 +1,29 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.wso2.am.integration.cucumbertests.runners.block;
+
+import io.cucumber.testng.CucumberOptions;
+
+/** Runner for GraphQL endpoint security (gateway injects the backend credential) — ports GraphqlTestCase. */
+@CucumberOptions(
+        features = {"src/test/resources/features/gateway/graphql_endpoint_security.feature"},
+        glue = {"org.wso2.am.integration.cucumbertests.stepdefinitions"},
+        plugin = {"pretty", "html:target/cucumber-report/gateway-graphql-endpoint-security.html"}
+)
+public class GatewayGraphqlEndpointSecurityRunner extends BaseBlockRunner {
+}

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/runners/block/GatewayGraphqlQueryLimitsRunner.java
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/runners/block/GatewayGraphqlQueryLimitsRunner.java
@@ -1,0 +1,29 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.wso2.am.integration.cucumbertests.runners.block;
+
+import io.cucumber.testng.CucumberOptions;
+
+/** Runner for HTTP GraphQL query-analysis limits (complexity/depth rejection over HTTP) — ports GraphqlTestCase. */
+@CucumberOptions(
+        features = {"src/test/resources/features/gateway/graphql_query_limits.feature"},
+        glue = {"org.wso2.am.integration.cucumbertests.stepdefinitions"},
+        plugin = {"pretty", "html:target/cucumber-report/gateway-graphql-query-limits.html"}
+)
+public class GatewayGraphqlQueryLimitsRunner extends BaseBlockRunner {
+}

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/runners/block/GatewayMcpInvocationRunner.java
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/runners/block/GatewayMcpInvocationRunner.java
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.wso2.am.integration.cucumbertests.runners.block;
+
+import io.cucumber.testng.CucumberOptions;
+
+/**
+ * Runner for gateway-plane MCP tool invocation across all three creation types (proxy / from-OpenAPI /
+ * from-API): the full stateful MCP JSON-RPC handshake, scope enforcement, and subscription throttling.
+ * Runs in a backend-enabled block (needs the node mcp-server backend).
+ */
+@CucumberOptions(
+        features = {
+                "src/test/resources/features/gateway/mcp_invocation.feature"
+        },
+        glue = {
+                "org.wso2.am.integration.cucumbertests.stepdefinitions"
+        },
+        plugin = {"pretty", "html:target/cucumber-report/gateway-mcp-invocation.html"}
+)
+public class GatewayMcpInvocationRunner extends BaseBlockRunner {
+}

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/runners/block/PublisherApiProductsRunner.java
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/runners/block/PublisherApiProductsRunner.java
@@ -1,0 +1,29 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.wso2.am.integration.cucumbertests.runners.block;
+
+import io.cucumber.testng.CucumberOptions;
+
+/** Runner for Publisher API Products design + revision. Parallel-safe (own uniquely-named product/API/app). */
+@CucumberOptions(
+        features = {"src/test/resources/features/publisher/api_products.feature"},
+        glue = {"org.wso2.am.integration.cucumbertests.stepdefinitions"},
+        plugin = {"pretty", "html:target/cucumber-report/publisher-api-products.html"}
+)
+public class PublisherApiProductsRunner extends BaseBlockRunner {
+}

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/runners/block/PublisherGraphqlFromUrlRunner.java
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/runners/block/PublisherGraphqlFromUrlRunner.java
@@ -1,7 +1,20 @@
 /*
  *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
- *  Licensed under the Apache License, Version 2.0 (the "License"); ...
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
  */
+
 package org.wso2.am.integration.cucumbertests.runners.block;
 
 import io.cucumber.testng.CucumberOptions;

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/runners/block/PublisherGraphqlFromUrlRunner.java
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/runners/block/PublisherGraphqlFromUrlRunner.java
@@ -1,0 +1,16 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *  Licensed under the Apache License, Version 2.0 (the "License"); ...
+ */
+package org.wso2.am.integration.cucumbertests.runners.block;
+
+import io.cucumber.testng.CucumberOptions;
+
+/** Runner for GraphQL API creation from a URL (introspection + SDL fetch) — ports GraphqlTestCase. */
+@CucumberOptions(
+        features = {"src/test/resources/features/publisher/graphql_design_from_url.feature"},
+        glue = {"org.wso2.am.integration.cucumbertests.stepdefinitions"},
+        plugin = {"pretty", "html:target/cucumber-report/publisher-graphql-from-url.html"}
+)
+public class PublisherGraphqlFromUrlRunner extends BaseBlockRunner {
+}

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/runners/block/PublisherMcpServersRunner.java
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/runners/block/PublisherMcpServersRunner.java
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.wso2.am.integration.cucumbertests.runners.block;
+
+import io.cucumber.testng.CucumberOptions;
+
+/**
+ * Runner for publisher-plane MCP server authoring — CRUD + backend-endpoint management across all three
+ * creation types (proxy / from-OpenAPI / from-API). Runs in a backend-enabled block, since proxy
+ * create-validation calls the node mcp-server backend.
+ */
+@CucumberOptions(
+        features = {
+                "src/test/resources/features/publisher/mcp_servers.feature"
+        },
+        glue = {
+                "org.wso2.am.integration.cucumbertests.stepdefinitions"
+        },
+        plugin = {"pretty", "html:target/cucumber-report/publisher-mcp-servers.html"}
+)
+public class PublisherMcpServersRunner extends BaseBlockRunner {
+}

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/runners/block/RemoteLoggingRunner.java
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/runners/block/RemoteLoggingRunner.java
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.wso2.am.integration.cucumbertests.runners.block;
+
+import io.cucumber.testng.CucumberOptions;
+
+/**
+ * Runner for server-global remote logging — ports RemoteLoggingAppenderTest. Mutates the shared server's
+ * log4j2.properties via the RemoteLoggingConfig admin service, so it runs in its own thread-count=1 block.
+ */
+@CucumberOptions(
+        features = {
+                "src/test/resources/features/analytics/remote_logging.feature"
+        },
+        glue = {
+                "org.wso2.am.integration.cucumbertests.stepdefinitions"
+        },
+        plugin = {"pretty", "html:target/cucumber-report/analytics-remote-logging.html"}
+)
+public class RemoteLoggingRunner extends BaseBlockRunner {
+}

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/APIInvocationSteps.java
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/APIInvocationSteps.java
@@ -25,9 +25,12 @@ import org.wso2.am.integration.cucumbertests.utils.TestContext;
 import org.wso2.am.integration.cucumbertests.utils.Utils;
 import org.wso2.am.integration.cucumbertests.utils.clients.SimpleHTTPClient;
 import org.wso2.am.integration.test.utils.Constants;
+import org.wso2.carbon.automation.engine.context.beans.User;
 import org.wso2.carbon.automation.test.utils.http.client.HttpResponse;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -142,6 +145,84 @@ public class APIInvocationSteps {
     }
 
     /**
+     * Invokes a deployed API at its full gateway context using a RAW (un-normalized) path, so a percent-encoded
+     * segment (e.g. {@code %28}/{@code %29}) is sent to the gateway verbatim rather than being decoded by the
+     * HTTP client. GET only. Needed to test the gateway's routing of an encoded URI path segment — the default
+     * invoke lets Apache HttpClient normalize/decode the path before it reaches the gateway. Retries until the
+     * expected status (transient IOExceptions only), then asserts.
+     */
+    @When("I invoke the API at raw gateway context {string} using access token {string} until response status code becomes {int} within {int} seconds")
+    public void invokeApiByRawContextUntilStatus(String context, String accessToken, int expectedStatus,
+                                                 int timeoutSeconds) throws Exception {
+
+        String resolvedContext = Utils.resolveContextPlaceholders(context);
+        long deadlineMillis = Math.max(timeoutSeconds * 1000L, Constants.DEPLOYMENT_WAIT_TIME);
+        long endTime = System.currentTimeMillis() + deadlineMillis;
+        HttpResponse last = null;
+        do {
+            try {
+                last = invokeApiByRawContext(resolvedContext, accessToken);
+                if (last.getResponseCode() == expectedStatus) {
+                    return;
+                }
+            } catch (IOException transientDuringWarmup) {
+                // Only transient connectivity errors are retried (see invokeApiByContextUntilStatus).
+            }
+            Thread.sleep(2000);
+        } while (System.currentTimeMillis() < endTime);
+        assertReachedExpectedStatus(last, expectedStatus);
+    }
+
+    /** GET a full gateway context with the raw (un-normalized) path; publishes the response to {@code httpResponse}. */
+    private HttpResponse invokeApiByRawContext(String resolvedContext, String accessToken) throws IOException {
+
+        String actualAccessToken = Utils.resolveFromContext(accessToken).toString();
+        // Join base + context with exactly one slash. The default invoke relies on the client's URI
+        // normalization to collapse a "//", but doGetRaw disables normalization, so a double slash would reach
+        // the gateway verbatim and be rejected as "Invalid URL".
+        String base = getBaseGatewayUrl();
+        if (base.endsWith("/")) {
+            base = base.substring(0, base.length() - 1);
+        }
+        String endpointUrl = base + (resolvedContext.startsWith("/") ? "" : "/") + resolvedContext;
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Authorization", "Bearer " + actualAccessToken);
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance().doGetRaw(endpointUrl, headers);
+        TestContext.set("httpResponse", response);
+        return response;
+    }
+
+    /**
+     * Invokes a deployed API at its full gateway context with NO Authorization header, retrying until the
+     * expected status. Used for prototyped APIs (invocable without a subscription/token → 200) and as the
+     * negative for a normal secured API (no token → 401).
+     */
+    @When("I invoke the API at gateway context {string} with method {string} without authentication until response status code becomes {int} within {int} seconds")
+    public void invokeApiByContextNoAuthUntilStatus(String context, String httpMethod, int expectedStatus,
+                                                     int timeoutSeconds) throws Exception {
+
+        String resolvedContext = Utils.resolveContextPlaceholders(context);
+        String endpointUrl = getBaseGatewayUrl() + (resolvedContext.startsWith("/") ? "" : "/") + resolvedContext;
+        long deadlineMillis = Math.max(timeoutSeconds * 1000L, Constants.DEPLOYMENT_WAIT_TIME);
+        long endTime = System.currentTimeMillis() + deadlineMillis;
+        HttpResponse last = null;
+        do {
+            try {
+                last = execute(CurlOption.HttpMethod.valueOf(httpMethod.toUpperCase()), endpointUrl,
+                        new HashMap<>(), "");
+                if (last.getResponseCode() == expectedStatus) {
+                    return;
+                }
+            } catch (IOException transientDuringWarmup) {
+                // Retry transient connectivity only (see invokeApiByContextUntilStatus).
+            }
+            Thread.sleep(2000);
+        } while (System.currentTimeMillis() < endTime);
+        assertReachedExpectedStatus(last, expectedStatus);
+    }
+
+    /**
      * Invokes a deployed API at its full gateway context, sending the bearer token in a CUSTOM authorization
      * header instead of the standard {@code Authorization} one, retrying until the expected status. Used by the
      * custom-auth-header feature, whose container sets {@code [apim.oauth_config] auth_header} so the gateway
@@ -159,6 +240,45 @@ public class APIInvocationSteps {
         do {
             try {
                 last = invokeApiByContext(resolvedContext, httpMethod, accessToken, payload, headerName);
+                if (last.getResponseCode() == expectedStatus) {
+                    return;
+                }
+            } catch (IOException transientDuringWarmup) {
+                // Retry transient connectivity only (see invokeApiByContextUntilStatus).
+            }
+            Thread.sleep(2000);
+        } while (System.currentTimeMillis() < endTime);
+        assertReachedExpectedStatus(last, expectedStatus);
+    }
+
+    /**
+     * Invokes a deployed API at its full gateway context with an extra CUSTOM request header (name + value)
+     * alongside the bearer token, retrying until the expected status. Needed by the gateway schema-validation
+     * test, where a resource declares a REQUIRED request header (X-Request-ID): omitting it is rejected by the
+     * gateway's request schema validation (400), while sending it lets the call through (200). Distinct from the
+     * {@code in header} variant, which places the TOKEN in a custom header rather than adding an arbitrary one.
+     */
+    @When("I invoke the API at gateway context {string} with method {string} using access token {string} and payload {string} with request header {string} set to {string} until response status code becomes {int} within {int} seconds")
+    public void invokeApiByContextWithHeaderUntilStatus(String context, String httpMethod, String accessToken,
+                                                        String payload, String headerName, String headerValue,
+                                                        int expectedStatus, int timeoutSeconds) throws Exception {
+
+        String resolvedContext = Utils.resolveContextPlaceholders(context);
+        long deadlineMillis = Math.max(timeoutSeconds * 1000L, Constants.DEPLOYMENT_WAIT_TIME);
+        long endTime = System.currentTimeMillis() + deadlineMillis;
+        HttpResponse last = null;
+        do {
+            try {
+                String actualAccessToken = Utils.resolveFromContext(accessToken).toString();
+                String actualPayload = (payload == null || payload.isEmpty())
+                        ? "" : Utils.resolveFromContext(payload).toString();
+                String endpointUrl = getBaseGatewayUrl()
+                        + (resolvedContext.startsWith("/") ? "" : "/") + resolvedContext;
+                Map<String, String> headers = new HashMap<>();
+                headers.put("Authorization", "Bearer " + actualAccessToken);
+                headers.put(headerName, headerValue);
+                last = execute(CurlOption.HttpMethod.valueOf(httpMethod.toUpperCase()), endpointUrl, headers,
+                        actualPayload);
                 if (last.getResponseCode() == expectedStatus) {
                     return;
                 }
@@ -293,6 +413,175 @@ public class APIInvocationSteps {
                 }
             } catch (IOException transientDuringWarmup) {
                 // Retry transient connectivity only (see invokeApiByContextUntilStatus).
+            }
+            Thread.sleep(2000);
+        } while (System.currentTimeMillis() < endTime);
+        assertReachedExpectedStatus(last, expectedStatus);
+    }
+
+    /**
+     * API-key invocation with a request PAYLOAD (e.g. an AI API's {@code POST /chat/completions}), retrying
+     * until the expected status. The api-key {@code ApiKey} header carries auth; the payload is sent as the
+     * body. Needed because the no-payload api-key variant can't drive POST bodies.
+     */
+    @When("I invoke the API at gateway context {string} with method {string} using api key {string} and payload {string} until response status code becomes {int} within {int} seconds")
+    public void invokeApiByContextUsingKeyAndPayloadUntilStatus(String context, String httpMethod, String apikey,
+                                                                String payload, int expectedStatus,
+                                                                int timeoutSeconds) throws Exception {
+        String resolvedContext = Utils.resolveContextPlaceholders(context);
+        String endpointUrl = getBaseGatewayUrl() + (resolvedContext.startsWith("/") ? "" : "/") + resolvedContext;
+        long deadlineMillis = Math.max(timeoutSeconds * 1000L, Constants.DEPLOYMENT_WAIT_TIME);
+        long endTime = System.currentTimeMillis() + deadlineMillis;
+        HttpResponse last = null;
+        do {
+            try {
+                String actualKey = Utils.resolveFromContext(apikey).toString();
+                String actualPayload = (payload == null || payload.isEmpty())
+                        ? "" : Utils.resolveFromContext(payload).toString();
+                Map<String, String> headers = new HashMap<>();
+                headers.put("accept", "application/json");
+                headers.put("ApiKey", actualKey);
+                last = execute(CurlOption.HttpMethod.valueOf(httpMethod.toUpperCase()), endpointUrl, headers,
+                        actualPayload);
+                if (last.getResponseCode() == expectedStatus) {
+                    return;
+                }
+            } catch (IOException transientDuringWarmup) {
+                // Retry transient connectivity only.
+            }
+            Thread.sleep(2000);
+        } while (System.currentTimeMillis() < endTime);
+        assertReachedExpectedStatus(last, expectedStatus);
+    }
+
+    /**
+     * API-key invocation presenting an {@code X-Forwarded-For} header, retrying until the expected status. For an
+     * API key generated with a {@code permittedIP} restriction, the REST passthrough derives the client IP from
+     * {@code X-Forwarded-For}, so a matching XFF is authorised (200) and a non-matching one is rejected (403).
+     * (Verified on a standalone server.)
+     */
+    @When("I invoke the API at gateway context {string} with method {string} using api key {string} and forwarded-for {string} until response status code becomes {int} within {int} seconds")
+    public void invokeApiByContextUsingKeyAndXffUntilStatus(String context, String httpMethod, String apikey,
+                                                            String forwardedFor, int expectedStatus,
+                                                            int timeoutSeconds) throws Exception {
+        String resolvedContext = Utils.resolveContextPlaceholders(context);
+        String endpointUrl = getBaseGatewayUrl() + (resolvedContext.startsWith("/") ? "" : "/") + resolvedContext;
+        long deadlineMillis = Math.max(timeoutSeconds * 1000L, Constants.DEPLOYMENT_WAIT_TIME);
+        long endTime = System.currentTimeMillis() + deadlineMillis;
+        HttpResponse last = null;
+        do {
+            try {
+                Map<String, String> headers = new HashMap<>();
+                headers.put("accept", "application/json");
+                headers.put("ApiKey", Utils.resolveFromContext(apikey).toString());
+                headers.put("X-Forwarded-For", Utils.resolveContextPlaceholders(forwardedFor));
+                last = execute(CurlOption.HttpMethod.valueOf(httpMethod.toUpperCase()), endpointUrl, headers, "");
+                if (last.getResponseCode() == expectedStatus) {
+                    return;
+                }
+            } catch (IOException transientDuringWarmup) {
+                // Retry transient connectivity only.
+            }
+            Thread.sleep(2000);
+        } while (System.currentTimeMillis() < endTime);
+        assertReachedExpectedStatus(last, expectedStatus);
+    }
+
+    /**
+     * API-key invocation presenting a {@code Referer} header, retrying until the expected status. For a key
+     * generated with a {@code permittedReferer} restriction, the gateway matches the request's {@code Referer}
+     * against the permitted patterns — a matching Referer is authorised (200), a non-matching one is forbidden
+     * (403). Ports the REST api-key Referer-restriction case of APISecurityTestCase.
+     */
+    @When("I invoke the API at gateway context {string} with method {string} using api key {string} and referer {string} until response status code becomes {int} within {int} seconds")
+    public void invokeApiByContextUsingKeyAndRefererUntilStatus(String context, String httpMethod, String apikey,
+                                                                String referer, int expectedStatus,
+                                                                int timeoutSeconds) throws Exception {
+        String resolvedContext = Utils.resolveContextPlaceholders(context);
+        String endpointUrl = getBaseGatewayUrl() + (resolvedContext.startsWith("/") ? "" : "/") + resolvedContext;
+        long deadlineMillis = Math.max(timeoutSeconds * 1000L, Constants.DEPLOYMENT_WAIT_TIME);
+        long endTime = System.currentTimeMillis() + deadlineMillis;
+        HttpResponse last = null;
+        do {
+            try {
+                Map<String, String> headers = new HashMap<>();
+                headers.put("accept", "application/json");
+                headers.put("ApiKey", Utils.resolveFromContext(apikey).toString());
+                headers.put("Referer", Utils.resolveContextPlaceholders(referer));
+                last = execute(CurlOption.HttpMethod.valueOf(httpMethod.toUpperCase()), endpointUrl, headers, "");
+                if (last.getResponseCode() == expectedStatus) {
+                    return;
+                }
+            } catch (IOException transientDuringWarmup) {
+                // Retry transient connectivity only.
+            }
+            Thread.sleep(2000);
+        } while (System.currentTimeMillis() < endTime);
+        assertReachedExpectedStatus(last, expectedStatus);
+    }
+
+    /**
+     * Basic-auth invocation using an ACTOR's carbon credentials (username:password → {@code Authorization: Basic}),
+     * retrying until the expected status. For an API whose securityScheme includes {@code basic_auth}, valid user
+     * credentials are authorised (200). Ports the basic-auth positive of APISecurityTestCase.
+     */
+    @When("I invoke the API at gateway context {string} with method {string} using basic auth for actor {string} until response status code becomes {int} within {int} seconds")
+    public void invokeApiByContextUsingBasicAuthActor(String context, String httpMethod, String actorRef,
+                                                      int expectedStatus, int timeoutSeconds) throws Exception {
+        User actor = Identity.resolveActor(actorRef);
+        String creds = Base64.getEncoder().encodeToString(
+                (actor.getUserName() + ":" + actor.getPassword()).getBytes(StandardCharsets.UTF_8));
+        invokeWithBasicAuthUntilStatus(context, httpMethod, "Basic " + creds, expectedStatus, timeoutSeconds);
+    }
+
+    /**
+     * Basic-auth invocation with EXPLICIT username/password (for the wrong-credentials negative), retrying until
+     * the expected status. Wrong credentials are rejected (401).
+     */
+    @When("I invoke the API at gateway context {string} with method {string} using basic auth username {string} password {string} until response status code becomes {int} within {int} seconds")
+    public void invokeApiByContextUsingBasicAuthCreds(String context, String httpMethod, String username,
+                                                      String password, int expectedStatus, int timeoutSeconds)
+            throws Exception {
+        String creds = Base64.getEncoder().encodeToString(
+                (Utils.resolveContextPlaceholders(username) + ":" + Utils.resolveContextPlaceholders(password))
+                        .getBytes(StandardCharsets.UTF_8));
+        invokeWithBasicAuthUntilStatus(context, httpMethod, "Basic " + creds, expectedStatus, timeoutSeconds);
+    }
+
+    /**
+     * Basic-auth invocation using a VALID actor's username with an OVERRIDDEN (wrong) password — the faithful
+     * wrong-credentials negative (a valid user + bad password → 401, consistently across tenants; a made-up
+     * domainless username instead resolves against the super tenant and yields 403 on a tenant API).
+     */
+    @When("I invoke the API at gateway context {string} with method {string} using basic auth for actor {string} with password {string} until response status code becomes {int} within {int} seconds")
+    public void invokeApiByContextUsingBasicAuthActorPassword(String context, String httpMethod, String actorRef,
+                                                              String password, int expectedStatus, int timeoutSeconds)
+            throws Exception {
+        User actor = Identity.resolveActor(actorRef);
+        String creds = Base64.getEncoder().encodeToString(
+                (actor.getUserName() + ":" + Utils.resolveContextPlaceholders(password)).getBytes(StandardCharsets.UTF_8));
+        invokeWithBasicAuthUntilStatus(context, httpMethod, "Basic " + creds, expectedStatus, timeoutSeconds);
+    }
+
+    /** Shared retry-until-status loop for a fixed {@code Authorization} header (Basic-auth invocations). */
+    private void invokeWithBasicAuthUntilStatus(String context, String httpMethod, String authHeader,
+                                                int expectedStatus, int timeoutSeconds) throws Exception {
+        String resolvedContext = Utils.resolveContextPlaceholders(context);
+        String endpointUrl = getBaseGatewayUrl() + (resolvedContext.startsWith("/") ? "" : "/") + resolvedContext;
+        long deadlineMillis = Math.max(timeoutSeconds * 1000L, Constants.DEPLOYMENT_WAIT_TIME);
+        long endTime = System.currentTimeMillis() + deadlineMillis;
+        HttpResponse last = null;
+        do {
+            try {
+                Map<String, String> headers = new HashMap<>();
+                headers.put("accept", "application/json");
+                headers.put("Authorization", authHeader);
+                last = execute(CurlOption.HttpMethod.valueOf(httpMethod.toUpperCase()), endpointUrl, headers, "");
+                if (last.getResponseCode() == expectedStatus) {
+                    return;
+                }
+            } catch (IOException transientDuringWarmup) {
+                // Retry transient connectivity only.
             }
             Thread.sleep(2000);
         } while (System.currentTimeMillis() < endTime);

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/APIInvocationSteps.java
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/APIInvocationSteps.java
@@ -68,29 +68,41 @@ public class APIInvocationSteps {
      * retry loops can hold the last real response locally without re-reading shared context.
      */
     private HttpResponse execute(CurlOption.HttpMethod method, String endpointUrl, Map<String, String> headers,
-                                 String payload, String contentType) throws IOException {
+                                 String payload, String contentType, boolean rawGet) throws IOException {
 
         TestContext.remove(HTTP_RESPONSE_KEY);
         SimpleHTTPClient client = SimpleHTTPClient.getInstance();
         HttpResponse response;
-        switch (method) {
-            case GET:
-                response = client.doGet(endpointUrl, headers);
-                break;
-            case DELETE:
-                response = client.doDelete(endpointUrl, headers);
-                break;
-            case POST:
-                response = client.doPost(endpointUrl, headers, payload, contentType);
-                break;
-            case PUT:
-                response = client.doPut(endpointUrl, headers, payload, contentType);
-                break;
-            default:
-                throw new IllegalArgumentException("Unsupported HTTP method for invocation: " + method);
+        if (rawGet) {
+            // GET with the client's URI normalization DISABLED, so a percent-encoded path segment reaches the
+            // gateway verbatim; method/payload/contentType are unused on this path.
+            response = client.doGetRaw(endpointUrl, headers);
+        } else {
+            switch (method) {
+                case GET:
+                    response = client.doGet(endpointUrl, headers);
+                    break;
+                case DELETE:
+                    response = client.doDelete(endpointUrl, headers);
+                    break;
+                case POST:
+                    response = client.doPost(endpointUrl, headers, payload, contentType);
+                    break;
+                case PUT:
+                    response = client.doPut(endpointUrl, headers, payload, contentType);
+                    break;
+                default:
+                    throw new IllegalArgumentException("Unsupported HTTP method for invocation: " + method);
+            }
         }
         TestContext.set(HTTP_RESPONSE_KEY, response);
         return response;
+    }
+
+    /** {@link #execute(CurlOption.HttpMethod, String, Map, String, String, boolean)} for a normalized request. */
+    private HttpResponse execute(CurlOption.HttpMethod method, String endpointUrl, Map<String, String> headers,
+                                 String payload, String contentType) throws IOException {
+        return execute(method, endpointUrl, headers, payload, contentType, false);
     }
 
     /** {@link #execute(CurlOption.HttpMethod, String, Map, String, String)} defaulting to a JSON content type. */
@@ -176,7 +188,7 @@ public class APIInvocationSteps {
     /** GET a full gateway context with the raw (un-normalized) path; publishes the response to {@code httpResponse}. */
     private HttpResponse invokeApiByRawContext(String resolvedContext, String accessToken) throws IOException {
 
-        String actualAccessToken = Utils.resolveFromContext(accessToken).toString();
+        String actualAccessToken = TestContext.resolve(accessToken).toString();
         // Join base + context with exactly one slash. The default invoke relies on the client's URI
         // normalization to collapse a "//", but doGetRaw disables normalization, so a double slash would reach
         // the gateway verbatim and be rejected as "Invalid URL".
@@ -187,10 +199,8 @@ public class APIInvocationSteps {
         String endpointUrl = base + (resolvedContext.startsWith("/") ? "" : "/") + resolvedContext;
         Map<String, String> headers = new HashMap<>();
         headers.put("Authorization", "Bearer " + actualAccessToken);
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance().doGetRaw(endpointUrl, headers);
-        TestContext.set("httpResponse", response);
-        return response;
+        return execute(CurlOption.HttpMethod.GET, endpointUrl, headers, "",
+                Constants.CONTENT_TYPES.APPLICATION_JSON, true);
     }
 
     /**
@@ -269,9 +279,9 @@ public class APIInvocationSteps {
         HttpResponse last = null;
         do {
             try {
-                String actualAccessToken = Utils.resolveFromContext(accessToken).toString();
+                String actualAccessToken = TestContext.resolve(accessToken).toString();
                 String actualPayload = (payload == null || payload.isEmpty())
-                        ? "" : Utils.resolveFromContext(payload).toString();
+                        ? "" : TestContext.resolve(payload).toString();
                 String endpointUrl = getBaseGatewayUrl()
                         + (resolvedContext.startsWith("/") ? "" : "/") + resolvedContext;
                 Map<String, String> headers = new HashMap<>();
@@ -335,8 +345,8 @@ public class APIInvocationSteps {
     private HttpResponse invokeApiByContext(String resolvedContext, String httpMethod, String accessToken,
                                             String payload, String authHeaderName) throws IOException {
 
-        String actualAccessToken = Utils.resolveFromContext(accessToken).toString();
-        String actualPayload = (payload == null || payload.isEmpty()) ? "" : Utils.resolveFromContext(payload).toString();
+        String actualAccessToken = TestContext.resolve(accessToken).toString();
+        String actualPayload = (payload == null || payload.isEmpty()) ? "" : TestContext.resolve(payload).toString();
         // The context already carries any /t/<tenant> prefix, so append it directly to the gateway base URL.
         String endpointUrl = getBaseGatewayUrl() + (resolvedContext.startsWith("/") ? "" : "/") + resolvedContext;
 
@@ -360,8 +370,8 @@ public class APIInvocationSteps {
     public HttpResponse invokeApiUsingAccessToken(String path, String httpMethod, String accessToken, String payload)
             throws IOException {
 
-        String actualAccessToken = Utils.resolveFromContext(accessToken).toString();
-        String actualPayload = (payload == null || payload.isEmpty()) ? "" : Utils.resolveFromContext(payload).toString();
+        String actualAccessToken = TestContext.resolve(accessToken).toString();
+        String actualPayload = (payload == null || payload.isEmpty()) ? "" : TestContext.resolve(payload).toString();
         // Resolve {{contextKey}} placeholders in the path so the invocation can target a uniquely-generated
         // API context (names/contexts are randomized by ${UNIQUE:...}), e.g. "{{apiContext}}/1.0.0/...".
         String resolvedPath = Utils.resolveContextPlaceholders(path);
@@ -435,9 +445,9 @@ public class APIInvocationSteps {
         HttpResponse last = null;
         do {
             try {
-                String actualKey = Utils.resolveFromContext(apikey).toString();
+                String actualKey = TestContext.resolve(apikey).toString();
                 String actualPayload = (payload == null || payload.isEmpty())
-                        ? "" : Utils.resolveFromContext(payload).toString();
+                        ? "" : TestContext.resolve(payload).toString();
                 Map<String, String> headers = new HashMap<>();
                 headers.put("accept", "application/json");
                 headers.put("ApiKey", actualKey);
@@ -473,7 +483,7 @@ public class APIInvocationSteps {
             try {
                 Map<String, String> headers = new HashMap<>();
                 headers.put("accept", "application/json");
-                headers.put("ApiKey", Utils.resolveFromContext(apikey).toString());
+                headers.put("ApiKey", TestContext.resolve(apikey).toString());
                 headers.put("X-Forwarded-For", Utils.resolveContextPlaceholders(forwardedFor));
                 last = execute(CurlOption.HttpMethod.valueOf(httpMethod.toUpperCase()), endpointUrl, headers, "");
                 if (last.getResponseCode() == expectedStatus) {
@@ -506,7 +516,7 @@ public class APIInvocationSteps {
             try {
                 Map<String, String> headers = new HashMap<>();
                 headers.put("accept", "application/json");
-                headers.put("ApiKey", Utils.resolveFromContext(apikey).toString());
+                headers.put("ApiKey", TestContext.resolve(apikey).toString());
                 headers.put("Referer", Utils.resolveContextPlaceholders(referer));
                 last = execute(CurlOption.HttpMethod.valueOf(httpMethod.toUpperCase()), endpointUrl, headers, "");
                 if (last.getResponseCode() == expectedStatus) {
@@ -591,7 +601,7 @@ public class APIInvocationSteps {
     /** Single API-key invocation against a fully-built gateway URL. */
     private HttpResponse invokeWithApiKey(String endpointUrl, String httpMethod, String apikey) throws IOException {
 
-        String actualKey = Utils.resolveFromContext(apikey).toString();
+        String actualKey = TestContext.resolve(apikey).toString();
         Map<String, String> headers = new HashMap<>();
         headers.put("accept", "application/json");
         headers.put("ApiKey", actualKey);
@@ -631,7 +641,7 @@ public class APIInvocationSteps {
     /** Single internal-key invocation against a fully-built gateway URL (token in the {@code Internal-Key} header). */
     private HttpResponse invokeWithInternalKey(String endpointUrl, String httpMethod, String internalKey) throws IOException {
 
-        String actualKey = Utils.resolveFromContext(internalKey).toString();
+        String actualKey = TestContext.resolve(internalKey).toString();
         Map<String, String> headers = new HashMap<>();
         headers.put("accept", "*/*");
         headers.put("Internal-Key", actualKey);
@@ -712,7 +722,7 @@ public class APIInvocationSteps {
     @When("I invoke the OpenID userinfo endpoint using access token {string}")
     public void invokeUserInfoEndpoint(String accessToken) throws Exception {
 
-        String actualAccessToken = Utils.resolveFromContext(accessToken).toString();
+        String actualAccessToken = TestContext.resolve(accessToken).toString();
         String baseUrl = TestContext.get("baseUrl").toString();
 
         Map<String, String> headers = new HashMap<>();
@@ -735,8 +745,8 @@ public class APIInvocationSteps {
     @When("I invoke the SOAP API at path {string} using access token {string} and payload {string} and soap action {string}")
     public void iInvokeTheSOAPAPIAtPathUsingAccessTokenAndPayloadAndSoapAction(String path, String accessToken, String payload, String soapAction) throws IOException {
 
-        String actualAccessToken = Utils.resolveFromContext(accessToken).toString();
-        String actualPayload = Utils.resolveFromContext(payload).toString();
+        String actualAccessToken = TestContext.resolve(accessToken).toString();
+        String actualPayload = TestContext.resolve(payload).toString();
         String endpointUrl = Utils.getAPIInvocationURL(getBaseGatewayUrl(),
                 Utils.resolveContextPlaceholders(path), actingTenantDomain());
 
@@ -759,8 +769,8 @@ public class APIInvocationSteps {
     @When("I invoke the SOAP API at gateway context {string} using access token {string} and payload {string} and soap action {string}")
     public void invokeSoapByGatewayContext(String context, String accessToken, String payload, String soapAction) throws IOException {
 
-        String actualAccessToken = Utils.resolveFromContext(accessToken).toString();
-        String actualPayload = Utils.resolveFromContext(payload).toString();
+        String actualAccessToken = TestContext.resolve(accessToken).toString();
+        String actualPayload = TestContext.resolve(payload).toString();
         String resolvedContext = Utils.resolveContextPlaceholders(context);
         String endpointUrl = getBaseGatewayUrl() + (resolvedContext.startsWith("/") ? "" : "/") + resolvedContext;
 

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/AiApiSteps.java
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/AiApiSteps.java
@@ -22,6 +22,7 @@ import org.apache.commons.io.IOUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.wso2.am.integration.cucumbertests.utils.Identity;
+import org.wso2.am.integration.cucumbertests.utils.Requests;
 import org.wso2.am.integration.cucumbertests.utils.ResourceCleanup;
 import org.wso2.am.integration.cucumbertests.utils.TestContext;
 import org.wso2.am.integration.cucumbertests.utils.Utils;
@@ -54,10 +55,7 @@ public class AiApiSteps {
     public void iRetrieveAiServiceProviders() throws Exception {
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.adminToken());
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doGet(Utils.getAIServiceProvidersURL(getBaseUrl()), headers);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.get(Utils.getAIServiceProvidersURL(getBaseUrl()), headers);
     }
 
     /**
@@ -88,10 +86,8 @@ public class AiApiSteps {
         Map<String, File> files = new HashMap<>();
         files.put("apiDefinition", defFile);
 
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPostMultipartWithFiles(Utils.getAIServiceProvidersURL(getBaseUrl()), headers, files, formFields);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.postMultipart(Utils.getAIServiceProvidersURL(getBaseUrl()), headers,
+                files, formFields);
         if (response.getResponseCode() >= 200 && response.getResponseCode() < 300) {
             Object createdId = Utils.extractValueFromPayload(response.getData(), "id");
             TestContext.set(idKey, createdId);
@@ -132,10 +128,8 @@ public class AiApiSteps {
         Map<String, File> files = new HashMap<>();
         files.put("apiDefinition", defFile);
 
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPostMultipartWithFiles(Utils.getAIServiceProvidersURL(getBaseUrl()), headers, files, formFields);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.postMultipart(Utils.getAIServiceProvidersURL(getBaseUrl()), headers,
+                files, formFields);
         if (response.getResponseCode() >= 200 && response.getResponseCode() < 300) {
             Object createdId = Utils.extractValueFromPayload(response.getData(), "id");
             TestContext.set(idKey, createdId);
@@ -150,7 +144,7 @@ public class AiApiSteps {
     @When("I update the AI service provider {string} named {string} version {string} to config {string} with definition {string} and description {string}")
     public void iUpdateAiServiceProvider(String idKey, String name, String apiVersion, String configPath,
                                          String defPath, String description) throws Exception {
-        Object id = Utils.resolveFromContext(idKey);
+        Object id = TestContext.resolve(idKey);
         String configurations = readClasspath(configPath);
         File defFile = classpathToTempFile(defPath, ".json");
 
@@ -164,23 +158,17 @@ public class AiApiSteps {
         Map<String, File> files = new HashMap<>();
         files.put("apiDefinition", defFile);
 
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPutMultipartWithFiles(Utils.getAIServiceProviderByIdURL(getBaseUrl(), id.toString()), headers,
-                        files, formFields);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.putMultipart(
+                Utils.getAIServiceProviderByIdURL(getBaseUrl(), id.toString()), headers, files, formFields);
     }
 
     /** Admin — GET /ai-service-providers/{id}. Retrieves a single provider (e.g. to assert an update persisted). */
     @When("I retrieve the AI service provider {string}")
     public void iRetrieveAiServiceProvider(String idKey) throws Exception {
-        Object id = Utils.resolveFromContext(idKey);
+        Object id = TestContext.resolve(idKey);
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.adminToken());
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doGet(Utils.getAIServiceProviderByIdURL(getBaseUrl(), id.toString()), headers);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.get(Utils.getAIServiceProviderByIdURL(getBaseUrl(), id.toString()), headers);
     }
 
     /**
@@ -189,30 +177,24 @@ public class AiApiSteps {
      */
     @When("I retrieve the models of AI service provider {string}")
     public void iRetrieveAiServiceProviderModels(String idKey) throws Exception {
-        Object id = Utils.resolveFromContext(idKey);
+        Object id = TestContext.resolve(idKey);
         Map<String, String> headers = new HashMap<>();
         // The publisher models endpoint requires apim:llm_provider_read — carried by the admin token (llm provider
         // scopes are admin-oriented; the publisher token's role does not grant them).
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.adminToken());
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doGet(Utils.getAIServiceProviderModelsURL(getBaseUrl(), id.toString()), headers);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.get(Utils.getAIServiceProviderModelsURL(getBaseUrl(), id.toString()),
+                headers);
     }
 
-    /** Admin — DELETE /ai-service-providers/{id}. Best-effort provider teardown (no ResourceCleanup hook). */
+    /** Admin — DELETE /ai-service-providers/{id} — the explicit delete scenarios use to assert removal.
+     *  Teardown is additionally covered by ResourceCleanup (the create side registers the provider). */
     @When("I delete the AI service provider {string}")
     public void iDeleteAiServiceProvider(String idKey) throws Exception {
-        Object id = TestContext.get(idKey);
-        if (id == null) {
-            return;
-        }
+        Object id = TestContext.resolve(idKey);
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.adminToken());
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doDelete(Utils.getAIServiceProviderByIdURL(getBaseUrl(), id.toString()), headers);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.delete(Utils.getAIServiceProviderByIdURL(getBaseUrl(), id.toString()),
+                headers);
     }
 
     /**
@@ -232,8 +214,8 @@ public class AiApiSteps {
     @When("I apply the AI mediation policy {string} with parameter {string} value {string} to API {string}")
     public void iApplyAiMediationPolicy(String policyName, String paramName, String configKey, String apiId)
             throws Exception {
-        String actualApiId = Utils.resolveFromContext(apiId).toString();
-        String config = Utils.resolveContextPlaceholders(Utils.resolveFromContext(configKey).toString());
+        String actualApiId = TestContext.resolve(apiId).toString();
+        String config = Utils.resolveContextPlaceholders(TestContext.resolve(configKey).toString());
         // Legacy contract: the JSON config is embedded in a String parameter with single quotes.
         String singleQuotedConfig = config.replace("\"", "'");
 
@@ -270,11 +252,8 @@ public class AiApiSteps {
                 .put("fault", new JSONArray());
         api.put("apiPolicies", apiPolicies);
 
-        TestContext.remove("httpResponse");
-        HttpResponse putResp = SimpleHTTPClient.getInstance()
-                .doPut(Utils.getResourceEndpointURL(getBaseUrl(), "apis", actualApiId), headers, api.toString(),
-                        Constants.CONTENT_TYPES.APPLICATION_JSON);
-        TestContext.set("httpResponse", putResp);
+        HttpResponse putResp = Requests.put(Utils.getResourceEndpointURL(getBaseUrl(), "apis", actualApiId), headers,
+                api.toString(), Constants.CONTENT_TYPES.APPLICATION_JSON);
     }
 
     /**
@@ -284,19 +263,16 @@ public class AiApiSteps {
      */
     @When("I set the primary production endpoint of API {string} to {string}")
     public void iSetPrimaryProductionEndpoint(String apiId, String endpointId) throws Exception {
-        String actualApiId = Utils.resolveFromContext(apiId).toString();
-        String actualEndpointId = Utils.resolveFromContext(endpointId).toString();
+        String actualApiId = TestContext.resolve(apiId).toString();
+        String actualEndpointId = TestContext.resolve(endpointId).toString();
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
         HttpResponse getApi = SimpleHTTPClient.getInstance()
                 .doGet(Utils.getResourceEndpointURL(getBaseUrl(), "apis", actualApiId), headers);
         JSONObject api = new JSONObject(getApi.getData());
         api.put("primaryProductionEndpointId", actualEndpointId);
-        TestContext.remove("httpResponse");
-        HttpResponse putResp = SimpleHTTPClient.getInstance()
-                .doPut(Utils.getResourceEndpointURL(getBaseUrl(), "apis", actualApiId), headers, api.toString(),
-                        Constants.CONTENT_TYPES.APPLICATION_JSON);
-        TestContext.set("httpResponse", putResp);
+        HttpResponse putResp = Requests.put(Utils.getResourceEndpointURL(getBaseUrl(), "apis", actualApiId), headers,
+                api.toString(), Constants.CONTENT_TYPES.APPLICATION_JSON);
     }
 
     private String readClasspath(String path) throws Exception {

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/AiApiSteps.java
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/AiApiSteps.java
@@ -1,0 +1,322 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.wso2.am.integration.cucumbertests.stepdefinitions;
+
+import io.cucumber.java.en.When;
+import org.apache.commons.io.IOUtils;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.wso2.am.integration.cucumbertests.utils.Identity;
+import org.wso2.am.integration.cucumbertests.utils.ResourceCleanup;
+import org.wso2.am.integration.cucumbertests.utils.TestContext;
+import org.wso2.am.integration.cucumbertests.utils.Utils;
+import org.wso2.am.integration.cucumbertests.utils.clients.SimpleHTTPClient;
+import org.wso2.am.integration.test.utils.Constants;
+import org.wso2.carbon.automation.test.utils.http.client.HttpResponse;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Admin-plane AI Service Provider glue (ports the provider half of AIAPITestCase): list the predefined
+ * providers and register a custom one. The custom no-auth provider is the prerequisite for creating an AIAPI
+ * subtype API whose backend is a mock LLM (built-in providers require real LLM credentials).
+ */
+public class AiApiSteps {
+
+    private String getBaseUrl() {
+        return TestContext.get("baseUrl").toString();
+    }
+
+    /** Admin — GET /ai-service-providers (lists predefined + custom providers). Stores the response. */
+    @When("I retrieve the AI service providers")
+    public void iRetrieveAiServiceProviders() throws Exception {
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.adminToken());
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doGet(Utils.getAIServiceProvidersURL(getBaseUrl()), headers);
+        TestContext.set("httpResponse", response);
+    }
+
+    /**
+     * Admin — POST /ai-service-providers (multipart): registers a custom AI service provider. Form fields
+     * name/apiVersion/description + the connector {@code configurations} JSON (inline) + the LLM
+     * {@code apiDefinition} OpenAPI file. Non-asserting; stores the created id on 2xx. Ports
+     * addCustomAiServiceProviderWithNoAuth.
+     *
+     * @param name       provider name (e.g. TestAIService)
+     * @param apiVersion provider api version (e.g. 1.0.0)
+     * @param configPath classpath path to the connector configuration JSON
+     * @param defPath    classpath path to the LLM OpenAPI definition
+     * @param idKey      context key to store the created provider id under
+     */
+    @When("I create an AI service provider {string} version {string} with config {string} and definition {string} as {string}")
+    public void iCreateAiServiceProvider(String name, String apiVersion, String configPath, String defPath,
+                                         String idKey) throws Exception {
+        String configurations = readClasspath(configPath);
+        File defFile = classpathToTempFile(defPath, ".json");
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.adminToken());
+        Map<String, String> formFields = new HashMap<>();
+        formFields.put("name", name);
+        formFields.put("apiVersion", apiVersion);
+        formFields.put("description", "AI service provider for integration tests (no-auth copy of MistralAI)");
+        formFields.put("configurations", configurations);
+        Map<String, File> files = new HashMap<>();
+        files.put("apiDefinition", defFile);
+
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doPostMultipartWithFiles(Utils.getAIServiceProvidersURL(getBaseUrl()), headers, files, formFields);
+        TestContext.set("httpResponse", response);
+        if (response.getResponseCode() >= 200 && response.getResponseCode() < 300) {
+            Object createdId = Utils.extractValueFromPayload(response.getData(), "id");
+            TestContext.set(idKey, createdId);
+            // Register for hook teardown — swept AFTER the AIAPI-subtype APIs that reference it (an AI provider
+            // delete is blocked by a foreign-key while any API still binds it). This also makes provider cleanup
+            // idempotent and failure-safe, instead of relying on an inline best-effort delete step.
+            ResourceCleanup.register(ResourceCleanup.CREATED_AI_PROVIDER_IDS, createdId);
+        }
+    }
+
+    /**
+     * As {@link #iCreateAiServiceProvider} but ALSO registers a model list on the provider via the
+     * {@code modelProviders} form field ({@code [{"models":[...],"name":"<provider>"}]}) — needed so the
+     * provider's model list can later be retrieved and asserted. {@code models} is a comma-separated list.
+     * Ports the model-registering half of AIAPITestCase's provider setup.
+     */
+    @When("I create an AI service provider {string} version {string} with config {string} definition {string} and models {string} as {string}")
+    public void iCreateAiServiceProviderWithModels(String name, String apiVersion, String configPath, String defPath,
+                                                   String models, String idKey) throws Exception {
+        String configurations = readClasspath(configPath);
+        File defFile = classpathToTempFile(defPath, ".json");
+
+        JSONArray modelArray = new JSONArray();
+        for (String m : models.split(",")) {
+            modelArray.put(m.trim());
+        }
+        String modelProviders = new JSONArray()
+                .put(new JSONObject().put("models", modelArray).put("name", name)).toString();
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.adminToken());
+        Map<String, String> formFields = new HashMap<>();
+        formFields.put("name", name);
+        formFields.put("apiVersion", apiVersion);
+        formFields.put("description", "AI service provider for integration tests (with a registered model list)");
+        formFields.put("configurations", configurations);
+        formFields.put("modelProviders", modelProviders);
+        Map<String, File> files = new HashMap<>();
+        files.put("apiDefinition", defFile);
+
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doPostMultipartWithFiles(Utils.getAIServiceProvidersURL(getBaseUrl()), headers, files, formFields);
+        TestContext.set("httpResponse", response);
+        if (response.getResponseCode() >= 200 && response.getResponseCode() < 300) {
+            Object createdId = Utils.extractValueFromPayload(response.getData(), "id");
+            TestContext.set(idKey, createdId);
+            ResourceCleanup.register(ResourceCleanup.CREATED_AI_PROVIDER_IDS, createdId);
+        }
+    }
+
+    /**
+     * Admin — PUT /ai-service-providers/{id} (multipart): updates a provider's configurations/description. Ports
+     * the update-provider case of AIAPITestCase. Non-asserting; stores the response.
+     */
+    @When("I update the AI service provider {string} named {string} version {string} to config {string} with definition {string} and description {string}")
+    public void iUpdateAiServiceProvider(String idKey, String name, String apiVersion, String configPath,
+                                         String defPath, String description) throws Exception {
+        Object id = Utils.resolveFromContext(idKey);
+        String configurations = readClasspath(configPath);
+        File defFile = classpathToTempFile(defPath, ".json");
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.adminToken());
+        Map<String, String> formFields = new HashMap<>();
+        formFields.put("name", name);
+        formFields.put("apiVersion", apiVersion);
+        formFields.put("description", description);
+        formFields.put("configurations", configurations);
+        Map<String, File> files = new HashMap<>();
+        files.put("apiDefinition", defFile);
+
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doPutMultipartWithFiles(Utils.getAIServiceProviderByIdURL(getBaseUrl(), id.toString()), headers,
+                        files, formFields);
+        TestContext.set("httpResponse", response);
+    }
+
+    /** Admin — GET /ai-service-providers/{id}. Retrieves a single provider (e.g. to assert an update persisted). */
+    @When("I retrieve the AI service provider {string}")
+    public void iRetrieveAiServiceProvider(String idKey) throws Exception {
+        Object id = Utils.resolveFromContext(idKey);
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.adminToken());
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doGet(Utils.getAIServiceProviderByIdURL(getBaseUrl(), id.toString()), headers);
+        TestContext.set("httpResponse", response);
+    }
+
+    /**
+     * Publisher — GET /ai-service-providers/{id}/models. Retrieves a provider's registered model list. Ports
+     * AIAPITestCase#testGetServiceProviderModels.
+     */
+    @When("I retrieve the models of AI service provider {string}")
+    public void iRetrieveAiServiceProviderModels(String idKey) throws Exception {
+        Object id = Utils.resolveFromContext(idKey);
+        Map<String, String> headers = new HashMap<>();
+        // The publisher models endpoint requires apim:llm_provider_read — carried by the admin token (llm provider
+        // scopes are admin-oriented; the publisher token's role does not grant them).
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.adminToken());
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doGet(Utils.getAIServiceProviderModelsURL(getBaseUrl(), id.toString()), headers);
+        TestContext.set("httpResponse", response);
+    }
+
+    /** Admin — DELETE /ai-service-providers/{id}. Best-effort provider teardown (no ResourceCleanup hook). */
+    @When("I delete the AI service provider {string}")
+    public void iDeleteAiServiceProvider(String idKey) throws Exception {
+        Object id = TestContext.get(idKey);
+        if (id == null) {
+            return;
+        }
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.adminToken());
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doDelete(Utils.getAIServiceProviderByIdURL(getBaseUrl(), id.toString()), headers);
+        TestContext.set("httpResponse", response);
+    }
+
+    /**
+     * Applies a built-in AI mediation operation policy (e.g. {@code modelWeightedRoundRobin}, {@code modelFailover})
+     * at the API level. Looks up the shipped COMMON policy by name to get its id, then GETs the API, injects an
+     * {@code apiPolicies.request} entry (policyType {@code common}) whose single {@code parameters.<paramName>}
+     * carries the config, and PUTs the API back. The config value's double-quotes are converted to single-quotes —
+     * the legacy contract for embedding a JSON config inside a String policy parameter. Ports the round-robin /
+     * failover policy-application of AIAPITestCase. {@code {{contextKey}}} placeholders in the config are resolved
+     * (e.g. a captured endpoint id).
+     *
+     * @param policyName the common policy name (must be shipped in the pack)
+     * @param paramName  the policy attribute name (weightedRoundRobinConfigs / failoverConfigs)
+     * @param configKey  context key (or inline value) holding the config JSON
+     * @param apiId      context key holding the API id
+     */
+    @When("I apply the AI mediation policy {string} with parameter {string} value {string} to API {string}")
+    public void iApplyAiMediationPolicy(String policyName, String paramName, String configKey, String apiId)
+            throws Exception {
+        String actualApiId = Utils.resolveFromContext(apiId).toString();
+        String config = Utils.resolveContextPlaceholders(Utils.resolveFromContext(configKey).toString());
+        // Legacy contract: the JSON config is embedded in a String parameter with single quotes.
+        String singleQuotedConfig = config.replace("\"", "'");
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
+
+        // 1. Resolve the shipped common policy's id by name.
+        HttpResponse listResp = SimpleHTTPClient.getInstance().doGet(Utils.getCommonPolicy(getBaseUrl()), headers);
+        String policyId = null;
+        JSONArray policies = new JSONObject(listResp.getData()).optJSONArray("list");
+        for (int i = 0; policies != null && i < policies.length(); i++) {
+            JSONObject p = policies.getJSONObject(i);
+            if (policyName.equals(p.optString("name"))) {
+                policyId = p.optString("id");
+                break;
+            }
+        }
+        if (policyId == null) {
+            throw new IllegalStateException("Common operation policy '" + policyName + "' not found in the pack");
+        }
+
+        // 2. GET the API, 3. inject apiPolicies.request, 4. PUT it back.
+        HttpResponse getApi = SimpleHTTPClient.getInstance()
+                .doGet(Utils.getResourceEndpointURL(getBaseUrl(), "apis", actualApiId), headers);
+        JSONObject api = new JSONObject(getApi.getData());
+        JSONObject policyEntry = new JSONObject()
+                .put("policyName", policyName)
+                .put("policyType", "common")
+                .put("policyId", policyId)
+                .put("parameters", new JSONObject().put(paramName, singleQuotedConfig));
+        JSONObject apiPolicies = new JSONObject()
+                .put("request", new JSONArray().put(policyEntry))
+                .put("response", new JSONArray())
+                .put("fault", new JSONArray());
+        api.put("apiPolicies", apiPolicies);
+
+        TestContext.remove("httpResponse");
+        HttpResponse putResp = SimpleHTTPClient.getInstance()
+                .doPut(Utils.getResourceEndpointURL(getBaseUrl(), "apis", actualApiId), headers, api.toString(),
+                        Constants.CONTENT_TYPES.APPLICATION_JSON);
+        TestContext.set("httpResponse", putResp);
+    }
+
+    /**
+     * Sets an AI API's {@code primaryProductionEndpointId} (GET the API, set the field, PUT it back). Needed for
+     * the failover test: the primary production endpoint must be the FAILOVER-TARGET endpoint so the gateway hits
+     * it first (429) and the modelFailover policy then retries the fallback model on the default endpoint.
+     */
+    @When("I set the primary production endpoint of API {string} to {string}")
+    public void iSetPrimaryProductionEndpoint(String apiId, String endpointId) throws Exception {
+        String actualApiId = Utils.resolveFromContext(apiId).toString();
+        String actualEndpointId = Utils.resolveFromContext(endpointId).toString();
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
+        HttpResponse getApi = SimpleHTTPClient.getInstance()
+                .doGet(Utils.getResourceEndpointURL(getBaseUrl(), "apis", actualApiId), headers);
+        JSONObject api = new JSONObject(getApi.getData());
+        api.put("primaryProductionEndpointId", actualEndpointId);
+        TestContext.remove("httpResponse");
+        HttpResponse putResp = SimpleHTTPClient.getInstance()
+                .doPut(Utils.getResourceEndpointURL(getBaseUrl(), "apis", actualApiId), headers, api.toString(),
+                        Constants.CONTENT_TYPES.APPLICATION_JSON);
+        TestContext.set("httpResponse", putResp);
+    }
+
+    private String readClasspath(String path) throws Exception {
+        try (InputStream in = getClass().getClassLoader().getResourceAsStream(path)) {
+            if (in == null) {
+                throw new FileNotFoundException("Resource not found: " + path);
+            }
+            return IOUtils.toString(in, StandardCharsets.UTF_8);
+        }
+    }
+
+    private File classpathToTempFile(String path, String suffix) throws Exception {
+        try (InputStream in = getClass().getClassLoader().getResourceAsStream(path)) {
+            if (in == null) {
+                throw new FileNotFoundException("Resource not found: " + path);
+            }
+            File temp = File.createTempFile("aidef", suffix);
+            temp.deleteOnExit();
+            Files.copy(in, temp.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            return temp;
+        }
+    }
+}

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/ApiEndpointSteps.java
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/ApiEndpointSteps.java
@@ -1,0 +1,117 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.wso2.am.integration.cucumbertests.stepdefinitions;
+
+import io.cucumber.java.en.When;
+import org.wso2.am.integration.cucumbertests.utils.Identity;
+import org.wso2.am.integration.cucumbertests.utils.TestContext;
+import org.wso2.am.integration.cucumbertests.utils.Utils;
+import org.wso2.am.integration.cucumbertests.utils.clients.SimpleHTTPClient;
+import org.wso2.am.integration.test.utils.Constants;
+import org.wso2.carbon.automation.test.utils.http.client.HttpResponse;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Publisher-plane glue for the API endpoints sub-resource ({@code /apis/{apiId}/endpoints}) — add, list, get,
+ * update and delete named endpoints on an API. Ports the endpoint-CRUD half of AIAPITestCase
+ * (testAddAiApiEndpoint / testGetApiEndpoints / testGetApiEndpoint / testUpdateApiEndpoint /
+ * testDeleteApiEndpoint). Endpoints are especially relevant for AIAPI-subtype APIs, which can carry several
+ * named production/sandbox endpoints (the basis for round-robin/failover routing), but the resource is
+ * general to any API. All operations use the publisher token; ids are resolved from and stored to context.
+ */
+public class ApiEndpointSteps {
+
+    private String getBaseUrl() {
+        return TestContext.get("baseUrl").toString();
+    }
+
+    private Map<String, String> publisherJsonHeaders() {
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
+        return headers;
+    }
+
+    /**
+     * POST /apis/{apiId}/endpoints — adds a named endpoint (body = APIEndpointDTO: name, deploymentStage,
+     * endpointConfig). Stores the created endpoint id under {@code idKey} on 2xx.
+     */
+    @When("I add an endpoint to API {string} with payload {string} as {string}")
+    public void iAddApiEndpoint(String apiId, String payload, String idKey) throws IOException {
+        String actualApiId = Utils.resolveFromContext(apiId).toString();
+        String jsonPayload = Utils.resolveFromContext(payload).toString();
+
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doPost(Utils.getApiEndpointsURL(getBaseUrl(), actualApiId), publisherJsonHeaders(), jsonPayload,
+                        Constants.CONTENT_TYPES.APPLICATION_JSON);
+        TestContext.set("httpResponse", response);
+        if (response.getResponseCode() >= 200 && response.getResponseCode() < 300) {
+            TestContext.set(idKey, Utils.extractValueFromPayload(response.getData(), "id"));
+        }
+    }
+
+    /** GET /apis/{apiId}/endpoints — lists all endpoints of the API. */
+    @When("I retrieve the endpoints of API {string}")
+    public void iRetrieveApiEndpoints(String apiId) throws IOException {
+        String actualApiId = Utils.resolveFromContext(apiId).toString();
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doGet(Utils.getApiEndpointsURL(getBaseUrl(), actualApiId), publisherJsonHeaders());
+        TestContext.set("httpResponse", response);
+    }
+
+    /** GET /apis/{apiId}/endpoints/{endpointId} — retrieves a single endpoint by id. */
+    @When("I retrieve endpoint {string} of API {string}")
+    public void iRetrieveApiEndpoint(String endpointId, String apiId) throws IOException {
+        String actualApiId = Utils.resolveFromContext(apiId).toString();
+        String actualEndpointId = Utils.resolveFromContext(endpointId).toString();
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doGet(Utils.getApiEndpointByIdURL(getBaseUrl(), actualApiId, actualEndpointId),
+                        publisherJsonHeaders());
+        TestContext.set("httpResponse", response);
+    }
+
+    /** PUT /apis/{apiId}/endpoints/{endpointId} — updates a single endpoint (body = full APIEndpointDTO). */
+    @When("I update endpoint {string} of API {string} with payload {string}")
+    public void iUpdateApiEndpoint(String endpointId, String apiId, String payload) throws IOException {
+        String actualApiId = Utils.resolveFromContext(apiId).toString();
+        String actualEndpointId = Utils.resolveFromContext(endpointId).toString();
+        String jsonPayload = Utils.resolveFromContext(payload).toString();
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doPut(Utils.getApiEndpointByIdURL(getBaseUrl(), actualApiId, actualEndpointId),
+                        publisherJsonHeaders(), jsonPayload, Constants.CONTENT_TYPES.APPLICATION_JSON);
+        TestContext.set("httpResponse", response);
+    }
+
+    /** DELETE /apis/{apiId}/endpoints/{endpointId} — removes a single endpoint. */
+    @When("I delete endpoint {string} of API {string}")
+    public void iDeleteApiEndpoint(String endpointId, String apiId) throws IOException {
+        String actualApiId = Utils.resolveFromContext(apiId).toString();
+        String actualEndpointId = Utils.resolveFromContext(endpointId).toString();
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doDelete(Utils.getApiEndpointByIdURL(getBaseUrl(), actualApiId, actualEndpointId),
+                        publisherJsonHeaders());
+        TestContext.set("httpResponse", response);
+    }
+}

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/ApiEndpointSteps.java
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/ApiEndpointSteps.java
@@ -19,9 +19,9 @@ package org.wso2.am.integration.cucumbertests.stepdefinitions;
 
 import io.cucumber.java.en.When;
 import org.wso2.am.integration.cucumbertests.utils.Identity;
+import org.wso2.am.integration.cucumbertests.utils.Requests;
 import org.wso2.am.integration.cucumbertests.utils.TestContext;
 import org.wso2.am.integration.cucumbertests.utils.Utils;
-import org.wso2.am.integration.cucumbertests.utils.clients.SimpleHTTPClient;
 import org.wso2.am.integration.test.utils.Constants;
 import org.wso2.carbon.automation.test.utils.http.client.HttpResponse;
 
@@ -55,14 +55,11 @@ public class ApiEndpointSteps {
      */
     @When("I add an endpoint to API {string} with payload {string} as {string}")
     public void iAddApiEndpoint(String apiId, String payload, String idKey) throws IOException {
-        String actualApiId = Utils.resolveFromContext(apiId).toString();
-        String jsonPayload = Utils.resolveFromContext(payload).toString();
+        String actualApiId = TestContext.resolve(apiId).toString();
+        String jsonPayload = TestContext.resolve(payload).toString();
 
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPost(Utils.getApiEndpointsURL(getBaseUrl(), actualApiId), publisherJsonHeaders(), jsonPayload,
-                        Constants.CONTENT_TYPES.APPLICATION_JSON);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.post(Utils.getApiEndpointsURL(getBaseUrl(), actualApiId),
+                publisherJsonHeaders(), jsonPayload, Constants.CONTENT_TYPES.APPLICATION_JSON);
         if (response.getResponseCode() >= 200 && response.getResponseCode() < 300) {
             TestContext.set(idKey, Utils.extractValueFromPayload(response.getData(), "id"));
         }
@@ -71,47 +68,36 @@ public class ApiEndpointSteps {
     /** GET /apis/{apiId}/endpoints — lists all endpoints of the API. */
     @When("I retrieve the endpoints of API {string}")
     public void iRetrieveApiEndpoints(String apiId) throws IOException {
-        String actualApiId = Utils.resolveFromContext(apiId).toString();
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doGet(Utils.getApiEndpointsURL(getBaseUrl(), actualApiId), publisherJsonHeaders());
-        TestContext.set("httpResponse", response);
+        String actualApiId = TestContext.resolve(apiId).toString();
+        HttpResponse response = Requests.get(Utils.getApiEndpointsURL(getBaseUrl(), actualApiId),
+                publisherJsonHeaders());
     }
 
     /** GET /apis/{apiId}/endpoints/{endpointId} — retrieves a single endpoint by id. */
     @When("I retrieve endpoint {string} of API {string}")
     public void iRetrieveApiEndpoint(String endpointId, String apiId) throws IOException {
-        String actualApiId = Utils.resolveFromContext(apiId).toString();
-        String actualEndpointId = Utils.resolveFromContext(endpointId).toString();
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doGet(Utils.getApiEndpointByIdURL(getBaseUrl(), actualApiId, actualEndpointId),
-                        publisherJsonHeaders());
-        TestContext.set("httpResponse", response);
+        String actualApiId = TestContext.resolve(apiId).toString();
+        String actualEndpointId = TestContext.resolve(endpointId).toString();
+        HttpResponse response = Requests.get(Utils.getApiEndpointByIdURL(getBaseUrl(), actualApiId, actualEndpointId),
+                publisherJsonHeaders());
     }
 
     /** PUT /apis/{apiId}/endpoints/{endpointId} — updates a single endpoint (body = full APIEndpointDTO). */
     @When("I update endpoint {string} of API {string} with payload {string}")
     public void iUpdateApiEndpoint(String endpointId, String apiId, String payload) throws IOException {
-        String actualApiId = Utils.resolveFromContext(apiId).toString();
-        String actualEndpointId = Utils.resolveFromContext(endpointId).toString();
-        String jsonPayload = Utils.resolveFromContext(payload).toString();
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPut(Utils.getApiEndpointByIdURL(getBaseUrl(), actualApiId, actualEndpointId),
-                        publisherJsonHeaders(), jsonPayload, Constants.CONTENT_TYPES.APPLICATION_JSON);
-        TestContext.set("httpResponse", response);
+        String actualApiId = TestContext.resolve(apiId).toString();
+        String actualEndpointId = TestContext.resolve(endpointId).toString();
+        String jsonPayload = TestContext.resolve(payload).toString();
+        HttpResponse response = Requests.put(Utils.getApiEndpointByIdURL(getBaseUrl(), actualApiId, actualEndpointId),
+                publisherJsonHeaders(), jsonPayload, Constants.CONTENT_TYPES.APPLICATION_JSON);
     }
 
     /** DELETE /apis/{apiId}/endpoints/{endpointId} — removes a single endpoint. */
     @When("I delete endpoint {string} of API {string}")
     public void iDeleteApiEndpoint(String endpointId, String apiId) throws IOException {
-        String actualApiId = Utils.resolveFromContext(apiId).toString();
-        String actualEndpointId = Utils.resolveFromContext(endpointId).toString();
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doDelete(Utils.getApiEndpointByIdURL(getBaseUrl(), actualApiId, actualEndpointId),
-                        publisherJsonHeaders());
-        TestContext.set("httpResponse", response);
+        String actualApiId = TestContext.resolve(apiId).toString();
+        String actualEndpointId = TestContext.resolve(endpointId).toString();
+        HttpResponse response = Requests.delete(Utils.getApiEndpointByIdURL(getBaseUrl(), actualApiId,
+                actualEndpointId), publisherJsonHeaders());
     }
 }

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/ApplicationBaseSteps.java
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/ApplicationBaseSteps.java
@@ -24,6 +24,7 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import org.testng.Assert;
 import org.wso2.am.integration.cucumbertests.utils.Identity;
+import org.wso2.am.integration.cucumbertests.utils.Names;
 import org.wso2.am.integration.cucumbertests.utils.ResourceCleanup;
 import org.wso2.am.integration.cucumbertests.utils.TestContext;
 import org.wso2.am.integration.cucumbertests.utils.Utils;
@@ -32,7 +33,9 @@ import org.wso2.am.integration.test.utils.Constants;
 import org.wso2.carbon.automation.engine.context.beans.User;
 import org.wso2.carbon.automation.test.utils.http.client.HttpResponse;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.HashMap;
@@ -87,7 +90,7 @@ public class ApplicationBaseSteps {
     @When("I create an application throttling policy {string} allowing {int} requests per minute")
     public void iCreateApplicationThrottlingPolicy(String policyBaseName, int requestsPerMinute) throws IOException {
 
-        String policyName = Utils.resolvePayloadPlaceholders(policyBaseName);
+        String policyName = Utils.resolveContextPlaceholders(Utils.resolvePayloadPlaceholders(policyBaseName));
         String payload = String.format(
                 "{\"policyName\":\"%s\",\"displayName\":\"%s\",\"description\":\"Throttle-enforcement test: %d req/min\","
                         + "\"type\":\"ApplicationThrottlePolicy\",\"defaultLimit\":{\"type\":\"REQUESTCOUNTLIMIT\","
@@ -131,23 +134,39 @@ public class ApplicationBaseSteps {
     @When("I create a subscription throttling policy {string} allowing {int} requests per minute with burst limit {int} per minute")
     public void iCreateSubscriptionThrottlingPolicyWithBurst(String policyBaseName, int requestsPerMinute,
                                                              int burstPerMinute) throws IOException {
-        createSubscriptionThrottlingPolicy(policyBaseName, requestsPerMinute, burstPerMinute);
+        createSubscriptionThrottlingPolicy(policyBaseName, requestsPerMinute, burstPerMinute, "Internal/everyone");
+    }
+
+    /**
+     * As above but ALLOW-restricted to a single role, so the tier is usable only by users in that role (a user
+     * outside it is refused at subscribe time with 403 "Tier … is not allowed"). Ports the role-restricted-tier
+     * check of SubscriptionThrottlingPolicyTestCase.
+     */
+    @When("I create a subscription throttling policy {string} allowing {int} requests per minute restricted to role {string}")
+    public void iCreateRestrictedSubscriptionThrottlingPolicy(String policyBaseName, int requestsPerMinute,
+                                                              String role) throws IOException {
+        createSubscriptionThrottlingPolicy(policyBaseName, requestsPerMinute, 0, role);
     }
 
     private void createSubscriptionThrottlingPolicy(String policyBaseName, int requestsPerMinute, int burstPerMinute)
             throws IOException {
+        createSubscriptionThrottlingPolicy(policyBaseName, requestsPerMinute, burstPerMinute, "Internal/everyone");
+    }
 
-        String policyName = Utils.resolvePayloadPlaceholders(policyBaseName);
+    private void createSubscriptionThrottlingPolicy(String policyBaseName, int requestsPerMinute, int burstPerMinute,
+                                                    String allowRole) throws IOException {
+
+        String policyName = Utils.resolveContextPlaceholders(Utils.resolvePayloadPlaceholders(policyBaseName));
         String payload = String.format(
                 "{\"policyName\":\"%s\",\"displayName\":\"%s\",\"description\":\"Throttle-enforcement test: %d req/min,"
                         + " burst %d/min\",\"type\":\"SubscriptionThrottlePolicy\",\"defaultLimit\":{\"type\":"
                         + "\"REQUESTCOUNTLIMIT\",\"requestCount\":{\"timeUnit\":\"min\",\"unitTime\":1,"
                         + "\"requestCount\":%d}},\"rateLimitCount\":%d,\"rateLimitTimeUnit\":\"min\","
                         + "\"stopOnQuotaReach\":true,\"billingPlan\":\"FREE\",\"customAttributes\":[],"
-                        // Subscription tiers are role-gated: without an ALLOW permission the tier is rejected as
-                        // "not allowed for user" (902002) at subscribe time. Internal/everyone → usable by any actor.
-                        + "\"permissions\":{\"permissionType\":\"ALLOW\",\"roles\":[\"Internal/everyone\"]}}",
-                policyName, policyName, requestsPerMinute, burstPerMinute, requestsPerMinute, burstPerMinute);
+                        // Subscription tiers are role-gated: a user lacking an ALLOW-listed role is refused the tier
+                        // at subscribe time (403 "not allowed"). Default Internal/everyone → usable by any actor.
+                        + "\"permissions\":{\"permissionType\":\"ALLOW\",\"roles\":[\"%s\"]}}",
+                policyName, policyName, requestsPerMinute, burstPerMinute, requestsPerMinute, burstPerMinute, allowRole);
 
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.adminToken());
@@ -176,7 +195,7 @@ public class ApplicationBaseSteps {
     @When("I create an advanced throttling policy {string} allowing {int} requests per minute")
     public void iCreateAdvancedThrottlingPolicy(String policyBaseName, int requestsPerMinute) throws IOException {
 
-        String policyName = Utils.resolvePayloadPlaceholders(policyBaseName);
+        String policyName = Utils.resolveContextPlaceholders(Utils.resolvePayloadPlaceholders(policyBaseName));
         String payload = String.format(
                 "{\"policyName\":\"%s\",\"displayName\":\"%s\",\"description\":\"Throttle-enforcement test: %d req/min\","
                         + "\"type\":\"AdvancedThrottlePolicy\",\"defaultLimit\":{\"type\":\"REQUESTCOUNTLIMIT\","
@@ -202,6 +221,433 @@ public class ApplicationBaseSteps {
         }
     }
 
+    // ---- Admin throttling-policy CRUD breadth (application/subscription/advanced/custom) ----
+
+    private void postAdminPolicy(String listUrl, String payload, String nameKey, String policyName, String idKey,
+                                 String cleanupListKey) throws IOException {
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.adminToken());
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doPost(listUrl, headers, payload, Constants.CONTENT_TYPES.APPLICATION_JSON);
+        TestContext.set("httpResponse", response);
+        TestContext.set(nameKey, policyName);
+        if (response.getResponseCode() >= 200 && response.getResponseCode() < 300) {
+            Object policyId = Utils.extractValueFromPayload(response.getData(), "policyId");
+            if (policyId != null) {
+                TestContext.set(idKey, policyId);
+                ResourceCleanup.register(cleanupListKey, policyId);
+            }
+        }
+    }
+
+    /** Subscription throttling policy with a BANDWIDTH limit (KB/min). */
+    @When("I create a subscription throttling policy {string} allowing {int} KB per minute")
+    public void iCreateSubscriptionBandwidthPolicy(String policyBaseName, int kbPerMinute) throws IOException {
+        String policyName = Utils.resolveContextPlaceholders(Utils.resolvePayloadPlaceholders(policyBaseName));
+        String payload = String.format(
+                "{\"policyName\":\"%s\",\"displayName\":\"%s\",\"description\":\"Subscription bandwidth %d KB/min\","
+                        + "\"type\":\"SubscriptionThrottlePolicy\",\"defaultLimit\":{\"type\":\"BANDWIDTHLIMIT\","
+                        + "\"bandwidth\":{\"timeUnit\":\"min\",\"unitTime\":1,\"dataAmount\":%d,\"dataUnit\":\"KB\"}},"
+                        + "\"rateLimitCount\":0,\"rateLimitTimeUnit\":\"min\",\"stopOnQuotaReach\":true,"
+                        + "\"billingPlan\":\"FREE\",\"customAttributes\":[],"
+                        + "\"permissions\":{\"permissionType\":\"ALLOW\",\"roles\":[\"Internal/everyone\"]}}",
+                policyName, policyName, kbPerMinute, kbPerMinute);
+        postAdminPolicy(Utils.getSubscriptionThrottlingPoliciesURL(getBaseUrl()), payload, "subThrottlePolicyName",
+                policyName, "subThrottlePolicyId", Constants.CREATED_SUBSCRIPTION_POLICY_IDS);
+    }
+
+    /**
+     * Subscription throttling policy with an AI TOKEN QUOTA limit (total tokens/min) — the quota enforced on
+     * AIAPI-subtype APIs. The gateway accumulates the token counts each backend LLM response reports (usage.*)
+     * against this quota and returns 429 once it is exceeded. requestCount and the prompt/completion sub-limits
+     * are set high so the TOTAL-token quota is unambiguously what trips. Ports the AI token-throttling aspect of
+     * the AI-API suite (the Gemini restart variant is parked). Stores {@code subThrottlePolicyName}/
+     * {@code subThrottlePolicyId} and registers the id for owner-aware teardown.
+     */
+    @When("I create a subscription throttling policy {string} allowing {int} total tokens per minute")
+    public void iCreateSubscriptionAiTokenQuotaPolicy(String policyBaseName, int totalTokensPerMinute)
+            throws IOException {
+        String policyName = Utils.resolveContextPlaceholders(Utils.resolvePayloadPlaceholders(policyBaseName));
+        String payload = String.format(
+                "{\"policyName\":\"%s\",\"displayName\":\"%s\",\"description\":\"AI token quota %d tokens/min\","
+                        + "\"type\":\"SubscriptionThrottlePolicy\",\"defaultLimit\":{\"type\":\"AIAPIQUOTALIMIT\","
+                        + "\"aiApiQuota\":{\"timeUnit\":\"min\",\"unitTime\":1,\"requestCount\":1000000,"
+                        + "\"totalTokenCount\":%d,\"promptTokenCount\":1000000,\"completionTokenCount\":1000000}},"
+                        + "\"rateLimitCount\":0,\"rateLimitTimeUnit\":\"min\",\"stopOnQuotaReach\":true,"
+                        + "\"billingPlan\":\"FREE\",\"customAttributes\":[],"
+                        + "\"permissions\":{\"permissionType\":\"ALLOW\",\"roles\":[\"Internal/everyone\"]}}",
+                policyName, policyName, totalTokensPerMinute, totalTokensPerMinute);
+        postAdminPolicy(Utils.getSubscriptionThrottlingPoliciesURL(getBaseUrl()), payload, "subThrottlePolicyName",
+                policyName, "subThrottlePolicyId", Constants.CREATED_SUBSCRIPTION_POLICY_IDS);
+    }
+
+    /**
+     * Subscription throttling policy with an EVENT-COUNT limit (events/min) — the ASYNC (streaming) quota enforced
+     * on WebSocket / WebSub / SSE APIs. Per the streaming rate-limiting docs the gateway counts each WS frame (both
+     * directions) as an event and throttles the connection once the count is exceeded. An EVENTCOUNTLIMIT
+     * subscription policy is an async plan, so a streaming API can offer it. Stores {@code subThrottlePolicyName}/
+     * {@code subThrottlePolicyId} and registers the id for owner-aware teardown.
+     */
+    @When("I create a subscription throttling policy {string} allowing {int} events per minute")
+    public void iCreateSubscriptionEventCountPolicy(String policyBaseName, int eventsPerMinute) throws IOException {
+        String policyName = Utils.resolveContextPlaceholders(Utils.resolvePayloadPlaceholders(policyBaseName));
+        String payload = String.format(
+                "{\"policyName\":\"%s\",\"displayName\":\"%s\",\"description\":\"Streaming event quota %d events/min\","
+                        + "\"type\":\"SubscriptionThrottlePolicy\",\"defaultLimit\":{\"type\":\"EVENTCOUNTLIMIT\","
+                        + "\"eventCount\":{\"timeUnit\":\"min\",\"unitTime\":1,\"eventCount\":%d}},"
+                        + "\"rateLimitCount\":0,\"rateLimitTimeUnit\":\"min\",\"stopOnQuotaReach\":true,"
+                        + "\"billingPlan\":\"FREE\",\"customAttributes\":[],"
+                        + "\"permissions\":{\"permissionType\":\"ALLOW\",\"roles\":[\"Internal/everyone\"]}}",
+                policyName, policyName, eventsPerMinute, eventsPerMinute);
+        postAdminPolicy(Utils.getSubscriptionThrottlingPoliciesURL(getBaseUrl()), payload, "subThrottlePolicyName",
+                policyName, "subThrottlePolicyId", Constants.CREATED_SUBSCRIPTION_POLICY_IDS);
+    }
+
+    /**
+     * Creates a SubscriptionThrottlePolicy carrying GraphQL query-analysis limits ({@code graphQLMaxComplexity} /
+     * {@code graphQLMaxDepth}) with a high request-count default (so only complexity/depth trips). Ports the
+     * QueryComplexPolicy / QueryDepthPolicy of GraphqlSubscriptionTestCase.
+     */
+    @When("I create a subscription throttling policy {string} with max complexity {int} and max depth {int}")
+    public void iCreateSubscriptionGraphQLPolicy(String policyBaseName, int maxComplexity, int maxDepth)
+            throws IOException {
+        String policyName = Utils.resolveContextPlaceholders(Utils.resolvePayloadPlaceholders(policyBaseName));
+        String payload = String.format(
+                "{\"policyName\":\"%s\",\"displayName\":\"%s\",\"description\":\"GraphQL query limits: complexity %d,"
+                        + " depth %d\",\"type\":\"SubscriptionThrottlePolicy\",\"defaultLimit\":{"
+                        + "\"type\":\"REQUESTCOUNTLIMIT\",\"requestCount\":{\"timeUnit\":\"min\",\"unitTime\":1,"
+                        + "\"requestCount\":1000}},\"graphQLMaxComplexity\":%d,\"graphQLMaxDepth\":%d,"
+                        + "\"rateLimitCount\":0,\"rateLimitTimeUnit\":\"min\",\"stopOnQuotaReach\":true,"
+                        + "\"billingPlan\":\"FREE\",\"customAttributes\":[],"
+                        + "\"permissions\":{\"permissionType\":\"ALLOW\",\"roles\":[\"Internal/everyone\"]}}",
+                policyName, policyName, maxComplexity, maxDepth, maxComplexity, maxDepth);
+        postAdminPolicy(Utils.getSubscriptionThrottlingPoliciesURL(getBaseUrl()), payload, "subThrottlePolicyName",
+                policyName, "subThrottlePolicyId", Constants.CREATED_SUBSCRIPTION_POLICY_IDS);
+    }
+
+    /**
+     * Sets an API's per-field GraphQL complexity values (PUT /apis/{id}/graphql-policies/complexity). Ports
+     * addGraphQLComplexityDetails — the per-field weights the gateway sums to compute a query's complexity.
+     */
+    @When("I set the GraphQL complexity for API {string} from payload {string}")
+    public void iSetGraphqlComplexity(String apiId, String payloadKey) throws IOException {
+        String actualApiId = Utils.resolveFromContext(apiId).toString();
+        String payload = Utils.resolveFromContext(payloadKey).toString();
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doPut(Utils.getGraphQLComplexityURL(getBaseUrl(), actualApiId), headers, payload,
+                        Constants.CONTENT_TYPES.APPLICATION_JSON);
+        TestContext.set("httpResponse", response);
+    }
+
+    /** Advanced (API-level) throttling policy with a BANDWIDTH limit (KB/min). */
+    @When("I create an advanced throttling policy {string} allowing {int} KB per minute")
+    public void iCreateAdvancedBandwidthPolicy(String policyBaseName, int kbPerMinute) throws IOException {
+        String policyName = Utils.resolveContextPlaceholders(Utils.resolvePayloadPlaceholders(policyBaseName));
+        String payload = String.format(
+                "{\"policyName\":\"%s\",\"displayName\":\"%s\",\"description\":\"Advanced bandwidth %d KB/min\","
+                        + "\"type\":\"AdvancedThrottlePolicy\",\"defaultLimit\":{\"type\":\"BANDWIDTHLIMIT\","
+                        + "\"bandwidth\":{\"timeUnit\":\"min\",\"unitTime\":1,\"dataAmount\":%d,\"dataUnit\":\"KB\"}},"
+                        + "\"conditionalGroups\":[]}",
+                policyName, policyName, kbPerMinute, kbPerMinute);
+        postAdminPolicy(Utils.getAdvancedThrottlingPoliciesURL(getBaseUrl()), payload, "advThrottlePolicyName",
+                policyName, "advThrottlePolicyId", Constants.CREATED_ADVANCED_POLICY_IDS);
+    }
+
+    /** Advanced throttling policy with a conditional group (a header-condition-gated sub-limit). */
+    @When("I create an advanced throttling policy {string} allowing {int} requests per minute with a header conditional group")
+    public void iCreateAdvancedConditionalPolicy(String policyBaseName, int requestsPerMinute) throws IOException {
+        String policyName = Utils.resolveContextPlaceholders(Utils.resolvePayloadPlaceholders(policyBaseName));
+        String payload = String.format(
+                "{\"policyName\":\"%s\",\"displayName\":\"%s\",\"description\":\"Advanced with conditional group\","
+                        + "\"type\":\"AdvancedThrottlePolicy\",\"defaultLimit\":{\"type\":\"REQUESTCOUNTLIMIT\","
+                        + "\"requestCount\":{\"timeUnit\":\"min\",\"unitTime\":1,\"requestCount\":%d}},"
+                        + "\"conditionalGroups\":[{\"description\":\"gold-header group\",\"conditions\":[{\"type\":"
+                        + "\"HEADERCONDITION\",\"invertCondition\":false,\"headerCondition\":{\"headerName\":"
+                        + "\"X-Tier\",\"headerValue\":\"gold\"}}],\"limit\":{\"type\":\"REQUESTCOUNTLIMIT\","
+                        + "\"requestCount\":{\"timeUnit\":\"min\",\"unitTime\":1,\"requestCount\":%d}}}]}",
+                policyName, policyName, requestsPerMinute, requestsPerMinute);
+        postAdminPolicy(Utils.getAdvancedThrottlingPoliciesURL(getBaseUrl()), payload, "advThrottlePolicyName",
+                policyName, "advThrottlePolicyId", Constants.CREATED_ADVANCED_POLICY_IDS);
+    }
+
+    /** Generic retrieve of a throttling policy by type + id (admin API). Non-asserting. */
+    @When("I retrieve the {string} throttling policy with id {string}")
+    public void iRetrieveThrottlingPolicyByType(String policyType, String idKey) throws IOException {
+        String policyId = Utils.resolveFromContext(idKey).toString();
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.adminToken());
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doGet(Utils.getThrottlingPolicyByTypeURL(getBaseUrl(), policyType, policyId), headers);
+        TestContext.set("httpResponse", response);
+    }
+
+    /** Generic delete of a throttling policy by type + id (admin API). Non-asserting (also used for 404 checks). */
+    @When("I delete the {string} throttling policy with id {string}")
+    public void iDeleteThrottlingPolicyByType(String policyType, String idKey) throws IOException {
+        String policyId = Utils.resolveFromContext(idKey).toString();
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.adminToken());
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doDelete(Utils.getThrottlingPolicyByTypeURL(getBaseUrl(), policyType, policyId), headers);
+        TestContext.set("httpResponse", response);
+    }
+
+    /** Generic update: retrieve the policy, set a new description, and PUT it back. */
+    @When("I update the {string} throttling policy {string} setting its description to {string}")
+    public void iUpdateThrottlingPolicyDescription(String policyType, String idKey, String description)
+            throws IOException {
+        String policyId = Utils.resolveFromContext(idKey).toString();
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.adminToken());
+        String url = Utils.getThrottlingPolicyByTypeURL(getBaseUrl(), policyType, policyId);
+        HttpResponse getResp = SimpleHTTPClient.getInstance().doGet(url, headers);
+        JSONObject policy = new JSONObject(getResp.getData());
+        policy.put("description", description);
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doPut(url, headers, policy.toString(), Constants.CONTENT_TYPES.APPLICATION_JSON);
+        TestContext.set("httpResponse", response);
+    }
+
+    /** Retrieve all throttling policies of a type (admin API). Non-asserting. */
+    @When("I retrieve all {string} throttling policies")
+    public void iRetrieveAllThrottlingPolicies(String policyType) throws IOException {
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.adminToken());
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doGet(Utils.getThrottlingPoliciesByTypeURL(getBaseUrl(), policyType), headers);
+        TestContext.set("httpResponse", response);
+    }
+
+    // ---- Admin gateway environment CRUD ----
+
+    private void createGatewayEnvironment(String name, String displayName, String host, String gatewayType)
+            throws IOException {
+        createGatewayEnvironment(name, displayName, host, gatewayType, null);
+    }
+
+    private void createGatewayEnvironment(String name, String displayName, String host, String gatewayType,
+                                          String allowRole) throws IOException {
+        JSONObject env = new JSONObject()
+                .put("name", name)
+                .put("displayName", displayName)
+                .put("description", "Gateway environment CRUD test")
+                .put("provider", "wso2")
+                .put("isReadOnly", false);
+        if (allowRole != null && !allowRole.isBlank()) {
+            env.put("permissions", new JSONObject()
+                    .put("permissionType", "ALLOW")
+                    .put("roles", new JSONArray().put(allowRole)));
+        }
+        JSONArray vhosts = new JSONArray();
+        boolean typedGateway = gatewayType != null && !gatewayType.isBlank();
+        if (host != null && !host.isBlank()) {
+            JSONObject vhost = new JSONObject().put("host", host).put("httpPort", 8280).put("httpsPort", 8243);
+            if (typedGateway) {
+                // Non-Regular gateways (e.g. APK) reject ws/wss ports and expect an httpContext.
+                vhost.put("httpContext", "gwctx");
+            } else {
+                vhost.put("httpContext", "").put("wsPort", 9099).put("wssPort", 8099);
+            }
+            vhosts.put(vhost);
+        }
+        env.put("vhosts", vhosts);
+        if (typedGateway) {
+            env.put("gatewayType", gatewayType);
+        }
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.adminToken());
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doPost(Utils.getEnvironmentsURL(getBaseUrl()), headers, env.toString(),
+                        Constants.CONTENT_TYPES.APPLICATION_JSON);
+        TestContext.set("httpResponse", response);
+        if (response.getResponseCode() >= 200 && response.getResponseCode() < 300) {
+            Object id = Utils.extractValueFromPayload(response.getData(), "id");
+            if (id != null) {
+                TestContext.set("environmentId", id);
+                ResourceCleanup.register(Constants.CREATED_ENVIRONMENT_IDS, id);
+            }
+        }
+    }
+
+    /** Create a gateway environment (single vhost). Non-asserting — feature confirms 201 or the negative code. */
+    @When("I create a gateway environment with name {string} display name {string} and vhost host {string}")
+    public void iCreateGatewayEnvironment(String nameBase, String displayName, String host) throws IOException {
+        createGatewayEnvironment(Utils.resolvePayloadPlaceholders(nameBase), displayName, host, null);
+    }
+
+    /** Create a gateway environment with a specific gateway type (e.g. APK). */
+    @When("I create a gateway environment {string} with vhost host {string} and gateway type {string}")
+    public void iCreateGatewayEnvironmentWithType(String nameBase, String host, String gatewayType) throws IOException {
+        String name = Utils.resolvePayloadPlaceholders(nameBase);
+        createGatewayEnvironment(name, name, host, gatewayType);
+    }
+
+    /**
+     * Create a gateway environment with an ALLOW role permission (only users in that role may use it). Salvages
+     * the (legacy-commented) env-permissions test as an admin-plane CRUD assertion: the permission persists.
+     */
+    @When("I create a gateway environment {string} with vhost host {string} allowing role {string}")
+    public void iCreateGatewayEnvironmentAllowingRole(String nameBase, String host, String role) throws IOException {
+        String name = Utils.resolvePayloadPlaceholders(nameBase);
+        createGatewayEnvironment(name, name, host, null, role);
+    }
+
+    /** Retrieve all gateway environments (admin API). */
+    @When("I retrieve all gateway environments")
+    public void iRetrieveAllGatewayEnvironments() throws IOException {
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.adminToken());
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doGet(Utils.getEnvironmentsURL(getBaseUrl()), headers);
+        TestContext.set("httpResponse", response);
+    }
+
+    /** Retrieve a gateway environment by id (admin API). */
+    @When("I retrieve the gateway environment with id {string}")
+    public void iRetrieveGatewayEnvironment(String idKey) throws IOException {
+        String id = Utils.resolveFromContext(idKey).toString();
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.adminToken());
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doGet(Utils.getEnvironmentByIdURL(getBaseUrl(), id), headers);
+        TestContext.set("httpResponse", response);
+    }
+
+    /** Update a gateway environment's description (GET → set → PUT). */
+    @When("I update the gateway environment {string} setting its description to {string}")
+    public void iUpdateGatewayEnvironment(String idKey, String description) throws IOException {
+        String id = Utils.resolveFromContext(idKey).toString();
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.adminToken());
+        String url = Utils.getEnvironmentByIdURL(getBaseUrl(), id);
+        HttpResponse getResp = SimpleHTTPClient.getInstance().doGet(url, headers);
+        JSONObject env = new JSONObject(getResp.getData());
+        env.put("description", description);
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doPut(url, headers, env.toString(), Constants.CONTENT_TYPES.APPLICATION_JSON);
+        TestContext.set("httpResponse", response);
+    }
+
+    /** Delete a gateway environment by id (admin API). Non-asserting (also used for 404 / delete-Default 400).
+     *  The id may be a context key (e.g. {@code environmentId}) or a literal id such as {@code Default}. */
+    @When("I delete the gateway environment with id {string}")
+    public void iDeleteGatewayEnvironment(String idKey) throws IOException {
+        String id = TestContext.contains(idKey) ? TestContext.get(idKey).toString() : idKey;
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.adminToken());
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doDelete(Utils.getEnvironmentByIdURL(getBaseUrl(), id), headers);
+        TestContext.set("httpResponse", response);
+    }
+
+    /** Retrieve the gateway instances of an environment (admin API). The id may be a context key
+     *  (e.g. {@code environmentId}) or a literal environment id such as {@code Default}. */
+    @When("I retrieve the gateway instances of environment {string}")
+    public void iRetrieveGatewayInstances(String idKey) throws IOException {
+        String id = TestContext.contains(idKey) ? TestContext.get(idKey).toString() : idKey;
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.adminToken());
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doGet(Utils.getEnvironmentGatewaysURL(getBaseUrl(), id), headers);
+        TestContext.set("httpResponse", response);
+    }
+
+    /** A vhost JSON object for a Regular (Synapse) gateway — http/https/ws/wss ports. */
+    private static JSONObject regularVhost(String host) {
+        return new JSONObject().put("host", host).put("httpContext", "")
+                .put("httpPort", 8280).put("httpsPort", 8243).put("wsPort", 9099).put("wssPort", 8099);
+    }
+
+    /** POST an environment payload, storing/registering the id on success. Non-asserting. */
+    private void postEnvironment(JSONObject env) throws IOException {
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.adminToken());
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doPost(Utils.getEnvironmentsURL(getBaseUrl()), headers, env.toString(),
+                        Constants.CONTENT_TYPES.APPLICATION_JSON);
+        TestContext.set("httpResponse", response);
+        if (response.getResponseCode() >= 200 && response.getResponseCode() < 300) {
+            Object id = Utils.extractValueFromPayload(response.getData(), "id");
+            if (id != null) {
+                TestContext.set("environmentId", id);
+                ResourceCleanup.register(Constants.CREATED_ENVIRONMENT_IDS, id);
+            }
+        }
+    }
+
+    /**
+     * Create a gateway environment with MULTIPLE vhosts (comma-separated hosts). Non-asserting — the feature
+     * confirms 201 (distinct hosts) or 400 (e.g. duplicate hostnames). Ports the multi-vhost half of
+     * EnvironmentTestCase (legacy-disabled; carried as new verified coverage).
+     */
+    @When("I create a gateway environment {string} with vhost hosts {string}")
+    public void iCreateGatewayEnvironmentMultiVhost(String nameBase, String hostsCsv) throws IOException {
+        String name = Utils.resolvePayloadPlaceholders(nameBase);
+        JSONArray vhosts = new JSONArray();
+        for (String h : hostsCsv.split(",")) {
+            vhosts.put(regularVhost(h.trim()));
+        }
+        JSONObject env = new JSONObject()
+                .put("name", name).put("displayName", name)
+                .put("description", "Multi-vhost gateway environment")
+                .put("provider", "wso2").put("isReadOnly", false)
+                .put("vhosts", vhosts);
+        postEnvironment(env);
+    }
+
+    /**
+     * Searches applications via the ADMIN API filtered by owner (the {@code user} query param). Ports the
+     * owner-search of ApplicationsSearchByNameOrOwnerTestCase. (The v4 admin /applications endpoint supports
+     * only owner search — there is no name-search query param — so only the by-owner path is portable.)
+     * Non-asserting.
+     *
+     * @param actorRef the owning actor (resolved to its username)
+     */
+    @When("I search admin applications owned by actor {string}")
+    public void iSearchAdminApplicationsByOwner(String actorRef) throws IOException {
+        String owner = Identity.resolveActor(actorRef).getUserName();
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.adminToken());
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doGet(Utils.getAdminApplicationsByOwnerURL(getBaseUrl(), owner), headers);
+        TestContext.set("httpResponse", response);
+    }
+
+    /**
+     * Searches applications via the ADMIN API filtered by name (the {@code name} query param). Ports the
+     * by-name search of ApplicationsSearchByNameOrOwnerTestCase. Non-asserting.
+     *
+     * @param name application name (or prefix); {@code {{contextKey}}} placeholders are resolved
+     */
+    @When("I search admin applications by name {string}")
+    public void iSearchAdminApplicationsByName(String name) throws IOException {
+        String actualName = Utils.resolveContextPlaceholders(name);
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.adminToken());
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doGet(Utils.getAdminApplicationsByNameURL(getBaseUrl(), actualName), headers);
+        TestContext.set("httpResponse", response);
+    }
+
+    /** Update a gateway environment to a single vhost host (removing any others). Non-asserting. */
+    @When("I update the gateway environment {string} to only vhost host {string}")
+    public void iUpdateGatewayEnvironmentToSingleVhost(String idKey, String host) throws IOException {
+        String id = Utils.resolveFromContext(idKey).toString();
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.adminToken());
+        String url = Utils.getEnvironmentByIdURL(getBaseUrl(), id);
+        HttpResponse getResp = SimpleHTTPClient.getInstance().doGet(url, headers);
+        JSONObject env = new JSONObject(getResp.getData());
+        env.put("vhosts", new JSONArray().put(regularVhost(host)));
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doPut(url, headers, env.toString(), Constants.CONTENT_TYPES.APPLICATION_JSON);
+        TestContext.set("httpResponse", response);
+    }
+
     /**
      * Creates an application throttling policy with a BANDWIDTH limit (KB/min) rather than a request count
      * (admin API). Stores {@code appThrottlePolicyName}/{@code appThrottlePolicyId} (so the existing
@@ -211,7 +657,7 @@ public class ApplicationBaseSteps {
     @When("I create an application throttling policy {string} allowing {int} KB per minute")
     public void iCreateApplicationBandwidthPolicy(String policyBaseName, int kbPerMinute) throws IOException {
 
-        String policyName = Utils.resolvePayloadPlaceholders(policyBaseName);
+        String policyName = Utils.resolveContextPlaceholders(Utils.resolvePayloadPlaceholders(policyBaseName));
         String payload = String.format(
                 "{\"policyName\":\"%s\",\"displayName\":\"%s\",\"description\":\"Bandwidth-enforcement test: %d KB/min\","
                         + "\"type\":\"ApplicationThrottlePolicy\",\"defaultLimit\":{\"type\":\"BANDWIDTHLIMIT\","
@@ -246,7 +692,7 @@ public class ApplicationBaseSteps {
     public void iCreateCustomThrottlingPolicy(String policyBaseName, String apiContext, int requestsPerMinute)
             throws IOException {
 
-        String policyName = Utils.resolvePayloadPlaceholders(policyBaseName);
+        String policyName = Utils.resolveContextPlaceholders(Utils.resolvePayloadPlaceholders(policyBaseName));
         String context = Utils.resolveContextPlaceholders(apiContext);
         // Isolation-safe: throttle ONLY this test's unique apiContext. Emit the request's apiContext as the
         // throttleKey and set keyTemplate=$apiContext so template and emitted key always align at runtime; match
@@ -467,7 +913,9 @@ public class ApplicationBaseSteps {
     public void iUpdateTheApplicationWithPayload(String appId, String updatePayload) throws IOException {
 
         String actualAppId = Utils.resolveFromContext(appId).toString();
-        String jsonPayload = Utils.resolveFromContext(updatePayload).toString();
+        // Resolve any {{contextKey}} placeholders (e.g. a captured application name so the PUT keeps its
+        // required name). No-op when the payload has none.
+        String jsonPayload = Utils.resolveContextPlaceholders(Utils.resolveFromContext(updatePayload).toString());
 
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION,
@@ -531,6 +979,11 @@ public class ApplicationBaseSteps {
         String jsonPayload = Utils.resolveFromContext(payload).toString();
         jsonPayload = jsonPayload.replace("{{applicationId}}", actualAppId);
         jsonPayload = jsonPayload.replace("{{apiId}}", actualApiId);
+        // Resolve any remaining {{contextKey}} placeholders, mirroring the positive iSubscribeToApi step. This
+        // also makes a typo'd placeholder fail FAST (resolveContextPlaceholders throws on an unknown key) rather
+        // than being sent to the server verbatim — an unresolved id yields a misleading 500 that masquerades as
+        // a genuine rejection (it once produced a false "org-policy denial returns 500" finding).
+        jsonPayload = Utils.resolveContextPlaceholders(jsonPayload);
 
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.devportalToken());
@@ -666,7 +1119,8 @@ public class ApplicationBaseSteps {
     public void iGenerateClientCredentialsForApplication(String appId, String payload) throws Exception {
 
         String actualAppId = Utils.resolveFromContext(appId).toString();
-        String jsonPayload = Utils.resolveFromContext(payload).toString();
+        // Resolve any {{contextKey}} placeholders (e.g. a captured key-manager name for a specific-KM key-gen).
+        String jsonPayload = Utils.resolveContextPlaceholders(Utils.resolveFromContext(payload).toString());
 
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.devportalToken());
@@ -676,9 +1130,176 @@ public class ApplicationBaseSteps {
                         Constants.CONTENT_TYPES.APPLICATION_JSON);
 
         TestContext.set("httpResponse", response);
-        TestContext.set("consumerKey", Utils.extractValueFromPayload(response.getData(), "consumerKey"));
-        TestContext.set("consumerSecret", Utils.extractValueFromPayload(response.getData(), "consumerSecret"));
-        TestContext.set("keyMappingId", Utils.extractValueFromPayload(response.getData(), "keyMappingId"));
+        // Only extract key fields on success — a non-2xx (e.g. a KM that denies the user's role → 403) has no
+        // consumerKey, and extracting it would throw before the feature can assert the rejection status.
+        if (response.getResponseCode() >= 200 && response.getResponseCode() < 300) {
+            TestContext.set("consumerKey", Utils.extractValueFromPayload(response.getData(), "consumerKey"));
+            TestContext.set("consumerSecret", Utils.extractValueFromPayload(response.getData(), "consumerSecret"));
+            TestContext.set("keyMappingId", Utils.extractValueFromPayload(response.getData(), "keyMappingId"));
+        }
+    }
+
+    /**
+     * Registers a pre-existing (BYO) OAuth client directly in the resident Key Manager via the DCR
+     * endpoint, capturing its raw {@code clientId}/{@code clientSecret} into context under
+     * {@code <idKey>ClientId} / {@code <idKey>ClientSecret}. This is the v2-native analogue of the legacy
+     * ApplicationTestCase#createOIDCApplication (which used the SOAP OAuthAdminService + a ServiceProvider):
+     * DCR produces a real OAuth2 consumer app in the resident IS, which is exactly what the subsequent
+     * map-keys step needs to bind to a Developer Portal application. The client name is made runner-unique
+     * so parallel scenarios never collide.
+     *
+     * @param clientName base name for the BYO OAuth client (uniquified per runner)
+     * @param idKey      context prefix under which the client id/secret are stored
+     */
+    @When("I register an OAuth client {string} as {string}")
+    public void iRegisterOAuthClient(String clientName, String idKey) throws IOException {
+
+        User actor = Identity.resolveActor(Identity.actingActorRef());
+        String uniqueName = Names.unique(clientName);
+
+        JSONObject json = new JSONObject();
+        json.put("callbackUrl", "http://localhost:8490/callback");
+        json.put("clientName", uniqueName);
+        json.put("grantType", "client_credentials password refresh_token");
+        json.put("saasApp", true);
+        json.put("owner", actor.getUserName());
+
+        String encodedCredentials = Base64.getEncoder().encodeToString(
+                (actor.getUserName() + ":" + actor.getPassword()).getBytes(StandardCharsets.UTF_8));
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Basic " + encodedCredentials);
+
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance().doPost(
+                Utils.getDCREndpointURL(getBaseUrl()), headers, json.toString(),
+                Constants.CONTENT_TYPES.APPLICATION_JSON);
+        TestContext.set("httpResponse", response);
+        Assert.assertEquals(response.getResponseCode(), 200,
+                "BYO OAuth client registration (DCR) failed: " + response.getData());
+        TestContext.set(idKey + "ClientId", Utils.extractValueFromPayload(response.getData(), "clientId"));
+        TestContext.set(idKey + "ClientSecret", Utils.extractValueFromPayload(response.getData(), "clientSecret"));
+    }
+
+    /**
+     * Maps a pre-existing (BYO) OAuth client's consumer key/secret to a Developer Portal application against
+     * a named key manager (typically {@code "Resident Key Manager"}). Ports the legacy
+     * ApplicationTestCase#mapApplicationKeys / mapApplicationKeysNegative arc. Non-asserting — the feature
+     * asserts the status (200 on a clean map, 409 "Key Mappings already exists" when keys are already
+     * generated/mapped) — so this one step serves both the positive and negative scenarios.
+     *
+     * @param idKey      context prefix of a client registered via the register-OAuth-client step
+     * @param appId      context key holding the target application id
+     * @param keyManager the key manager to map against (e.g. "Resident Key Manager")
+     */
+    @When("I map OAuth client {string} to application {string} via key manager {string}")
+    public void iMapOAuthClientToApplication(String idKey, String appId, String keyManager) throws IOException {
+
+        String actualAppId = Utils.resolveFromContext(appId).toString();
+        String consumerKey = Utils.resolveFromContext(idKey + "ClientId").toString();
+        String consumerSecret = Utils.resolveFromContext(idKey + "ClientSecret").toString();
+
+        JSONObject json = new JSONObject();
+        json.put("consumerKey", consumerKey);
+        json.put("consumerSecret", consumerSecret);
+        json.put("keyType", "PRODUCTION");
+        json.put("keyManager", keyManager);
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.devportalToken());
+
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance().doPost(
+                Utils.getMapKeysURL(getBaseUrl(), actualAppId), headers, json.toString(),
+                Constants.CONTENT_TYPES.APPLICATION_JSON);
+        TestContext.set("httpResponse", response);
+    }
+
+    /**
+     * Cleans up an application's key registration for a key mapping (the DevPortal clean-up operation used
+     * after a failed/partial key generation). Ports ApplicationTestCase#testCleanupApplicationRegistrationById.
+     * Non-asserting — the feature asserts the status.
+     *
+     * @param appId           context key holding the application id
+     * @param keyMappingIdKey context key holding the key mapping id
+     */
+    @When("I clean up the key registration for application {string} with key mapping {string}")
+    public void iCleanUpKeyRegistration(String appId, String keyMappingIdKey) throws IOException {
+
+        String actualAppId = Utils.resolveFromContext(appId).toString();
+        String keyMappingId = Utils.resolveFromContext(keyMappingIdKey).toString();
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.devportalToken());
+
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance().doPost(
+                Utils.getCleanupRegistrationURL(getBaseUrl(), actualAppId, keyMappingId), headers, "",
+                Constants.CONTENT_TYPES.APPLICATION_JSON);
+        TestContext.set("httpResponse", response);
+    }
+
+    /**
+     * Asserts that the backend JWT (the {@code X-JWT-Assertion} request header the gateway injects towards the
+     * backend, reflected back by the /reflect-headers backend route) carries the given application attribute.
+     * The last {@code httpResponse} body is expected to be {@code {"headers": {"x-jwt-assertion": "<jwt>", ...}}};
+     * the JWT payload segment is base64-decoded and checked for the attribute name and value. Ports the
+     * applicationAttributes-claim assertion of ApplicationAttributesTestCase.
+     *
+     * @param attributeName  the application attribute name (e.g. "External Reference Id")
+     * @param attributeValue the expected value (e.g. "c1237890")
+     */
+    @Then("The reflected backend JWT should contain application attribute {string} with value {string}")
+    public void theReflectedBackendJwtShouldContainAttribute(String attributeName, String attributeValue) {
+
+        HttpResponse response = (HttpResponse) TestContext.get("httpResponse");
+        Assert.assertNotNull(response, "No invocation response captured");
+        JSONObject body = new JSONObject(response.getData());
+        Assert.assertTrue(body.has("headers"),
+                "Reflected response has no 'headers' object: " + response.getData());
+        JSONObject headers = body.getJSONObject("headers");
+
+        String jwt = null;
+        for (String key : headers.keySet()) {
+            if ("x-jwt-assertion".equalsIgnoreCase(key)) {
+                jwt = headers.getString(key);
+                break;
+            }
+        }
+        Assert.assertNotNull(jwt, "No X-JWT-Assertion header reached the backend: " + headers);
+
+        String[] segments = jwt.split("\\.");
+        Assert.assertTrue(segments.length >= 2, "Malformed JWT assertion (expected >= 2 segments): " + jwt);
+        // The gateway emits the assertion base64-encoded (config: encoding = "base64"); decode tolerantly
+        // (URL-safe first, then standard) so either encoding is accepted.
+        String payload;
+        try {
+            payload = new String(Base64.getUrlDecoder().decode(segments[1]), StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException e) {
+            payload = new String(Base64.getDecoder().decode(segments[1]), StandardCharsets.UTF_8);
+        }
+
+        Assert.assertTrue(payload.contains(attributeName),
+                "Decoded backend JWT does not contain attribute name '" + attributeName + "': " + payload);
+        Assert.assertTrue(payload.contains(attributeValue),
+                "Decoded backend JWT does not contain attribute value '" + attributeValue + "': " + payload);
+    }
+
+    /**
+     * Regenerates (rotates) the consumer secret of an application's keys for a key type. Ports
+     * ApplicationConsumerSecretRegenerateTestCase — the response carries a NEW consumer secret. Non-asserting.
+     */
+    @When("I regenerate the consumer secret for application {string} with key mapping {string}")
+    public void iRegenerateConsumerSecret(String appId, String keyMappingIdKey) throws IOException {
+
+        String actualAppId = Utils.resolveFromContext(appId).toString();
+        String keyMappingId = Utils.resolveFromContext(keyMappingIdKey).toString();
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.devportalToken());
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance().doPost(
+                Utils.getRegenerateConsumerSecretURL(getBaseUrl(), actualAppId, keyMappingId), headers, "",
+                Constants.CONTENT_TYPES.APPLICATION_JSON);
+        TestContext.set("httpResponse", response);
     }
 
     /**
@@ -860,6 +1481,58 @@ public class ApplicationBaseSteps {
     }
 
     /**
+     * Lists an application's PRODUCTION API keys and stores the FIRST key's {@code keyUUID} under {@code ctxKey}.
+     * A store-generated (opaque) API key is revoked by its keyUUID (not the key value), so this captures it for
+     * the revoke step. Each scenario creates a fresh application with a single key, so the first entry is it.
+     *
+     * @param appId  context key holding the application id
+     * @param ctxKey context key to store the captured keyUUID under
+     */
+    @When("I retrieve the api key UUID for application id {string} as {string}")
+    public void iRetrieveApiKeyUuid(String appId, String ctxKey) throws IOException {
+        String actualAppId = Utils.resolveFromContext(appId).toString();
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.devportalToken());
+
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doGet(Utils.getListAPIKeysURL(getBaseUrl(), actualAppId), headers);
+        TestContext.set("httpResponse", response);
+        // The endpoint returns either a bare array [{...}] or a {"count":n,"list":[...]} wrapper depending on
+        // the pack — handle both. Each scenario's app has a single key, so the first entry is the one to revoke.
+        String data = response.getData().trim();
+        org.json.JSONArray list = data.startsWith("[")
+                ? new org.json.JSONArray(data)
+                : new org.json.JSONObject(data).getJSONArray("list");
+        String uuid = list.getJSONObject(0).getString("keyUUID");
+        TestContext.set(Utils.normalizeContextKey(ctxKey), uuid);
+    }
+
+    /**
+     * Revokes a store-generated (opaque) application API key by its {@code keyUUID} via the DevPortal revoke
+     * endpoint ({@code applications/{id}/api-keys/PRODUCTION/revoke}, body {@code {"keyUUID":"<uuid>"}}). After
+     * revocation the key must be rejected at the gateway (401). Ports the opaque api-key revocation of
+     * APISecurityTestCase (which revokes by keyUUID — revoke-by-value rejects the opaque key as invalid).
+     *
+     * @param uuidRef context key holding the keyUUID to revoke
+     * @param appId   context key holding the application id
+     */
+    @When("I revoke the api key with UUID {string} for application id {string}")
+    public void iRevokeApiKeyByUuid(String uuidRef, String appId) throws IOException {
+        String actualAppId = Utils.resolveFromContext(appId).toString();
+        String uuid = Utils.resolveFromContext(uuidRef).toString();
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.devportalToken());
+        String payload = "{\"keyUUID\":\"" + uuid + "\"}";
+
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doPost(Utils.getRevokeAPIKeyURL(getBaseUrl(), actualAppId), headers, payload,
+                        Constants.CONTENT_TYPES.APPLICATION_JSON);
+        TestContext.set("httpResponse", response);
+    }
+
+    /**
      * Deletes a subscription by its ID.
      *
      * @param subscriptionId Context key containing the subscription ID to delete
@@ -966,6 +1639,21 @@ public class ApplicationBaseSteps {
      */
     @When("I have set up application with keys, subscribed to API {string}, and obtained access token for {string}")
     public void iSetupApplicationSubscribeAndGetToken(String apiId, String subscriptionID) throws Exception {
+        iSetupApplicationSubscribeAndGetTokenWithPlan(apiId, "Bronze", subscriptionID);
+    }
+
+    /**
+     * Plan-parameterised variant of the application-setup composite — subscribes with the given business plan
+     * instead of the default {@code Bronze}. Needed for API types whose allowed tiers differ, e.g. a WebSocket
+     * (async) API only accepts async plans such as {@code AsyncUnlimited} (a sync plan → 403 "not allowed").
+     *
+     * @param apiId          context key holding the API id
+     * @param plan           the subscription business plan (e.g. {@code AsyncUnlimited})
+     * @param subscriptionID context key to store the created subscription id under
+     */
+    @When("I have set up application with keys, subscribed to API {string} with plan {string}, and obtained access token for {string}")
+    public void iSetupApplicationSubscribeAndGetTokenWithPlan(String apiId, String plan, String subscriptionID)
+            throws Exception {
 
         // create an application
         baseSteps.putJsonPayloadFromFile("artifacts/payloads/create_apim_test_app.json", "<createAppPayload>");
@@ -980,7 +1668,48 @@ public class ApplicationBaseSteps {
 
         // subscribe to an api with that created application
         baseSteps.putJsonPayloadInContext("<apiSubscriptionPayload>", "{\"applicationId\": \"{{applicationId}}\"," +
-                "\"apiId\": \"{{apiId}}\",\"throttlingPolicy\": \"Bronze\"}");
+                "\"apiId\": \"{{apiId}}\",\"throttlingPolicy\": \"" + plan + "\"}");
+        iSubscribeToApi(apiId, "<createdAppId>", "<apiSubscriptionPayload>", subscriptionID);
+        baseSteps.theResponseStatusCodeShouldBe(201);
+
+        // generate access token
+        baseSteps.putJsonPayloadInContext("<createApplicationAccessTokenPayload>", "{\"consumerSecret\": \"{{appConsumerSecret}}\"," +
+                "\"validityPeriod\": 3600}");
+        iRequestAccessToken("<createdAppId>", "<createApplicationAccessTokenPayload>");
+        baseSteps.theResponseStatusCodeShouldBe(200);
+    }
+
+    /**
+     * Token-type-parameterised variant of the application-setup composite — creates the application with the given
+     * {@code tokenType} ({@code JWT} = self-contained signed token, the product default; {@code OAUTH} = opaque
+     * UUID token), then generates keys, subscribes on the given plan, and obtains an access token. Needed to
+     * exercise BOTH token-issuance paths (e.g. a WebSocket API invoked with a JWT token and with an OAUTH/opaque
+     * token — the legacy WebSocketAPITestCase covers both).
+     *
+     * @param tokenType      the application token type: {@code JWT} or {@code OAUTH}
+     * @param apiId          context key holding the API id
+     * @param plan           the subscription business plan (e.g. {@code AsyncUnlimited})
+     * @param subscriptionID context key to store the created subscription id under
+     */
+    @When("I have set up a {string} token type application with keys, subscribed to API {string} with plan {string}, and obtained access token for {string}")
+    public void iSetupTokenTypeApplicationSubscribeAndGetTokenWithPlan(String tokenType, String apiId, String plan,
+                                                                       String subscriptionID) throws Exception {
+
+        // create an application of the given token type
+        baseSteps.putJsonPayloadFromFile("artifacts/payloads/create_apim_test_app.json", "<createAppPayload>");
+        baseSteps.iSetFieldInPayload("tokenType", tokenType, "<createAppPayload>");
+        iCreateAnApplicationWithJsonPayload("<createAppPayload>");
+        baseSteps.theResponseStatusCodeShouldBe(201);
+
+        // generate credentials for application
+        baseSteps.putJsonPayloadInContext("<generateApplicationKeysPayload>", "{\"keyType\": \"PRODUCTION\"," +
+                "\"grantTypesToBeSupported\": [\"client_credentials\"]}");
+        iGenerateClientCredentialsForApplication("<createdAppId>", "<generateApplicationKeysPayload>");
+        baseSteps.theResponseStatusCodeShouldBe(200);
+
+        // subscribe to an api with that created application
+        baseSteps.putJsonPayloadInContext("<apiSubscriptionPayload>", "{\"applicationId\": \"{{applicationId}}\"," +
+                "\"apiId\": \"{{apiId}}\",\"throttlingPolicy\": \"" + plan + "\"}");
         iSubscribeToApi(apiId, "<createdAppId>", "<apiSubscriptionPayload>", subscriptionID);
         baseSteps.theResponseStatusCodeShouldBe(201);
 
@@ -1090,6 +1819,628 @@ public class ApplicationBaseSteps {
         HttpResponse response = SimpleHTTPClient.getInstance()
                 .doGet(Utils.getApiDocumentsURL(getBaseUrl(), actualApiId), headers);
 
+        TestContext.set("httpResponse", response);
+    }
+
+    // ---- Key manager configuration (admin) -------------------------------------------------------------
+
+    private Map<String, String> adminAuthHeaders() {
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.adminToken());
+        return headers;
+    }
+
+    /**
+     * Adds a system-scope role-alias mapping (admin REST {@code PUT /role-aliases}): maps {@code role} to include
+     * {@code alias}. Ports APISystemScopesTestCase#testAddScopeMapping. Non-asserting.
+     */
+    @When("I set the role alias {string} for role {string}")
+    public void iSetRoleAlias(String alias, String role) throws IOException {
+
+        JSONObject entry = new JSONObject().put("role", role).put("aliases", new JSONArray().put(alias));
+        JSONObject payload = new JSONObject().put("count", 1).put("list", new JSONArray().put(entry));
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance().doPut(Utils.getRoleAliasesURL(getBaseUrl()),
+                adminAuthHeaders(), payload.toString(), Constants.CONTENT_TYPES.APPLICATION_JSON);
+        TestContext.set("httpResponse", response);
+    }
+
+    /** Retrieves the system-scope role-alias mappings (admin REST {@code GET /role-aliases}). Non-asserting. */
+    @When("I retrieve the role aliases")
+    public void iRetrieveRoleAliases() throws IOException {
+
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance().doGet(Utils.getRoleAliasesURL(getBaseUrl()),
+                adminAuthHeaders());
+        TestContext.set("httpResponse", response);
+    }
+
+    /**
+     * Clears all system-scope role-alias mappings (admin REST {@code PUT /role-aliases} with an empty list) —
+     * the teardown for the role-alias mapping test. Non-asserting.
+     */
+    @When("I clear all role aliases")
+    public void iClearRoleAliases() throws IOException {
+
+        JSONObject payload = new JSONObject().put("count", 0).put("list", new JSONArray());
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance().doPut(Utils.getRoleAliasesURL(getBaseUrl()),
+                adminAuthHeaders(), payload.toString(), Constants.CONTENT_TYPES.APPLICATION_JSON);
+        TestContext.set("httpResponse", response);
+    }
+
+    /** Maps a friendly throttling-policy kind to the export/import {@code type} token. */
+    private static String throttleExportType(String friendlyType) {
+        switch (friendlyType) {
+            case "subscription": return "sub";
+            case "application":  return "app";
+            case "advanced":     return "api";
+            case "custom":       return "global";
+            default:             return friendlyType; // allow a raw token to pass through
+        }
+    }
+
+    /**
+     * Exports a throttling policy (admin REST {@code GET /throttling/policies/export?name=&type=}). {@code kind}
+     * is the friendly type (subscription/application/advanced/custom); {@code nameKey} is the context key holding
+     * the policy name (as stored by the create steps). On 2xx the exported JSON body is stored under
+     * {@code exportKey} for a subsequent import. Non-asserting. Ports ThrottlePolicyExportImportTestCase (export).
+     */
+    @When("I export the {string} throttling policy named {string} as {string}")
+    public void iExportThrottlePolicy(String kind, String nameKey, String exportKey) throws IOException {
+
+        String name = Utils.resolveFromContext(nameKey).toString();
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance().doGet(
+                Utils.getThrottlePolicyExportURL(getBaseUrl(), name, throttleExportType(kind)), adminAuthHeaders());
+        TestContext.set("httpResponse", response);
+        if (response.getResponseCode() >= 200 && response.getResponseCode() < 300) {
+            TestContext.set(Utils.normalizeContextKey(exportKey), response.getData());
+        }
+    }
+
+    /**
+     * Imports a throttling policy from a previously-exported JSON body (admin REST
+     * {@code POST /throttling/policies/import?overwrite=} as a multipart {@code file}). {@code overwrite=false}
+     * on an existing policy → 409; {@code overwrite=true} → 200; on an absent policy → 201. Non-asserting. Ports
+     * ThrottlePolicyExportImportTestCase (import: conflict / update / new).
+     */
+    @When("I import the throttling policy from {string} with overwrite {string}")
+    public void iImportThrottlePolicy(String exportKey, String overwrite) throws IOException {
+
+        String body = Utils.resolveFromContext(exportKey).toString();
+        java.io.File temp = java.io.File.createTempFile("throttle-policy", ".json");
+        temp.deleteOnExit();
+        java.nio.file.Files.write(temp.toPath(), body.getBytes(StandardCharsets.UTF_8));
+
+        Map<String, java.io.File> files = new HashMap<>();
+        files.put("file", temp);
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance().doPostMultipartWithFiles(
+                Utils.getThrottlePolicyImportURL(getBaseUrl(), overwrite), adminAuthHeaders(), files, new HashMap<>());
+        TestContext.set("httpResponse", response);
+    }
+
+    /** Loads a key-manager JSON payload off the classpath, resolving {@code ${UNIQUE:...}} name placeholders. */
+    private JSONObject loadKeyManagerPayload(String resourcePath) throws IOException {
+
+        try (InputStream inputStream = getClass().getClassLoader().getResourceAsStream(resourcePath)) {
+            if (inputStream == null) {
+                throw new FileNotFoundException("Resource not found: " + resourcePath);
+            }
+            String raw = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+            return new JSONObject(Utils.resolvePayloadPlaceholders(raw));
+        }
+    }
+
+    private HttpResponse postKeyManager(JSONObject payload) throws IOException {
+
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance().doPost(Utils.getKeyManagersURL(getBaseUrl()),
+                adminAuthHeaders(), payload.toString(), Constants.CONTENT_TYPES.APPLICATION_JSON);
+        TestContext.set("httpResponse", response);
+        return response;
+    }
+
+    /**
+     * Creates a key manager from a JSON payload fixture, asserts 201, stores the new id under {@code idKey} (and
+     * its name under {@code <idKey>Name} for the duplicate-name negative), and registers it for teardown.
+     */
+    @When("I create a key manager from payload {string} as {string}")
+    public void iCreateKeyManager(String resourcePath, String idKey) throws IOException {
+
+        HttpResponse response = postKeyManager(loadKeyManagerPayload(resourcePath));
+        Assert.assertEquals(response.getResponseCode(), 201, response.getData());
+        Object kmId = Utils.extractValueFromPayload(response.getData(), "id");
+        Object kmName = Utils.extractValueFromPayload(response.getData(), "name");
+        TestContext.set(idKey, kmId);
+        TestContext.set(idKey + "Name", kmName);
+        ResourceCleanup.register(Constants.CREATED_KEY_MANAGER_IDS, kmId);
+    }
+
+    /**
+     * Attempts to create a key manager from a payload with its connector config (additionalProperties) stripped
+     * — the mandatory-parameter negative. Non-asserting; the feature asserts the 400.
+     */
+    @When("I attempt to create a key manager from payload {string} without connector config")
+    public void iAttemptToCreateKeyManagerWithoutConnectorConfig(String resourcePath) throws IOException {
+
+        JSONObject payload = loadKeyManagerPayload(resourcePath);
+        payload.remove("additionalProperties");
+        postKeyManager(payload);
+    }
+
+    /**
+     * Attempts to create a key manager from a payload but with its name overridden (resolving {@code {{...}}}
+     * from context) — used for the duplicate-name negative. Non-asserting; the feature asserts the 409.
+     */
+    @When("I attempt to create a key manager from payload {string} with name {string}")
+    public void iAttemptToCreateKeyManagerWithName(String resourcePath, String name) throws IOException {
+
+        JSONObject payload = loadKeyManagerPayload(resourcePath);
+        payload.put("name", Utils.resolveContextPlaceholders(name));
+        postKeyManager(payload);
+    }
+
+    /** Retrieves a single key manager by the id held under {@code idKey}. */
+    @When("I retrieve the key manager {string}")
+    public void iRetrieveKeyManager(String idKey) throws IOException {
+
+        String kmId = Utils.resolveFromContext(idKey).toString();
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doGet(Utils.getKeyManagerByIdURL(getBaseUrl(), kmId), adminAuthHeaders());
+        TestContext.set("httpResponse", response);
+    }
+
+    /** Lists all key managers. */
+    @When("I retrieve all key managers")
+    public void iRetrieveAllKeyManagers() throws IOException {
+
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doGet(Utils.getKeyManagersURL(getBaseUrl()), adminAuthHeaders());
+        TestContext.set("httpResponse", response);
+    }
+
+    /**
+     * Updates a key manager's description in place: retrieves the current config, replaces its description, and
+     * PUTs it back. Non-asserting — the feature asserts the status and the reflected description.
+     */
+    @When("I update the key manager {string} setting its description to {string}")
+    public void iUpdateKeyManagerDescription(String idKey, String newDescription) throws IOException {
+
+        String kmId = Utils.resolveFromContext(idKey).toString();
+        HttpResponse current = SimpleHTTPClient.getInstance()
+                .doGet(Utils.getKeyManagerByIdURL(getBaseUrl(), kmId), adminAuthHeaders());
+        Assert.assertEquals(current.getResponseCode(), 200, current.getData());
+
+        JSONObject km = new JSONObject(current.getData());
+        km.put("description", newDescription);
+
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance().doPut(
+                Utils.getKeyManagerByIdURL(getBaseUrl(), kmId), adminAuthHeaders(), km.toString(),
+                Constants.CONTENT_TYPES.APPLICATION_JSON);
+        TestContext.set("httpResponse", response);
+    }
+
+    /** Deletes the key manager held under {@code idKey}. Non-asserting — the feature asserts the status. */
+    @When("I delete the key manager {string}")
+    public void iDeleteKeyManager(String idKey) throws IOException {
+
+        String kmId = Utils.resolveFromContext(idKey).toString();
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doDelete(Utils.getKeyManagerByIdURL(getBaseUrl(), kmId), adminAuthHeaders());
+        TestContext.set("httpResponse", response);
+    }
+
+    /**
+     * Creates a key manager from a payload fixture with {@code allowedOrganizations} set (comma-separated,
+     * resolves {@code {{...}}}), asserts 201, stores the id and registers it. For org key-manager visibility.
+     */
+    @When("I create a key manager from payload {string} with allowed organizations {string} as {string}")
+    public void iCreateKeyManagerWithAllowedOrgs(String resourcePath, String allowedOrgs, String idKey)
+            throws IOException {
+
+        JSONObject payload = loadKeyManagerPayload(resourcePath);
+        JSONArray orgs = new JSONArray();
+        for (String o : Utils.resolveContextPlaceholders(allowedOrgs).split("\\s*,\\s*")) {
+            orgs.put(o);
+        }
+        payload.put("allowedOrganizations", orgs);
+        HttpResponse response = postKeyManager(payload);
+        Assert.assertEquals(response.getResponseCode(), 201, response.getData());
+        Object kmId = Utils.extractValueFromPayload(response.getData(), "id");
+        TestContext.set(idKey, kmId);
+        ResourceCleanup.register(Constants.CREATED_KEY_MANAGER_IDS, kmId);
+    }
+
+    /**
+     * Creates a key manager from a payload fixture with {@code permissions} set to DENY a single role, so users
+     * in that role are refused key generation via this KM (403). Asserts 201, stores the id under {@code idKey}
+     * and the KM name under {@code <idKey>Name}. Ports the KM-permissions check of KeyManagersTestCase.
+     */
+    @When("I create a key manager from payload {string} denying role {string} as {string}")
+    public void iCreateKeyManagerDenyingRole(String resourcePath, String role, String idKey) throws IOException {
+
+        JSONObject payload = loadKeyManagerPayload(resourcePath);
+        payload.put("permissions", new JSONObject()
+                .put("permissionType", "DENY")
+                .put("roles", new JSONArray().put(role)));
+        HttpResponse response = postKeyManager(payload);
+        Assert.assertEquals(response.getResponseCode(), 201, response.getData());
+        TestContext.set(idKey, Utils.extractValueFromPayload(response.getData(), "id"));
+        TestContext.set(idKey + "Name", Utils.extractValueFromPayload(response.getData(), "name"));
+        ResourceCleanup.register(Constants.CREATED_KEY_MANAGER_IDS,
+                Utils.extractValueFromPayload(response.getData(), "id"));
+    }
+
+    /** Sets a key manager's {@code allowedOrganizations} in place (GET→modify→PUT). Non-asserting. */
+    @When("I set the allowed organizations of key manager {string} to {string}")
+    public void iSetKeyManagerAllowedOrgs(String idKey, String allowedOrgs) throws IOException {
+
+        String kmId = Utils.resolveFromContext(idKey).toString();
+        HttpResponse current = SimpleHTTPClient.getInstance()
+                .doGet(Utils.getKeyManagerByIdURL(getBaseUrl(), kmId), adminAuthHeaders());
+        Assert.assertEquals(current.getResponseCode(), 200, current.getData());
+        JSONObject km = new JSONObject(current.getData());
+        JSONArray orgs = new JSONArray();
+        for (String o : Utils.resolveContextPlaceholders(allowedOrgs).split("\\s*,\\s*")) {
+            orgs.put(o);
+        }
+        km.put("allowedOrganizations", orgs);
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance().doPut(
+                Utils.getKeyManagerByIdURL(getBaseUrl(), kmId), adminAuthHeaders(), km.toString(),
+                Constants.CONTENT_TYPES.APPLICATION_JSON);
+        TestContext.set("httpResponse", response);
+    }
+
+    // ---- Deny (blocking-condition) policies (admin) ----------------------------------------------------
+
+    private HttpResponse postDenyPolicy(String conditionType, Object conditionValue) throws IOException {
+
+        JSONObject dto = new JSONObject();
+        dto.put("conditionType", conditionType);
+        dto.put("conditionValue", conditionValue);
+        dto.put("conditionStatus", true);
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance().doPost(Utils.getDenyPoliciesURL(getBaseUrl()),
+                adminAuthHeaders(), dto.toString(), Constants.CONTENT_TYPES.APPLICATION_JSON);
+        TestContext.set("httpResponse", response);
+        return response;
+    }
+
+    private void registerCreatedDenyPolicy(HttpResponse response, String idKey) throws IOException {
+
+        Object conditionId = Utils.extractValueFromPayload(response.getData(), "conditionId");
+        TestContext.set(idKey, conditionId);
+        ResourceCleanup.register(Constants.CREATED_DENY_POLICY_IDS, conditionId);
+    }
+
+    private JSONObject ipConditionValue(String fixedIp) {
+
+        JSONObject value = new JSONObject();
+        value.put("invert", false);
+        value.put("fixedIp", fixedIp);
+        return value;
+    }
+
+    /**
+     * Creates a deny (blocking-condition) policy of a string-valued type (API context / USER / APPLICATION),
+     * asserts 201, stores the condition id under {@code idKey} and registers it for teardown.
+     */
+    @When("I create a deny policy of type {string} with value {string} as {string}")
+    public void iCreateDenyPolicy(String conditionType, String conditionValue, String idKey) throws IOException {
+
+        HttpResponse response = postDenyPolicy(conditionType, Utils.resolveContextPlaceholders(conditionValue));
+        Assert.assertEquals(response.getResponseCode(), 201, response.getData());
+        registerCreatedDenyPolicy(response, idKey);
+    }
+
+    /** Attempts to create a string-valued deny policy without asserting — for negatives. */
+    @When("I attempt to create a deny policy of type {string} with value {string}")
+    public void iAttemptToCreateDenyPolicy(String conditionType, String conditionValue) throws IOException {
+
+        postDenyPolicy(conditionType, Utils.resolveContextPlaceholders(conditionValue));
+    }
+
+    /** Creates an IP deny policy for a fixed IP, asserts 201, stores + registers it. */
+    @When("I create an IP deny policy for fixed IP {string} as {string}")
+    public void iCreateIpDenyPolicy(String fixedIp, String idKey) throws IOException {
+
+        HttpResponse response = postDenyPolicy("IP", ipConditionValue(fixedIp));
+        Assert.assertEquals(response.getResponseCode(), 201, response.getData());
+        registerCreatedDenyPolicy(response, idKey);
+    }
+
+    /** Attempts to create an IP deny policy for a fixed IP without asserting — for negatives. */
+    @When("I attempt to create an IP deny policy for fixed IP {string}")
+    public void iAttemptToCreateIpDenyPolicy(String fixedIp) throws IOException {
+
+        postDenyPolicy("IP", ipConditionValue(fixedIp));
+    }
+
+    /** Creates an IP-range deny policy, asserts 201, stores + registers it. */
+    @When("I create an IP range deny policy from {string} to {string} as {string}")
+    public void iCreateIpRangeDenyPolicy(String startingIp, String endingIp, String idKey) throws IOException {
+
+        JSONObject value = new JSONObject();
+        value.put("invert", false);
+        value.put("startingIp", startingIp);
+        value.put("endingIp", endingIp);
+        HttpResponse response = postDenyPolicy("IPRANGE", value);
+        Assert.assertEquals(response.getResponseCode(), 201, response.getData());
+        registerCreatedDenyPolicy(response, idKey);
+    }
+
+    /** Retrieves a single deny policy by the condition id held under {@code idKey}. */
+    @When("I retrieve the deny policy {string}")
+    public void iRetrieveDenyPolicy(String idKey) throws IOException {
+
+        String id = Utils.resolveFromContext(idKey).toString();
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doGet(Utils.getDenyPolicyByIdURL(getBaseUrl(), id), adminAuthHeaders());
+        TestContext.set("httpResponse", response);
+    }
+
+    /** Updates a deny policy's enabled status (PATCH conditionStatus). Non-asserting — the feature asserts. */
+    @When("I set the deny policy {string} status to {string}")
+    public void iSetDenyPolicyStatus(String idKey, String status) throws IOException {
+
+        String id = Utils.resolveFromContext(idKey).toString();
+        JSONObject dto = new JSONObject();
+        dto.put("conditionStatus", Boolean.parseBoolean(status));
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance().doPatch(
+                Utils.getDenyPolicyByIdURL(getBaseUrl(), id), adminAuthHeaders(), dto.toString(),
+                Constants.CONTENT_TYPES.APPLICATION_JSON);
+        TestContext.set("httpResponse", response);
+    }
+
+    /** Deletes the deny policy held under {@code idKey}. Non-asserting — the feature asserts the status. */
+    @When("I delete the deny policy {string}")
+    public void iDeleteDenyPolicy(String idKey) throws IOException {
+
+        String id = Utils.resolveFromContext(idKey).toString();
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doDelete(Utils.getDenyPolicyByIdURL(getBaseUrl(), id), adminAuthHeaders());
+        TestContext.set("httpResponse", response);
+    }
+
+    /** Searches deny policies by condition type and value (query grammar: conditionType:X&conditionValue:Y). */
+    @When("I search deny policies of type {string} with value {string}")
+    public void iSearchDenyPolicies(String conditionType, String conditionValue) throws IOException {
+
+        String query = urlEncode("conditionType:" + conditionType + "&conditionValue:" + conditionValue);
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doGet(Utils.getDenyPoliciesURL(getBaseUrl()) + "?query=" + query, adminAuthHeaders());
+        TestContext.set("httpResponse", response);
+    }
+
+    // ---- Tenant configuration (admin) ------------------------------------------------------------------
+
+    /** Retrieves the tenant configuration. */
+    @When("I retrieve the tenant configuration")
+    public void iRetrieveTenantConfiguration() throws IOException {
+
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doGet(Utils.getTenantConfigURL(getBaseUrl()), adminAuthHeaders());
+        TestContext.set("httpResponse", response);
+    }
+
+    /** Retrieves the tenant configuration JSON schema. */
+    @When("I retrieve the tenant configuration schema")
+    public void iRetrieveTenantConfigurationSchema() throws IOException {
+
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doGet(Utils.getTenantConfigSchemaURL(getBaseUrl()), adminAuthHeaders());
+        TestContext.set("httpResponse", response);
+    }
+
+    /** Captures the current tenant configuration body under {@code contextKey} (for a round-trip update/restore). */
+    @When("I capture the tenant configuration as {string}")
+    public void iCaptureTenantConfiguration(String contextKey) throws IOException {
+
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doGet(Utils.getTenantConfigURL(getBaseUrl()), adminAuthHeaders());
+        Assert.assertEquals(response.getResponseCode(), 200, response.getData());
+        TestContext.set(Utils.normalizeContextKey(contextKey), response.getData());
+    }
+
+    /** Updates the tenant configuration with the JSON held under {@code contextKey}. Non-asserting. */
+    @When("I update the tenant configuration from {string}")
+    public void iUpdateTenantConfiguration(String contextKey) throws IOException {
+
+        String payload = Utils.resolveFromContext(contextKey).toString();
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance().doPut(Utils.getTenantConfigURL(getBaseUrl()),
+                adminAuthHeaders(), payload, Constants.CONTENT_TYPES.APPLICATION_JSON);
+        TestContext.set("httpResponse", response);
+    }
+
+    /** Attempts to update the tenant configuration with a syntactically-invalid (bad-signature) bearer JWT. */
+    @When("I attempt to update the tenant configuration from {string} with an invalid token")
+    public void iAttemptUpdateTenantConfigInvalidToken(String contextKey) throws IOException {
+
+        String payload = Utils.resolveFromContext(contextKey).toString();
+        // A structurally-valid JWT with a bogus signature the server cannot verify.
+        String invalidJwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
+                + "eyJzdWIiOiJhZG1pbiIsInNjb3BlIjoib3BlbmlkIGFwaW06YWRtaW4ifQ.aW52YWxpZF9zaWduYXR1cmU";
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + invalidJwt);
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance().doPut(Utils.getTenantConfigURL(getBaseUrl()),
+                headers, payload, Constants.CONTENT_TYPES.APPLICATION_JSON);
+        TestContext.set("httpResponse", response);
+    }
+
+    /**
+     * Attempts to update the tenant configuration with the acting actor's PUBLISHER token, which lacks the
+     * {@code apim:admin} scope — the non-admin negative. Non-asserting; the feature asserts the status.
+     */
+    @When("I attempt to update the tenant configuration from {string} without admin scope")
+    public void iAttemptUpdateTenantConfigNonAdmin(String contextKey) throws IOException {
+
+        String payload = Utils.resolveFromContext(contextKey).toString();
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance().doPut(Utils.getTenantConfigURL(getBaseUrl()),
+                headers, payload, Constants.CONTENT_TYPES.APPLICATION_JSON);
+        TestContext.set("httpResponse", response);
+    }
+
+    // ---- Application organization sharing (devportal) --------------------------------------------------
+
+    /**
+     * Creates a devportal application with a given {@code visibility} (PRIVATE / SHARED_WITH_ORG) as the acting
+     * actor, asserts 201, stores the id under {@code idKey} and registers it for teardown. The name resolves
+     * {@code ${UNIQUE:...}}.
+     */
+    @When("I create an application {string} with visibility {string} as {string}")
+    public void iCreateApplicationWithVisibility(String name, String visibility, String idKey) throws IOException {
+
+        JSONObject app = new JSONObject();
+        app.put("name", Utils.resolvePayloadPlaceholders(name));
+        app.put("throttlingPolicy", "Unlimited");
+        app.put("description", "Org-sharing test application");
+        app.put("tokenType", "JWT");
+        app.put("visibility", visibility);
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.devportalToken());
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance().doPost(Utils.getApplicationCreateURL(getBaseUrl()),
+                headers, app.toString(), Constants.CONTENT_TYPES.APPLICATION_JSON);
+        TestContext.set("httpResponse", response);
+        Assert.assertEquals(response.getResponseCode(), 201, response.getData());
+        Object appId = Utils.extractValueFromPayload(response.getData(), "applicationId");
+        TestContext.set(idKey, appId);
+        ResourceCleanup.register(Constants.CREATED_APPLICATION_IDS, appId);
+    }
+
+    /** Retrieves a devportal application by id as the acting actor (200 visible / 403 not). Non-asserting. */
+    @When("I retrieve the application {string}")
+    public void iRetrieveApplicationById(String idKey) throws IOException {
+
+        String appId = Utils.resolveFromContext(idKey).toString();
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.devportalToken());
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doGet(Utils.getApplicationEndpointURL(getBaseUrl(), appId), headers);
+        TestContext.set("httpResponse", response);
+    }
+
+    /** Updates a devportal application's visibility in place (GET→modify→PUT). Non-asserting. */
+    @When("I set the visibility of application {string} to {string}")
+    public void iSetApplicationVisibility(String idKey, String visibility) throws IOException {
+
+        String appId = Utils.resolveFromContext(idKey).toString();
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.devportalToken());
+        HttpResponse current = SimpleHTTPClient.getInstance()
+                .doGet(Utils.getApplicationEndpointURL(getBaseUrl(), appId), headers);
+        Assert.assertEquals(current.getResponseCode(), 200, current.getData());
+        JSONObject app = new JSONObject(current.getData());
+        app.put("visibility", visibility);
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance().doPut(
+                Utils.getApplicationEndpointURL(getBaseUrl(), appId), headers, app.toString(),
+                Constants.CONTENT_TYPES.APPLICATION_JSON);
+        TestContext.set("httpResponse", response);
+    }
+
+    // ---- Consumer secret management (multiple client secrets, devportal) -------------------------------
+
+    private Map<String, String> devportalAuthHeaders() {
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.devportalToken());
+        return headers;
+    }
+
+    /**
+     * Generates an additional consumer secret for an application's key mapping (requires multiple-client-secrets
+     * mode enabled). Non-asserting; on a 2xx the new {@code secretId} is stored under {@code secretIdKey}.
+     *
+     * @param description     value for the secret's {@code description} additional-property (may be empty)
+     * @param appIdKey        context key holding the application id
+     * @param keyMappingIdKey context key holding the key-mapping id
+     * @param secretIdKey     context key to store the generated secret id
+     */
+    @When("I generate a consumer secret with description {string} for application {string} with key mapping {string} as {string}")
+    public void iGenerateConsumerSecret(String description, String appIdKey, String keyMappingIdKey,
+                                        String secretIdKey) throws IOException {
+
+        String appId = Utils.resolveFromContext(appIdKey).toString();
+        String keyMappingId = Utils.resolveFromContext(keyMappingIdKey).toString();
+
+        JSONObject additionalProperties = new JSONObject();
+        if (description != null && !description.isEmpty()) {
+            additionalProperties.put("description", description);
+        }
+        JSONObject request = new JSONObject();
+        request.put("additionalProperties", additionalProperties);
+
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance().doPost(
+                Utils.getGenerateApplicationSecretURL(getBaseUrl(), appId, keyMappingId), devportalAuthHeaders(),
+                request.toString(), Constants.CONTENT_TYPES.APPLICATION_JSON);
+        TestContext.set("httpResponse", response);
+        if (response.getResponseCode() < 300) {
+            TestContext.set(secretIdKey, Utils.extractValueFromPayload(response.getData(), "secretId"));
+        }
+    }
+
+    /** Lists an application key mapping's consumer secrets. */
+    @When("I retrieve the consumer secrets for application {string} with key mapping {string}")
+    public void iRetrieveConsumerSecrets(String appIdKey, String keyMappingIdKey) throws IOException {
+
+        String appId = Utils.resolveFromContext(appIdKey).toString();
+        String keyMappingId = Utils.resolveFromContext(keyMappingIdKey).toString();
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doGet(Utils.getAllApplicationSecretsURL(getBaseUrl(), appId, keyMappingId), devportalAuthHeaders());
+        TestContext.set("httpResponse", response);
+    }
+
+    /** Revokes a consumer secret (by the id held under {@code secretIdKey}). Non-asserting. */
+    @When("I revoke the consumer secret {string} for application {string} with key mapping {string}")
+    public void iRevokeConsumerSecret(String secretIdKey, String appIdKey, String keyMappingIdKey)
+            throws IOException {
+
+        String appId = Utils.resolveFromContext(appIdKey).toString();
+        String keyMappingId = Utils.resolveFromContext(keyMappingIdKey).toString();
+        String secretId = Utils.resolveFromContext(secretIdKey).toString();
+
+        JSONObject request = new JSONObject();
+        request.put("secretId", secretId);
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance().doPost(
+                Utils.getRevokeApplicationSecretURL(getBaseUrl(), appId, keyMappingId), devportalAuthHeaders(),
+                request.toString(), Constants.CONTENT_TYPES.APPLICATION_JSON);
+        TestContext.set("httpResponse", response);
+    }
+
+    /** Fetches an application's OAuth key details by key-mapping id. */
+    @When("I fetch the oauth key details for application {string} with key mapping {string}")
+    public void iFetchKeyDetailsByKeyMappingId(String appIdKey, String keyMappingIdKey) throws IOException {
+
+        String appId = Utils.resolveFromContext(appIdKey).toString();
+        String keyMappingId = Utils.resolveFromContext(keyMappingIdKey).toString();
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doGet(Utils.getUpdateKey(getBaseUrl(), appId, keyMappingId), devportalAuthHeaders());
         TestContext.set("httpResponse", response);
     }
 }

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/ApplicationBaseSteps.java
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/ApplicationBaseSteps.java
@@ -25,6 +25,7 @@ import org.json.JSONObject;
 import org.testng.Assert;
 import org.wso2.am.integration.cucumbertests.utils.Identity;
 import org.wso2.am.integration.cucumbertests.utils.Names;
+import org.wso2.am.integration.cucumbertests.utils.Requests;
 import org.wso2.am.integration.cucumbertests.utils.ResourceCleanup;
 import org.wso2.am.integration.cucumbertests.utils.TestContext;
 import org.wso2.am.integration.cucumbertests.utils.Utils;
@@ -60,16 +61,13 @@ public class ApplicationBaseSteps {
     @When("I create an application with payload {string}")
     public void iCreateAnApplicationWithJsonPayload(String payload) throws IOException {
 
-        String jsonPayload = Utils.resolveFromContext(payload).toString();
+        String jsonPayload = TestContext.resolve(payload).toString();
 
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.devportalToken());
 
-        HttpResponse applicationCreateResponse = SimpleHTTPClient.getInstance()
-                .doPost(Utils.getApplicationCreateURL(getBaseUrl()), headers, jsonPayload,
+        HttpResponse applicationCreateResponse = Requests.post(Utils.getApplicationCreateURL(getBaseUrl()), headers, jsonPayload,
                         Constants.CONTENT_TYPES.APPLICATION_JSON);
-
-        TestContext.set("httpResponse", applicationCreateResponse);
         Assert.assertEquals(applicationCreateResponse.getResponseCode(), 201, applicationCreateResponse.getData());
         Object createdAppId = Utils.extractValueFromPayload(applicationCreateResponse.getData(), "applicationId");
         TestContext.set("createdAppId", createdAppId);
@@ -100,10 +98,8 @@ public class ApplicationBaseSteps {
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.adminToken());
 
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPost(Utils.getApplicationThrottlingPoliciesURL(getBaseUrl()), headers, payload,
+        HttpResponse response = Requests.post(Utils.getApplicationThrottlingPoliciesURL(getBaseUrl()), headers, payload,
                         Constants.CONTENT_TYPES.APPLICATION_JSON);
-        TestContext.set("httpResponse", response);
         TestContext.set("appThrottlePolicyName", policyName);
 
         if (response.getResponseCode() >= 200 && response.getResponseCode() < 300) {
@@ -171,10 +167,8 @@ public class ApplicationBaseSteps {
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.adminToken());
 
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPost(Utils.getSubscriptionThrottlingPoliciesURL(getBaseUrl()), headers, payload,
+        HttpResponse response = Requests.post(Utils.getSubscriptionThrottlingPoliciesURL(getBaseUrl()), headers, payload,
                         Constants.CONTENT_TYPES.APPLICATION_JSON);
-        TestContext.set("httpResponse", response);
         TestContext.set("subThrottlePolicyName", policyName);
 
         if (response.getResponseCode() >= 200 && response.getResponseCode() < 300) {
@@ -206,10 +200,8 @@ public class ApplicationBaseSteps {
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.adminToken());
 
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPost(Utils.getAdvancedThrottlingPoliciesURL(getBaseUrl()), headers, payload,
+        HttpResponse response = Requests.post(Utils.getAdvancedThrottlingPoliciesURL(getBaseUrl()), headers, payload,
                         Constants.CONTENT_TYPES.APPLICATION_JSON);
-        TestContext.set("httpResponse", response);
         TestContext.set("advThrottlePolicyName", policyName);
 
         if (response.getResponseCode() >= 200 && response.getResponseCode() < 300) {
@@ -227,9 +219,7 @@ public class ApplicationBaseSteps {
                                  String cleanupListKey) throws IOException {
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.adminToken());
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPost(listUrl, headers, payload, Constants.CONTENT_TYPES.APPLICATION_JSON);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.post(listUrl, headers, payload, Constants.CONTENT_TYPES.APPLICATION_JSON);
         TestContext.set(nameKey, policyName);
         if (response.getResponseCode() >= 200 && response.getResponseCode() < 300) {
             Object policyId = Utils.extractValueFromPayload(response.getData(), "policyId");
@@ -331,14 +321,12 @@ public class ApplicationBaseSteps {
      */
     @When("I set the GraphQL complexity for API {string} from payload {string}")
     public void iSetGraphqlComplexity(String apiId, String payloadKey) throws IOException {
-        String actualApiId = Utils.resolveFromContext(apiId).toString();
-        String payload = Utils.resolveFromContext(payloadKey).toString();
+        String actualApiId = TestContext.resolve(apiId).toString();
+        String payload = TestContext.resolve(payloadKey).toString();
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPut(Utils.getGraphQLComplexityURL(getBaseUrl(), actualApiId), headers, payload,
+        HttpResponse response = Requests.put(Utils.getGraphQLComplexityURL(getBaseUrl(), actualApiId), headers, payload,
                         Constants.CONTENT_TYPES.APPLICATION_JSON);
-        TestContext.set("httpResponse", response);
     }
 
     /** Advanced (API-level) throttling policy with a BANDWIDTH limit (KB/min). */
@@ -375,39 +363,33 @@ public class ApplicationBaseSteps {
     /** Generic retrieve of a throttling policy by type + id (admin API). Non-asserting. */
     @When("I retrieve the {string} throttling policy with id {string}")
     public void iRetrieveThrottlingPolicyByType(String policyType, String idKey) throws IOException {
-        String policyId = Utils.resolveFromContext(idKey).toString();
+        String policyId = TestContext.resolve(idKey).toString();
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.adminToken());
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doGet(Utils.getThrottlingPolicyByTypeURL(getBaseUrl(), policyType, policyId), headers);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.get(Utils.getThrottlingPolicyByTypeURL(getBaseUrl(), policyType, policyId), headers);
     }
 
     /** Generic delete of a throttling policy by type + id (admin API). Non-asserting (also used for 404 checks). */
     @When("I delete the {string} throttling policy with id {string}")
     public void iDeleteThrottlingPolicyByType(String policyType, String idKey) throws IOException {
-        String policyId = Utils.resolveFromContext(idKey).toString();
+        String policyId = TestContext.resolve(idKey).toString();
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.adminToken());
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doDelete(Utils.getThrottlingPolicyByTypeURL(getBaseUrl(), policyType, policyId), headers);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.delete(Utils.getThrottlingPolicyByTypeURL(getBaseUrl(), policyType, policyId), headers);
     }
 
     /** Generic update: retrieve the policy, set a new description, and PUT it back. */
     @When("I update the {string} throttling policy {string} setting its description to {string}")
     public void iUpdateThrottlingPolicyDescription(String policyType, String idKey, String description)
             throws IOException {
-        String policyId = Utils.resolveFromContext(idKey).toString();
+        String policyId = TestContext.resolve(idKey).toString();
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.adminToken());
         String url = Utils.getThrottlingPolicyByTypeURL(getBaseUrl(), policyType, policyId);
         HttpResponse getResp = SimpleHTTPClient.getInstance().doGet(url, headers);
         JSONObject policy = new JSONObject(getResp.getData());
         policy.put("description", description);
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPut(url, headers, policy.toString(), Constants.CONTENT_TYPES.APPLICATION_JSON);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.put(url, headers, policy.toString(), Constants.CONTENT_TYPES.APPLICATION_JSON);
     }
 
     /** Retrieve all throttling policies of a type (admin API). Non-asserting. */
@@ -415,9 +397,7 @@ public class ApplicationBaseSteps {
     public void iRetrieveAllThrottlingPolicies(String policyType) throws IOException {
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.adminToken());
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doGet(Utils.getThrottlingPoliciesByTypeURL(getBaseUrl(), policyType), headers);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.get(Utils.getThrottlingPoliciesByTypeURL(getBaseUrl(), policyType), headers);
     }
 
     // ---- Admin gateway environment CRUD ----
@@ -458,10 +438,8 @@ public class ApplicationBaseSteps {
         }
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.adminToken());
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPost(Utils.getEnvironmentsURL(getBaseUrl()), headers, env.toString(),
+        HttpResponse response = Requests.post(Utils.getEnvironmentsURL(getBaseUrl()), headers, env.toString(),
                         Constants.CONTENT_TYPES.APPLICATION_JSON);
-        TestContext.set("httpResponse", response);
         if (response.getResponseCode() >= 200 && response.getResponseCode() < 300) {
             Object id = Utils.extractValueFromPayload(response.getData(), "id");
             if (id != null) {
@@ -499,35 +477,29 @@ public class ApplicationBaseSteps {
     public void iRetrieveAllGatewayEnvironments() throws IOException {
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.adminToken());
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doGet(Utils.getEnvironmentsURL(getBaseUrl()), headers);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.get(Utils.getEnvironmentsURL(getBaseUrl()), headers);
     }
 
     /** Retrieve a gateway environment by id (admin API). */
     @When("I retrieve the gateway environment with id {string}")
     public void iRetrieveGatewayEnvironment(String idKey) throws IOException {
-        String id = Utils.resolveFromContext(idKey).toString();
+        String id = TestContext.resolve(idKey).toString();
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.adminToken());
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doGet(Utils.getEnvironmentByIdURL(getBaseUrl(), id), headers);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.get(Utils.getEnvironmentByIdURL(getBaseUrl(), id), headers);
     }
 
     /** Update a gateway environment's description (GET → set → PUT). */
     @When("I update the gateway environment {string} setting its description to {string}")
     public void iUpdateGatewayEnvironment(String idKey, String description) throws IOException {
-        String id = Utils.resolveFromContext(idKey).toString();
+        String id = TestContext.resolve(idKey).toString();
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.adminToken());
         String url = Utils.getEnvironmentByIdURL(getBaseUrl(), id);
         HttpResponse getResp = SimpleHTTPClient.getInstance().doGet(url, headers);
         JSONObject env = new JSONObject(getResp.getData());
         env.put("description", description);
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPut(url, headers, env.toString(), Constants.CONTENT_TYPES.APPLICATION_JSON);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.put(url, headers, env.toString(), Constants.CONTENT_TYPES.APPLICATION_JSON);
     }
 
     /** Delete a gateway environment by id (admin API). Non-asserting (also used for 404 / delete-Default 400).
@@ -537,9 +509,7 @@ public class ApplicationBaseSteps {
         String id = TestContext.contains(idKey) ? TestContext.get(idKey).toString() : idKey;
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.adminToken());
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doDelete(Utils.getEnvironmentByIdURL(getBaseUrl(), id), headers);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.delete(Utils.getEnvironmentByIdURL(getBaseUrl(), id), headers);
     }
 
     /** Retrieve the gateway instances of an environment (admin API). The id may be a context key
@@ -549,9 +519,7 @@ public class ApplicationBaseSteps {
         String id = TestContext.contains(idKey) ? TestContext.get(idKey).toString() : idKey;
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.adminToken());
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doGet(Utils.getEnvironmentGatewaysURL(getBaseUrl(), id), headers);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.get(Utils.getEnvironmentGatewaysURL(getBaseUrl(), id), headers);
     }
 
     /** A vhost JSON object for a Regular (Synapse) gateway — http/https/ws/wss ports. */
@@ -564,10 +532,8 @@ public class ApplicationBaseSteps {
     private void postEnvironment(JSONObject env) throws IOException {
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.adminToken());
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPost(Utils.getEnvironmentsURL(getBaseUrl()), headers, env.toString(),
+        HttpResponse response = Requests.post(Utils.getEnvironmentsURL(getBaseUrl()), headers, env.toString(),
                         Constants.CONTENT_TYPES.APPLICATION_JSON);
-        TestContext.set("httpResponse", response);
         if (response.getResponseCode() >= 200 && response.getResponseCode() < 300) {
             Object id = Utils.extractValueFromPayload(response.getData(), "id");
             if (id != null) {
@@ -610,10 +576,7 @@ public class ApplicationBaseSteps {
         String owner = Identity.resolveActor(actorRef).getUserName();
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.adminToken());
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doGet(Utils.getAdminApplicationsByOwnerURL(getBaseUrl(), owner), headers);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.get(Utils.getAdminApplicationsByOwnerURL(getBaseUrl(), owner), headers);
     }
 
     /**
@@ -627,25 +590,20 @@ public class ApplicationBaseSteps {
         String actualName = Utils.resolveContextPlaceholders(name);
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.adminToken());
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doGet(Utils.getAdminApplicationsByNameURL(getBaseUrl(), actualName), headers);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.get(Utils.getAdminApplicationsByNameURL(getBaseUrl(), actualName), headers);
     }
 
     /** Update a gateway environment to a single vhost host (removing any others). Non-asserting. */
     @When("I update the gateway environment {string} to only vhost host {string}")
     public void iUpdateGatewayEnvironmentToSingleVhost(String idKey, String host) throws IOException {
-        String id = Utils.resolveFromContext(idKey).toString();
+        String id = TestContext.resolve(idKey).toString();
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.adminToken());
         String url = Utils.getEnvironmentByIdURL(getBaseUrl(), id);
         HttpResponse getResp = SimpleHTTPClient.getInstance().doGet(url, headers);
         JSONObject env = new JSONObject(getResp.getData());
         env.put("vhosts", new JSONArray().put(regularVhost(host)));
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPut(url, headers, env.toString(), Constants.CONTENT_TYPES.APPLICATION_JSON);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.put(url, headers, env.toString(), Constants.CONTENT_TYPES.APPLICATION_JSON);
     }
 
     /**
@@ -667,10 +625,8 @@ public class ApplicationBaseSteps {
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.adminToken());
 
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPost(Utils.getApplicationThrottlingPoliciesURL(getBaseUrl()), headers, payload,
+        HttpResponse response = Requests.post(Utils.getApplicationThrottlingPoliciesURL(getBaseUrl()), headers, payload,
                         Constants.CONTENT_TYPES.APPLICATION_JSON);
-        TestContext.set("httpResponse", response);
         TestContext.set("appThrottlePolicyName", policyName);
 
         if (response.getResponseCode() >= 200 && response.getResponseCode() < 300) {
@@ -717,10 +673,8 @@ public class ApplicationBaseSteps {
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.adminToken());
 
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPost(Utils.getCustomThrottlingPoliciesURL(getBaseUrl()), headers, payload,
+        HttpResponse response = Requests.post(Utils.getCustomThrottlingPoliciesURL(getBaseUrl()), headers, payload,
                         Constants.CONTENT_TYPES.APPLICATION_JSON);
-        TestContext.set("httpResponse", response);
         TestContext.set("customThrottlePolicyName", policyName);
 
         if (response.getResponseCode() >= 200 && response.getResponseCode() < 300) {
@@ -736,52 +690,44 @@ public class ApplicationBaseSteps {
     @When("I retrieve the application throttling policy {string}")
     public void iRetrieveApplicationThrottlingPolicy(String policyIdKey) throws IOException {
 
-        String policyId = Utils.resolveFromContext(policyIdKey).toString();
+        String policyId = TestContext.resolve(policyIdKey).toString();
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.adminToken());
 
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doGet(Utils.getApplicationThrottlingPolicyByIdURL(getBaseUrl(), policyId), headers);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.get(Utils.getApplicationThrottlingPolicyByIdURL(getBaseUrl(), policyId), headers);
     }
 
     /** Deletes an application throttling policy by id (admin API), storing the raw response for assertions. */
     @When("I delete the application throttling policy {string}")
     public void iDeleteApplicationThrottlingPolicy(String policyIdKey) throws IOException {
 
-        String policyId = Utils.resolveFromContext(policyIdKey).toString();
+        String policyId = TestContext.resolve(policyIdKey).toString();
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.adminToken());
 
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doDelete(Utils.getApplicationThrottlingPolicyByIdURL(getBaseUrl(), policyId), headers);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.delete(Utils.getApplicationThrottlingPolicyByIdURL(getBaseUrl(), policyId), headers);
     }
 
     /** Retrieves a custom (Siddhi) throttling rule by id (admin API), storing the raw response for assertions. */
     @When("I retrieve the custom throttling policy {string}")
     public void iRetrieveCustomThrottlingPolicy(String policyIdKey) throws IOException {
 
-        String policyId = Utils.resolveFromContext(policyIdKey).toString();
+        String policyId = TestContext.resolve(policyIdKey).toString();
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.adminToken());
 
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doGet(Utils.getCustomThrottlingPolicyByIdURL(getBaseUrl(), policyId), headers);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.get(Utils.getCustomThrottlingPolicyByIdURL(getBaseUrl(), policyId), headers);
     }
 
     /** Deletes a custom (Siddhi) throttling rule by id (admin API), storing the raw response for assertions. */
     @When("I delete the custom throttling policy {string}")
     public void iDeleteCustomThrottlingPolicy(String policyIdKey) throws IOException {
 
-        String policyId = Utils.resolveFromContext(policyIdKey).toString();
+        String policyId = TestContext.resolve(policyIdKey).toString();
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.adminToken());
 
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doDelete(Utils.getCustomThrottlingPolicyByIdURL(getBaseUrl(), policyId), headers);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.delete(Utils.getCustomThrottlingPolicyByIdURL(getBaseUrl(), policyId), headers);
     }
 
     /**
@@ -797,7 +743,7 @@ public class ApplicationBaseSteps {
     public void iCreateApplicationWithThrottlingPolicy(String appName, String policyNameKey) throws IOException {
 
         String resolvedName = Utils.resolvePayloadPlaceholders(appName);
-        String policyName = Utils.resolveFromContext(policyNameKey).toString();
+        String policyName = TestContext.resolve(policyNameKey).toString();
         String jsonPayload = String.format(
                 "{\"name\":\"%s\",\"throttlingPolicy\":\"%s\",\"description\":\"Throttle-enforcement test application\"}",
                 resolvedName, policyName);
@@ -805,10 +751,8 @@ public class ApplicationBaseSteps {
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.devportalToken());
 
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPost(Utils.getApplicationCreateURL(getBaseUrl()), headers, jsonPayload,
+        HttpResponse response = Requests.post(Utils.getApplicationCreateURL(getBaseUrl()), headers, jsonPayload,
                         Constants.CONTENT_TYPES.APPLICATION_JSON);
-        TestContext.set("httpResponse", response);
         Assert.assertEquals(response.getResponseCode(), 201, response.getData());
         Object createdAppId = Utils.extractValueFromPayload(response.getData(), "applicationId");
         TestContext.set("createdAppId", createdAppId);
@@ -824,15 +768,13 @@ public class ApplicationBaseSteps {
     @When("I attempt to create an application with payload {string}")
     public void iAttemptToCreateAnApplicationWithPayload(String payload) throws IOException {
 
-        String jsonPayload = Utils.resolveFromContext(payload).toString();
+        String jsonPayload = TestContext.resolve(payload).toString();
 
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.devportalToken());
 
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPost(Utils.getApplicationCreateURL(getBaseUrl()), headers, jsonPayload,
+        HttpResponse response = Requests.post(Utils.getApplicationCreateURL(getBaseUrl()), headers, jsonPayload,
                         Constants.CONTENT_TYPES.APPLICATION_JSON);
-        TestContext.set("httpResponse", response);
     }
 
     /**
@@ -843,15 +785,12 @@ public class ApplicationBaseSteps {
     @When("I delete the application with id {string}")
     public void iDeleteApplication(String appId) throws IOException{
 
-        String actualAppId = Utils.resolveFromContext(appId).toString();
+        String actualAppId = TestContext.resolve(appId).toString();
 
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.devportalToken());
 
-        HttpResponse applicationDeleteResponse = SimpleHTTPClient.getInstance()
-                .doDelete(Utils.getApplicationEndpointURL(getBaseUrl(), actualAppId), headers);
-
-        TestContext.set("httpResponse", applicationDeleteResponse);
+        HttpResponse applicationDeleteResponse = Requests.delete(Utils.getApplicationEndpointURL(getBaseUrl(), actualAppId), headers);
     }
 
     /**
@@ -862,15 +801,12 @@ public class ApplicationBaseSteps {
     @When("I retrieve the application with id {string}")
     public void iShouldBeAbleToRetrieveApplication(String appId) throws Exception {
 
-        String actualAppId = Utils.resolveFromContext(appId).toString();
+        String actualAppId = TestContext.resolve(appId).toString();
 
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.devportalToken());
 
-        HttpResponse applicationRetrieveResponse = SimpleHTTPClient.getInstance()
-                .doGet(Utils.getApplicationEndpointURL(getBaseUrl(), actualAppId), headers);
-
-        TestContext.set("httpResponse", applicationRetrieveResponse);
+        HttpResponse applicationRetrieveResponse = Requests.get(Utils.getApplicationEndpointURL(getBaseUrl(), actualAppId), headers);
     }
 
     /**
@@ -886,8 +822,7 @@ public class ApplicationBaseSteps {
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION,
                 "Bearer " + Identity.devportalToken());
 
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doGet(Utils.getApplicationSearchURL(getBaseUrl(), applicationName), headers);
+        HttpResponse response = Requests.get(Utils.getApplicationSearchURL(getBaseUrl(), applicationName), headers);
 
         TestContext.set("httpResponse", response);
 
@@ -912,20 +847,18 @@ public class ApplicationBaseSteps {
     @When("I update the application {string} with payload {string}")
     public void iUpdateTheApplicationWithPayload(String appId, String updatePayload) throws IOException {
 
-        String actualAppId = Utils.resolveFromContext(appId).toString();
+        String actualAppId = TestContext.resolve(appId).toString();
         // Resolve any {{contextKey}} placeholders (e.g. a captured application name so the PUT keeps its
         // required name). No-op when the payload has none.
-        String jsonPayload = Utils.resolveContextPlaceholders(Utils.resolveFromContext(updatePayload).toString());
+        String jsonPayload = Utils.resolveContextPlaceholders(TestContext.resolve(updatePayload).toString());
 
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION,
                 "Bearer " + Identity.devportalToken());
 
-        HttpResponse response = SimpleHTTPClient.getInstance().doPut(
+        HttpResponse response = Requests.put(
                 Utils.getApplicationEndpointURL(getBaseUrl(), actualAppId), headers, jsonPayload,
                 Constants.CONTENT_TYPES.APPLICATION_JSON);
-
-        TestContext.set("httpResponse", response);
     }
 
     /**
@@ -941,11 +874,11 @@ public class ApplicationBaseSteps {
     @When("I subscribe to API {string} using application {string} with payload {string} as {string}")
     public void iSubscribeToApi(String apiId, String appId, String payload, String subscriptionID) throws Exception {
 
-        String actualApiId = Utils.resolveFromContext(apiId).toString();
-        String actualAppId = Utils.resolveFromContext(appId).toString();
+        String actualApiId = TestContext.resolve(apiId).toString();
+        String actualAppId = TestContext.resolve(appId).toString();
 
         // Add application id and API id to the payload
-        String jsonPayload = Utils.resolveFromContext(payload).toString();
+        String jsonPayload = TestContext.resolve(payload).toString();
         jsonPayload = jsonPayload.replace("{{applicationId}}", actualAppId);
         jsonPayload = jsonPayload.replace("{{apiId}}", actualApiId);
         // Resolve any remaining {{contextKey}} placeholders (e.g. a custom subscription throttling policy name
@@ -956,10 +889,8 @@ public class ApplicationBaseSteps {
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.devportalToken());
 
-        HttpResponse response = SimpleHTTPClient.getInstance().doPost(Utils.getCreateSubscriptionURL(getBaseUrl()),
+        HttpResponse response = Requests.post(Utils.getCreateSubscriptionURL(getBaseUrl()),
                 headers, jsonPayload, Constants.CONTENT_TYPES.APPLICATION_JSON);
-
-        TestContext.set("httpResponse", response);
         Assert.assertEquals(response.getResponseCode(), 201, response.getData());
         TestContext.set(subscriptionID,Utils.extractValueFromPayload(response.getData(), "subscriptionId"));
     }
@@ -973,10 +904,10 @@ public class ApplicationBaseSteps {
     @When("I attempt to subscribe to API {string} using application {string} with payload {string}")
     public void iAttemptToSubscribeToApi(String apiId, String appId, String payload) throws Exception {
 
-        String actualApiId = Utils.resolveFromContext(apiId).toString();
-        String actualAppId = Utils.resolveFromContext(appId).toString();
+        String actualApiId = TestContext.resolve(apiId).toString();
+        String actualAppId = TestContext.resolve(appId).toString();
 
-        String jsonPayload = Utils.resolveFromContext(payload).toString();
+        String jsonPayload = TestContext.resolve(payload).toString();
         jsonPayload = jsonPayload.replace("{{applicationId}}", actualAppId);
         jsonPayload = jsonPayload.replace("{{apiId}}", actualApiId);
         // Resolve any remaining {{contextKey}} placeholders, mirroring the positive iSubscribeToApi step. This
@@ -988,9 +919,8 @@ public class ApplicationBaseSteps {
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.devportalToken());
 
-        HttpResponse response = SimpleHTTPClient.getInstance().doPost(Utils.getCreateSubscriptionURL(getBaseUrl()),
+        HttpResponse response = Requests.post(Utils.getCreateSubscriptionURL(getBaseUrl()),
                 headers, jsonPayload, Constants.CONTENT_TYPES.APPLICATION_JSON);
-        TestContext.set("httpResponse", response);
     }
 
     /**
@@ -1002,17 +932,14 @@ public class ApplicationBaseSteps {
     @Then("I retrieve the subscription for Api {string} by Application {string}")
     public void iShouldBeAbleToRetrieveSubscription(String apiId, String appId) throws Exception {
 
-        String actualApiId = Utils.resolveFromContext(apiId).toString();
-        String actualAppId = Utils.resolveFromContext(appId).toString();
+        String actualApiId = TestContext.resolve(apiId).toString();
+        String actualAppId = TestContext.resolve(appId).toString();
 
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.devportalToken());
 
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doGet(Utils.getAllSubscriptionsURL(getBaseUrl(), actualApiId, actualAppId, null, null,
+        HttpResponse response = Requests.get(Utils.getAllSubscriptionsURL(getBaseUrl(), actualApiId, actualAppId, null, null,
                         null), headers);
-
-        TestContext.set("httpResponse", response);
 
         JSONObject responseJson = new JSONObject(response.getData());
         if (responseJson.has("list") && !responseJson.getJSONArray("list").isEmpty()) {
@@ -1035,15 +962,12 @@ public class ApplicationBaseSteps {
     @When("I retrieve existing application keys for {string}")
     public void iRetrieveExistingApplicationKeys(String appId) throws IOException {
 
-        String actualAppId = Utils.resolveFromContext(appId).toString();
+        String actualAppId = TestContext.resolve(appId).toString();
 
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.devportalToken());
 
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doGet(Utils.getApplicationAllKeys(getBaseUrl(), actualAppId), headers);
-
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.get(Utils.getApplicationAllKeys(getBaseUrl(), actualAppId), headers);
 
         JSONObject responseJson = new JSONObject(response.getData());
         if (responseJson.has("list") && !responseJson.getJSONArray("list").isEmpty()) {
@@ -1076,17 +1000,15 @@ public class ApplicationBaseSteps {
     @And("I update the keys for application with {string}")
     public void iUpdateTheKeysForApplicationWith(String appId) throws IOException {
 
-        String actualAppId = Utils.resolveFromContext(appId).toString();
-        String keyMappingId = Utils.resolveFromContext("keyMappingId").toString();
-        String jsonPayload =Utils.resolveFromContext("updateKeysPayload").toString();
+        String actualAppId = TestContext.resolve(appId).toString();
+        String keyMappingId = TestContext.resolve("keyMappingId").toString();
+        String jsonPayload =TestContext.resolve("updateKeysPayload").toString();
 
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.devportalToken());
 
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPut(Utils.getUpdateKey(getBaseUrl(), actualAppId, keyMappingId), headers, jsonPayload,
+        HttpResponse response = Requests.put(Utils.getUpdateKey(getBaseUrl(), actualAppId, keyMappingId), headers, jsonPayload,
                         Constants.CONTENT_TYPES.APPLICATION_JSON);
-        TestContext.set("httpResponse", response);
     }
 
     /**
@@ -1097,15 +1019,13 @@ public class ApplicationBaseSteps {
     @When("I delete the generated keys for {string}")
     public void iDeleteTheGeneratedKeysFor(String appId) throws IOException {
 
-        String actualAppId = Utils.resolveFromContext(appId).toString();
-        String keyMappingId = Utils.resolveFromContext("keyMappingId").toString();
+        String actualAppId = TestContext.resolve(appId).toString();
+        String keyMappingId = TestContext.resolve("keyMappingId").toString();
 
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.devportalToken());
 
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doDelete(Utils.getUpdateKey(getBaseUrl(), actualAppId, keyMappingId), headers);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.delete(Utils.getUpdateKey(getBaseUrl(), actualAppId, keyMappingId), headers);
     }
 
     /**
@@ -1118,18 +1038,15 @@ public class ApplicationBaseSteps {
     @When("I generate client credentials for application id {string} with payload {string}")
     public void iGenerateClientCredentialsForApplication(String appId, String payload) throws Exception {
 
-        String actualAppId = Utils.resolveFromContext(appId).toString();
+        String actualAppId = TestContext.resolve(appId).toString();
         // Resolve any {{contextKey}} placeholders (e.g. a captured key-manager name for a specific-KM key-gen).
-        String jsonPayload = Utils.resolveContextPlaceholders(Utils.resolveFromContext(payload).toString());
+        String jsonPayload = Utils.resolveContextPlaceholders(TestContext.resolve(payload).toString());
 
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.devportalToken());
 
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPost(Utils.getGenerateApplicationKeysURL(getBaseUrl(), actualAppId), headers, jsonPayload,
+        HttpResponse response = Requests.post(Utils.getGenerateApplicationKeysURL(getBaseUrl(), actualAppId), headers, jsonPayload,
                         Constants.CONTENT_TYPES.APPLICATION_JSON);
-
-        TestContext.set("httpResponse", response);
         // Only extract key fields on success — a non-2xx (e.g. a KM that denies the user's role → 403) has no
         // consumerKey, and extracting it would throw before the feature can assert the rejection status.
         if (response.getResponseCode() >= 200 && response.getResponseCode() < 300) {
@@ -1169,15 +1086,18 @@ public class ApplicationBaseSteps {
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Basic " + encodedCredentials);
 
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance().doPost(
+        HttpResponse response = Requests.post(
                 Utils.getDCREndpointURL(getBaseUrl()), headers, json.toString(),
                 Constants.CONTENT_TYPES.APPLICATION_JSON);
-        TestContext.set("httpResponse", response);
         Assert.assertEquals(response.getResponseCode(), 200,
                 "BYO OAuth client registration (DCR) failed: " + response.getData());
-        TestContext.set(idKey + "ClientId", Utils.extractValueFromPayload(response.getData(), "clientId"));
+        Object clientId = Utils.extractValueFromPayload(response.getData(), "clientId");
+        TestContext.set(idKey + "ClientId", clientId);
         TestContext.set(idKey + "ClientSecret", Utils.extractValueFromPayload(response.getData(), "clientSecret"));
+        // A DCR client is a standalone OAuth service provider not removed by app deletion, and the DCR REST
+        // endpoint has no delete — so register its consumer key for teardown, which deregisters it via the
+        // OAuthAdminService SOAP admin service (as its owner) rather than leaking it onto the shared server.
+        ResourceCleanup.register(ResourceCleanup.CREATED_DCR_CLIENT_IDS, clientId);
     }
 
     /**
@@ -1194,9 +1114,9 @@ public class ApplicationBaseSteps {
     @When("I map OAuth client {string} to application {string} via key manager {string}")
     public void iMapOAuthClientToApplication(String idKey, String appId, String keyManager) throws IOException {
 
-        String actualAppId = Utils.resolveFromContext(appId).toString();
-        String consumerKey = Utils.resolveFromContext(idKey + "ClientId").toString();
-        String consumerSecret = Utils.resolveFromContext(idKey + "ClientSecret").toString();
+        String actualAppId = TestContext.resolve(appId).toString();
+        String consumerKey = TestContext.resolve(idKey + "ClientId").toString();
+        String consumerSecret = TestContext.resolve(idKey + "ClientSecret").toString();
 
         JSONObject json = new JSONObject();
         json.put("consumerKey", consumerKey);
@@ -1207,11 +1127,9 @@ public class ApplicationBaseSteps {
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.devportalToken());
 
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance().doPost(
+        HttpResponse response = Requests.post(
                 Utils.getMapKeysURL(getBaseUrl(), actualAppId), headers, json.toString(),
                 Constants.CONTENT_TYPES.APPLICATION_JSON);
-        TestContext.set("httpResponse", response);
     }
 
     /**
@@ -1225,17 +1143,15 @@ public class ApplicationBaseSteps {
     @When("I clean up the key registration for application {string} with key mapping {string}")
     public void iCleanUpKeyRegistration(String appId, String keyMappingIdKey) throws IOException {
 
-        String actualAppId = Utils.resolveFromContext(appId).toString();
-        String keyMappingId = Utils.resolveFromContext(keyMappingIdKey).toString();
+        String actualAppId = TestContext.resolve(appId).toString();
+        String keyMappingId = TestContext.resolve(keyMappingIdKey).toString();
 
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.devportalToken());
 
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance().doPost(
+        HttpResponse response = Requests.post(
                 Utils.getCleanupRegistrationURL(getBaseUrl(), actualAppId, keyMappingId), headers, "",
                 Constants.CONTENT_TYPES.APPLICATION_JSON);
-        TestContext.set("httpResponse", response);
     }
 
     /**
@@ -1291,15 +1207,13 @@ public class ApplicationBaseSteps {
     @When("I regenerate the consumer secret for application {string} with key mapping {string}")
     public void iRegenerateConsumerSecret(String appId, String keyMappingIdKey) throws IOException {
 
-        String actualAppId = Utils.resolveFromContext(appId).toString();
-        String keyMappingId = Utils.resolveFromContext(keyMappingIdKey).toString();
+        String actualAppId = TestContext.resolve(appId).toString();
+        String keyMappingId = TestContext.resolve(keyMappingIdKey).toString();
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.devportalToken());
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance().doPost(
+        HttpResponse response = Requests.post(
                 Utils.getRegenerateConsumerSecretURL(getBaseUrl(), actualAppId, keyMappingId), headers, "",
                 Constants.CONTENT_TYPES.APPLICATION_JSON);
-        TestContext.set("httpResponse", response);
     }
 
     /**
@@ -1313,22 +1227,19 @@ public class ApplicationBaseSteps {
     @When("I request an access token for application id {string} using payload {string}")
     public void iRequestAccessToken(String appId, String payload) throws Exception {
 
-        String actualAppId = Utils.resolveFromContext(appId).toString();
-        String keyMappingId = Utils.resolveFromContext("keyMappingId").toString();
-        String consumerSecret = Utils.resolveFromContext("consumerSecret").toString();
+        String actualAppId = TestContext.resolve(appId).toString();
+        String keyMappingId = TestContext.resolve("keyMappingId").toString();
+        String consumerSecret = TestContext.resolve("consumerSecret").toString();
 
         // Add consumer secret to the payload
-        String jsonPayload = Utils.resolveFromContext(payload).toString();
+        String jsonPayload = TestContext.resolve(payload).toString();
         jsonPayload = jsonPayload.replace("{{appConsumerSecret}}", consumerSecret);
 
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.devportalToken());
 
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPost(Utils.getGenerateApplicationTokenURL(getBaseUrl(), actualAppId, keyMappingId), headers, jsonPayload,
+        HttpResponse response = Requests.post(Utils.getGenerateApplicationTokenURL(getBaseUrl(), actualAppId, keyMappingId), headers, jsonPayload,
                         Constants.CONTENT_TYPES.APPLICATION_JSON);
-
-        TestContext.set("httpResponse", response);
         String accessToken = Utils.extractValueFromPayload(response.getData(), "accessToken").toString();
         TestContext.set("generatedAccessToken", accessToken);
     }
@@ -1353,10 +1264,8 @@ public class ApplicationBaseSteps {
             body.append("&scope=").append(urlEncode(scope));
         }
 
-        HttpResponse response = SimpleHTTPClient.getInstance().doPost(Utils.getAPIMTokenEndpointURL(getBaseUrl()),
+        HttpResponse response = Requests.post(Utils.getAPIMTokenEndpointURL(getBaseUrl()),
                 clientCredentialsHeader(), body.toString(), Constants.CONTENT_TYPES.APPLICATION_X_WWW_FORM_URLENCODED);
-
-        TestContext.set("httpResponse", response);
         captureTokens(response);
     }
 
@@ -1369,14 +1278,12 @@ public class ApplicationBaseSteps {
     @When("I request a new OAuth access token using refresh token {string}")
     public void iRequestTokenUsingRefreshToken(String refreshTokenKey) throws Exception {
 
-        String refreshToken = Utils.resolveFromContext(refreshTokenKey).toString();
+        String refreshToken = TestContext.resolve(refreshTokenKey).toString();
 
         String body = "grant_type=refresh_token&refresh_token=" + urlEncode(refreshToken);
 
-        HttpResponse response = SimpleHTTPClient.getInstance().doPost(Utils.getAPIMTokenEndpointURL(getBaseUrl()),
+        HttpResponse response = Requests.post(Utils.getAPIMTokenEndpointURL(getBaseUrl()),
                 clientCredentialsHeader(), body, Constants.CONTENT_TYPES.APPLICATION_X_WWW_FORM_URLENCODED);
-
-        TestContext.set("httpResponse", response);
         captureTokens(response);
     }
 
@@ -1393,13 +1300,11 @@ public class ApplicationBaseSteps {
     @When("I revoke the OAuth access token {string}")
     public void iRevokeOAuthAccessToken(String tokenKey) throws Exception {
 
-        String token = Utils.resolveFromContext(tokenKey).toString();
+        String token = TestContext.resolve(tokenKey).toString();
 
-        HttpResponse response = SimpleHTTPClient.getInstance().doPost(Utils.getRevokeEndpointURL(getBaseUrl()),
+        HttpResponse response = Requests.post(Utils.getRevokeEndpointURL(getBaseUrl()),
                 clientCredentialsHeader(), "token=" + token,
                 Constants.CONTENT_TYPES.APPLICATION_X_WWW_FORM_URLENCODED);
-
-        TestContext.set("httpResponse", response);
     }
 
     /**
@@ -1408,8 +1313,8 @@ public class ApplicationBaseSteps {
      */
     private Map<String, String> clientCredentialsHeader() {
 
-        String consumerKey = Utils.resolveFromContext("consumerKey").toString();
-        String consumerSecret = Utils.resolveFromContext("consumerSecret").toString();
+        String consumerKey = TestContext.resolve("consumerKey").toString();
+        String consumerSecret = TestContext.resolve("consumerSecret").toString();
         String credentials = Base64.getEncoder().encodeToString(
                 (consumerKey + ":" + consumerSecret).getBytes(StandardCharsets.UTF_8));
 
@@ -1445,7 +1350,7 @@ public class ApplicationBaseSteps {
     @Then("The generated access token should be in JWT format")
     public void theGeneratedAccessTokenShouldBeInJWTFormat() {
 
-        String token = Utils.resolveFromContext("generatedAccessToken").toString();
+        String token = TestContext.resolve("generatedAccessToken").toString();
         String[] parts = token.split("\\.");
         Assert.assertEquals(parts.length, 3,
                 "Access token is not in JWT format (expected 3 dot-separated segments): " + token);
@@ -1465,17 +1370,14 @@ public class ApplicationBaseSteps {
     @And("I request an api key for application id {string} using payload {string}")
     public void iRequestAnApiKeyForApplicationIdUsingPayload(String appId, String payload) throws IOException {
 
-        String actualAppId = Utils.resolveFromContext(appId).toString();
-        String jsonPayload = Utils.resolveFromContext(payload).toString();
+        String actualAppId = TestContext.resolve(appId).toString();
+        String jsonPayload = TestContext.resolve(payload).toString();
 
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.devportalToken());
 
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPost(Utils.getGenerateAPIKeyURL(getBaseUrl(), actualAppId), headers, jsonPayload,
+        HttpResponse response = Requests.post(Utils.getGenerateAPIKeyURL(getBaseUrl(), actualAppId), headers, jsonPayload,
                         Constants.CONTENT_TYPES.APPLICATION_JSON);
-
-        TestContext.set("httpResponse", response);
         String apikey = Utils.extractValueFromPayload(response.getData(), "apikey").toString();
         TestContext.set("apiKey", apikey);
     }
@@ -1490,14 +1392,12 @@ public class ApplicationBaseSteps {
      */
     @When("I retrieve the api key UUID for application id {string} as {string}")
     public void iRetrieveApiKeyUuid(String appId, String ctxKey) throws IOException {
-        String actualAppId = Utils.resolveFromContext(appId).toString();
+        String actualAppId = TestContext.resolve(appId).toString();
 
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.devportalToken());
 
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doGet(Utils.getListAPIKeysURL(getBaseUrl(), actualAppId), headers);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.get(Utils.getListAPIKeysURL(getBaseUrl(), actualAppId), headers);
         // The endpoint returns either a bare array [{...}] or a {"count":n,"list":[...]} wrapper depending on
         // the pack — handle both. Each scenario's app has a single key, so the first entry is the one to revoke.
         String data = response.getData().trim();
@@ -1519,17 +1419,15 @@ public class ApplicationBaseSteps {
      */
     @When("I revoke the api key with UUID {string} for application id {string}")
     public void iRevokeApiKeyByUuid(String uuidRef, String appId) throws IOException {
-        String actualAppId = Utils.resolveFromContext(appId).toString();
-        String uuid = Utils.resolveFromContext(uuidRef).toString();
+        String actualAppId = TestContext.resolve(appId).toString();
+        String uuid = TestContext.resolve(uuidRef).toString();
 
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.devportalToken());
         String payload = "{\"keyUUID\":\"" + uuid + "\"}";
 
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPost(Utils.getRevokeAPIKeyURL(getBaseUrl(), actualAppId), headers, payload,
+        HttpResponse response = Requests.post(Utils.getRevokeAPIKeyURL(getBaseUrl(), actualAppId), headers, payload,
                         Constants.CONTENT_TYPES.APPLICATION_JSON);
-        TestContext.set("httpResponse", response);
     }
 
     /**
@@ -1539,15 +1437,13 @@ public class ApplicationBaseSteps {
      */
     @When("I delete the subscription with id {string}")
     public void iDeleteSubscription(String subscriptionId) throws Exception {
-        String actualSubscriptionId = Utils.resolveFromContext(subscriptionId).toString();
+        String actualSubscriptionId = TestContext.resolve(subscriptionId).toString();
 
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.devportalToken());
 
-        HttpResponse response = SimpleHTTPClient.getInstance().doDelete(Utils.getSubscriptionURL(getBaseUrl(),
+        HttpResponse response = Requests.delete(Utils.getSubscriptionURL(getBaseUrl(),
                 actualSubscriptionId), headers);
-
-        TestContext.set("httpResponse", response);
     }
 
     /**
@@ -1560,10 +1456,10 @@ public class ApplicationBaseSteps {
     @When("I update the subscription {string} with subscription plan {string}")
     public void iUpdateTheSubscriptionWithSubscriptionPlan(String subscriptionId, String subscriptionPlan) throws IOException {
 
-        String actualSubscriptionId = Utils.resolveFromContext(subscriptionId).toString();
+        String actualSubscriptionId = TestContext.resolve(subscriptionId).toString();
 
         // Add application id and API id to the payload
-        String jsonPayload = Utils.resolveFromContext("subscriptionPayload").toString();
+        String jsonPayload = TestContext.resolve("subscriptionPayload").toString();
         // Set the throttling policy to the requested plan regardless of the current value or JSON spacing
         // (the payload may be a pretty-printed template or a compact subscription response).
         jsonPayload = jsonPayload.replaceAll("(\"throttlingPolicy\"\\s*:\\s*)\"[^\"]*\"",
@@ -1582,10 +1478,8 @@ public class ApplicationBaseSteps {
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.devportalToken());
 
-        HttpResponse response = SimpleHTTPClient.getInstance().doPut(Utils.getSubscriptionURL(getBaseUrl(), actualSubscriptionId),
+        HttpResponse response = Requests.put(Utils.getSubscriptionURL(getBaseUrl(), actualSubscriptionId),
                 headers, jsonPayload, Constants.CONTENT_TYPES.APPLICATION_JSON);
-
-        TestContext.set("httpResponse", response);
     }
 
     /**
@@ -1596,15 +1490,13 @@ public class ApplicationBaseSteps {
     @When("I get the subscription with id {string}")
     public void iGetSubscription(String subscriptionId) throws Exception {
 
-        String actualSubscriptionId = Utils.resolveFromContext(subscriptionId).toString();
+        String actualSubscriptionId = TestContext.resolve(subscriptionId).toString();
 
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.devportalToken());
 
-        HttpResponse response = SimpleHTTPClient.getInstance().doGet(Utils.getSubscriptionURL(getBaseUrl(),
+        HttpResponse response = Requests.get(Utils.getSubscriptionURL(getBaseUrl(),
                 actualSubscriptionId), headers);
-
-        TestContext.set("httpResponse", response);
     }
 
     /**
@@ -1617,7 +1509,7 @@ public class ApplicationBaseSteps {
     @Then("The subscription with id {string} should be in the list of all subscriptions")
     public void subscriptionShouldBeInTheListOfAllSubscriptions(String subscriptionId) {
 
-        String actualSubscriptionId = Utils.resolveFromContext(subscriptionId).toString();
+        String actualSubscriptionId = TestContext.resolve(subscriptionId).toString();
         HttpResponse response = (HttpResponse) TestContext.get("httpResponse");
         JSONArray subscriptionsList= new JSONObject(response.getData()).getJSONArray("list");
 
@@ -1811,15 +1703,12 @@ public class ApplicationBaseSteps {
      */
     @And("I retrieve devportal documents for {string}")
     public void iRetrieveDevportalDocumentsFor(String resourceId) throws IOException {
-        String actualApiId = Utils.resolveFromContext(resourceId).toString();
+        String actualApiId = TestContext.resolve(resourceId).toString();
 
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.devportalToken());
 
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doGet(Utils.getApiDocumentsURL(getBaseUrl(), actualApiId), headers);
-
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.get(Utils.getApiDocumentsURL(getBaseUrl(), actualApiId), headers);
     }
 
     // ---- Key manager configuration (admin) -------------------------------------------------------------
@@ -1843,17 +1732,14 @@ public class ApplicationBaseSteps {
         TestContext.remove("httpResponse");
         HttpResponse response = SimpleHTTPClient.getInstance().doPut(Utils.getRoleAliasesURL(getBaseUrl()),
                 adminAuthHeaders(), payload.toString(), Constants.CONTENT_TYPES.APPLICATION_JSON);
-        TestContext.set("httpResponse", response);
     }
 
     /** Retrieves the system-scope role-alias mappings (admin REST {@code GET /role-aliases}). Non-asserting. */
     @When("I retrieve the role aliases")
     public void iRetrieveRoleAliases() throws IOException {
 
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance().doGet(Utils.getRoleAliasesURL(getBaseUrl()),
+        HttpResponse response = Requests.get(Utils.getRoleAliasesURL(getBaseUrl()),
                 adminAuthHeaders());
-        TestContext.set("httpResponse", response);
     }
 
     /**
@@ -1864,10 +1750,8 @@ public class ApplicationBaseSteps {
     public void iClearRoleAliases() throws IOException {
 
         JSONObject payload = new JSONObject().put("count", 0).put("list", new JSONArray());
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance().doPut(Utils.getRoleAliasesURL(getBaseUrl()),
+        HttpResponse response = Requests.put(Utils.getRoleAliasesURL(getBaseUrl()),
                 adminAuthHeaders(), payload.toString(), Constants.CONTENT_TYPES.APPLICATION_JSON);
-        TestContext.set("httpResponse", response);
     }
 
     /** Maps a friendly throttling-policy kind to the export/import {@code type} token. */
@@ -1890,11 +1774,9 @@ public class ApplicationBaseSteps {
     @When("I export the {string} throttling policy named {string} as {string}")
     public void iExportThrottlePolicy(String kind, String nameKey, String exportKey) throws IOException {
 
-        String name = Utils.resolveFromContext(nameKey).toString();
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance().doGet(
+        String name = TestContext.resolve(nameKey).toString();
+        HttpResponse response = Requests.get(
                 Utils.getThrottlePolicyExportURL(getBaseUrl(), name, throttleExportType(kind)), adminAuthHeaders());
-        TestContext.set("httpResponse", response);
         if (response.getResponseCode() >= 200 && response.getResponseCode() < 300) {
             TestContext.set(Utils.normalizeContextKey(exportKey), response.getData());
         }
@@ -1909,17 +1791,15 @@ public class ApplicationBaseSteps {
     @When("I import the throttling policy from {string} with overwrite {string}")
     public void iImportThrottlePolicy(String exportKey, String overwrite) throws IOException {
 
-        String body = Utils.resolveFromContext(exportKey).toString();
+        String body = TestContext.resolve(exportKey).toString();
         java.io.File temp = java.io.File.createTempFile("throttle-policy", ".json");
         temp.deleteOnExit();
         java.nio.file.Files.write(temp.toPath(), body.getBytes(StandardCharsets.UTF_8));
 
         Map<String, java.io.File> files = new HashMap<>();
         files.put("file", temp);
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance().doPostMultipartWithFiles(
+        HttpResponse response = Requests.postMultipart(
                 Utils.getThrottlePolicyImportURL(getBaseUrl(), overwrite), adminAuthHeaders(), files, new HashMap<>());
-        TestContext.set("httpResponse", response);
     }
 
     /** Loads a key-manager JSON payload off the classpath, resolving {@code ${UNIQUE:...}} name placeholders. */
@@ -1936,10 +1816,8 @@ public class ApplicationBaseSteps {
 
     private HttpResponse postKeyManager(JSONObject payload) throws IOException {
 
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance().doPost(Utils.getKeyManagersURL(getBaseUrl()),
+        HttpResponse response = Requests.post(Utils.getKeyManagersURL(getBaseUrl()),
                 adminAuthHeaders(), payload.toString(), Constants.CONTENT_TYPES.APPLICATION_JSON);
-        TestContext.set("httpResponse", response);
         return response;
     }
 
@@ -1987,21 +1865,15 @@ public class ApplicationBaseSteps {
     @When("I retrieve the key manager {string}")
     public void iRetrieveKeyManager(String idKey) throws IOException {
 
-        String kmId = Utils.resolveFromContext(idKey).toString();
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doGet(Utils.getKeyManagerByIdURL(getBaseUrl(), kmId), adminAuthHeaders());
-        TestContext.set("httpResponse", response);
+        String kmId = TestContext.resolve(idKey).toString();
+        HttpResponse response = Requests.get(Utils.getKeyManagerByIdURL(getBaseUrl(), kmId), adminAuthHeaders());
     }
 
     /** Lists all key managers. */
     @When("I retrieve all key managers")
     public void iRetrieveAllKeyManagers() throws IOException {
 
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doGet(Utils.getKeyManagersURL(getBaseUrl()), adminAuthHeaders());
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.get(Utils.getKeyManagersURL(getBaseUrl()), adminAuthHeaders());
     }
 
     /**
@@ -2011,7 +1883,7 @@ public class ApplicationBaseSteps {
     @When("I update the key manager {string} setting its description to {string}")
     public void iUpdateKeyManagerDescription(String idKey, String newDescription) throws IOException {
 
-        String kmId = Utils.resolveFromContext(idKey).toString();
+        String kmId = TestContext.resolve(idKey).toString();
         HttpResponse current = SimpleHTTPClient.getInstance()
                 .doGet(Utils.getKeyManagerByIdURL(getBaseUrl(), kmId), adminAuthHeaders());
         Assert.assertEquals(current.getResponseCode(), 200, current.getData());
@@ -2019,22 +1891,17 @@ public class ApplicationBaseSteps {
         JSONObject km = new JSONObject(current.getData());
         km.put("description", newDescription);
 
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance().doPut(
+        HttpResponse response = Requests.put(
                 Utils.getKeyManagerByIdURL(getBaseUrl(), kmId), adminAuthHeaders(), km.toString(),
                 Constants.CONTENT_TYPES.APPLICATION_JSON);
-        TestContext.set("httpResponse", response);
     }
 
     /** Deletes the key manager held under {@code idKey}. Non-asserting — the feature asserts the status. */
     @When("I delete the key manager {string}")
     public void iDeleteKeyManager(String idKey) throws IOException {
 
-        String kmId = Utils.resolveFromContext(idKey).toString();
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doDelete(Utils.getKeyManagerByIdURL(getBaseUrl(), kmId), adminAuthHeaders());
-        TestContext.set("httpResponse", response);
+        String kmId = TestContext.resolve(idKey).toString();
+        HttpResponse response = Requests.delete(Utils.getKeyManagerByIdURL(getBaseUrl(), kmId), adminAuthHeaders());
     }
 
     /**
@@ -2082,7 +1949,7 @@ public class ApplicationBaseSteps {
     @When("I set the allowed organizations of key manager {string} to {string}")
     public void iSetKeyManagerAllowedOrgs(String idKey, String allowedOrgs) throws IOException {
 
-        String kmId = Utils.resolveFromContext(idKey).toString();
+        String kmId = TestContext.resolve(idKey).toString();
         HttpResponse current = SimpleHTTPClient.getInstance()
                 .doGet(Utils.getKeyManagerByIdURL(getBaseUrl(), kmId), adminAuthHeaders());
         Assert.assertEquals(current.getResponseCode(), 200, current.getData());
@@ -2092,11 +1959,9 @@ public class ApplicationBaseSteps {
             orgs.put(o);
         }
         km.put("allowedOrganizations", orgs);
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance().doPut(
+        HttpResponse response = Requests.put(
                 Utils.getKeyManagerByIdURL(getBaseUrl(), kmId), adminAuthHeaders(), km.toString(),
                 Constants.CONTENT_TYPES.APPLICATION_JSON);
-        TestContext.set("httpResponse", response);
     }
 
     // ---- Deny (blocking-condition) policies (admin) ----------------------------------------------------
@@ -2107,10 +1972,8 @@ public class ApplicationBaseSteps {
         dto.put("conditionType", conditionType);
         dto.put("conditionValue", conditionValue);
         dto.put("conditionStatus", true);
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance().doPost(Utils.getDenyPoliciesURL(getBaseUrl()),
+        HttpResponse response = Requests.post(Utils.getDenyPoliciesURL(getBaseUrl()),
                 adminAuthHeaders(), dto.toString(), Constants.CONTENT_TYPES.APPLICATION_JSON);
-        TestContext.set("httpResponse", response);
         return response;
     }
 
@@ -2181,36 +2044,28 @@ public class ApplicationBaseSteps {
     @When("I retrieve the deny policy {string}")
     public void iRetrieveDenyPolicy(String idKey) throws IOException {
 
-        String id = Utils.resolveFromContext(idKey).toString();
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doGet(Utils.getDenyPolicyByIdURL(getBaseUrl(), id), adminAuthHeaders());
-        TestContext.set("httpResponse", response);
+        String id = TestContext.resolve(idKey).toString();
+        HttpResponse response = Requests.get(Utils.getDenyPolicyByIdURL(getBaseUrl(), id), adminAuthHeaders());
     }
 
     /** Updates a deny policy's enabled status (PATCH conditionStatus). Non-asserting — the feature asserts. */
     @When("I set the deny policy {string} status to {string}")
     public void iSetDenyPolicyStatus(String idKey, String status) throws IOException {
 
-        String id = Utils.resolveFromContext(idKey).toString();
+        String id = TestContext.resolve(idKey).toString();
         JSONObject dto = new JSONObject();
         dto.put("conditionStatus", Boolean.parseBoolean(status));
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance().doPatch(
+        HttpResponse response = Requests.patch(
                 Utils.getDenyPolicyByIdURL(getBaseUrl(), id), adminAuthHeaders(), dto.toString(),
                 Constants.CONTENT_TYPES.APPLICATION_JSON);
-        TestContext.set("httpResponse", response);
     }
 
     /** Deletes the deny policy held under {@code idKey}. Non-asserting — the feature asserts the status. */
     @When("I delete the deny policy {string}")
     public void iDeleteDenyPolicy(String idKey) throws IOException {
 
-        String id = Utils.resolveFromContext(idKey).toString();
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doDelete(Utils.getDenyPolicyByIdURL(getBaseUrl(), id), adminAuthHeaders());
-        TestContext.set("httpResponse", response);
+        String id = TestContext.resolve(idKey).toString();
+        HttpResponse response = Requests.delete(Utils.getDenyPolicyByIdURL(getBaseUrl(), id), adminAuthHeaders());
     }
 
     /** Searches deny policies by condition type and value (query grammar: conditionType:X&conditionValue:Y). */
@@ -2218,10 +2073,7 @@ public class ApplicationBaseSteps {
     public void iSearchDenyPolicies(String conditionType, String conditionValue) throws IOException {
 
         String query = urlEncode("conditionType:" + conditionType + "&conditionValue:" + conditionValue);
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doGet(Utils.getDenyPoliciesURL(getBaseUrl()) + "?query=" + query, adminAuthHeaders());
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.get(Utils.getDenyPoliciesURL(getBaseUrl()) + "?query=" + query, adminAuthHeaders());
     }
 
     // ---- Tenant configuration (admin) ------------------------------------------------------------------
@@ -2230,28 +2082,21 @@ public class ApplicationBaseSteps {
     @When("I retrieve the tenant configuration")
     public void iRetrieveTenantConfiguration() throws IOException {
 
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doGet(Utils.getTenantConfigURL(getBaseUrl()), adminAuthHeaders());
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.get(Utils.getTenantConfigURL(getBaseUrl()), adminAuthHeaders());
     }
 
     /** Retrieves the tenant configuration JSON schema. */
     @When("I retrieve the tenant configuration schema")
     public void iRetrieveTenantConfigurationSchema() throws IOException {
 
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doGet(Utils.getTenantConfigSchemaURL(getBaseUrl()), adminAuthHeaders());
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.get(Utils.getTenantConfigSchemaURL(getBaseUrl()), adminAuthHeaders());
     }
 
     /** Captures the current tenant configuration body under {@code contextKey} (for a round-trip update/restore). */
     @When("I capture the tenant configuration as {string}")
     public void iCaptureTenantConfiguration(String contextKey) throws IOException {
 
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doGet(Utils.getTenantConfigURL(getBaseUrl()), adminAuthHeaders());
+        HttpResponse response = Requests.get(Utils.getTenantConfigURL(getBaseUrl()), adminAuthHeaders());
         Assert.assertEquals(response.getResponseCode(), 200, response.getData());
         TestContext.set(Utils.normalizeContextKey(contextKey), response.getData());
     }
@@ -2260,27 +2105,24 @@ public class ApplicationBaseSteps {
     @When("I update the tenant configuration from {string}")
     public void iUpdateTenantConfiguration(String contextKey) throws IOException {
 
-        String payload = Utils.resolveFromContext(contextKey).toString();
+        String payload = TestContext.resolve(contextKey).toString();
         TestContext.remove("httpResponse");
         HttpResponse response = SimpleHTTPClient.getInstance().doPut(Utils.getTenantConfigURL(getBaseUrl()),
                 adminAuthHeaders(), payload, Constants.CONTENT_TYPES.APPLICATION_JSON);
-        TestContext.set("httpResponse", response);
     }
 
     /** Attempts to update the tenant configuration with a syntactically-invalid (bad-signature) bearer JWT. */
     @When("I attempt to update the tenant configuration from {string} with an invalid token")
     public void iAttemptUpdateTenantConfigInvalidToken(String contextKey) throws IOException {
 
-        String payload = Utils.resolveFromContext(contextKey).toString();
+        String payload = TestContext.resolve(contextKey).toString();
         // A structurally-valid JWT with a bogus signature the server cannot verify.
         String invalidJwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
                 + "eyJzdWIiOiJhZG1pbiIsInNjb3BlIjoib3BlbmlkIGFwaW06YWRtaW4ifQ.aW52YWxpZF9zaWduYXR1cmU";
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + invalidJwt);
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance().doPut(Utils.getTenantConfigURL(getBaseUrl()),
+        HttpResponse response = Requests.put(Utils.getTenantConfigURL(getBaseUrl()),
                 headers, payload, Constants.CONTENT_TYPES.APPLICATION_JSON);
-        TestContext.set("httpResponse", response);
     }
 
     /**
@@ -2290,13 +2132,11 @@ public class ApplicationBaseSteps {
     @When("I attempt to update the tenant configuration from {string} without admin scope")
     public void iAttemptUpdateTenantConfigNonAdmin(String contextKey) throws IOException {
 
-        String payload = Utils.resolveFromContext(contextKey).toString();
+        String payload = TestContext.resolve(contextKey).toString();
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance().doPut(Utils.getTenantConfigURL(getBaseUrl()),
+        HttpResponse response = Requests.put(Utils.getTenantConfigURL(getBaseUrl()),
                 headers, payload, Constants.CONTENT_TYPES.APPLICATION_JSON);
-        TestContext.set("httpResponse", response);
     }
 
     // ---- Application organization sharing (devportal) --------------------------------------------------
@@ -2318,10 +2158,8 @@ public class ApplicationBaseSteps {
 
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.devportalToken());
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance().doPost(Utils.getApplicationCreateURL(getBaseUrl()),
+        HttpResponse response = Requests.post(Utils.getApplicationCreateURL(getBaseUrl()),
                 headers, app.toString(), Constants.CONTENT_TYPES.APPLICATION_JSON);
-        TestContext.set("httpResponse", response);
         Assert.assertEquals(response.getResponseCode(), 201, response.getData());
         Object appId = Utils.extractValueFromPayload(response.getData(), "applicationId");
         TestContext.set(idKey, appId);
@@ -2332,20 +2170,17 @@ public class ApplicationBaseSteps {
     @When("I retrieve the application {string}")
     public void iRetrieveApplicationById(String idKey) throws IOException {
 
-        String appId = Utils.resolveFromContext(idKey).toString();
+        String appId = TestContext.resolve(idKey).toString();
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.devportalToken());
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doGet(Utils.getApplicationEndpointURL(getBaseUrl(), appId), headers);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.get(Utils.getApplicationEndpointURL(getBaseUrl(), appId), headers);
     }
 
     /** Updates a devportal application's visibility in place (GET→modify→PUT). Non-asserting. */
     @When("I set the visibility of application {string} to {string}")
     public void iSetApplicationVisibility(String idKey, String visibility) throws IOException {
 
-        String appId = Utils.resolveFromContext(idKey).toString();
+        String appId = TestContext.resolve(idKey).toString();
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.devportalToken());
         HttpResponse current = SimpleHTTPClient.getInstance()
@@ -2353,11 +2188,9 @@ public class ApplicationBaseSteps {
         Assert.assertEquals(current.getResponseCode(), 200, current.getData());
         JSONObject app = new JSONObject(current.getData());
         app.put("visibility", visibility);
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance().doPut(
+        HttpResponse response = Requests.put(
                 Utils.getApplicationEndpointURL(getBaseUrl(), appId), headers, app.toString(),
                 Constants.CONTENT_TYPES.APPLICATION_JSON);
-        TestContext.set("httpResponse", response);
     }
 
     // ---- Consumer secret management (multiple client secrets, devportal) -------------------------------
@@ -2382,8 +2215,8 @@ public class ApplicationBaseSteps {
     public void iGenerateConsumerSecret(String description, String appIdKey, String keyMappingIdKey,
                                         String secretIdKey) throws IOException {
 
-        String appId = Utils.resolveFromContext(appIdKey).toString();
-        String keyMappingId = Utils.resolveFromContext(keyMappingIdKey).toString();
+        String appId = TestContext.resolve(appIdKey).toString();
+        String keyMappingId = TestContext.resolve(keyMappingIdKey).toString();
 
         JSONObject additionalProperties = new JSONObject();
         if (description != null && !description.isEmpty()) {
@@ -2392,11 +2225,9 @@ public class ApplicationBaseSteps {
         JSONObject request = new JSONObject();
         request.put("additionalProperties", additionalProperties);
 
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance().doPost(
+        HttpResponse response = Requests.post(
                 Utils.getGenerateApplicationSecretURL(getBaseUrl(), appId, keyMappingId), devportalAuthHeaders(),
                 request.toString(), Constants.CONTENT_TYPES.APPLICATION_JSON);
-        TestContext.set("httpResponse", response);
         if (response.getResponseCode() < 300) {
             TestContext.set(secretIdKey, Utils.extractValueFromPayload(response.getData(), "secretId"));
         }
@@ -2406,12 +2237,9 @@ public class ApplicationBaseSteps {
     @When("I retrieve the consumer secrets for application {string} with key mapping {string}")
     public void iRetrieveConsumerSecrets(String appIdKey, String keyMappingIdKey) throws IOException {
 
-        String appId = Utils.resolveFromContext(appIdKey).toString();
-        String keyMappingId = Utils.resolveFromContext(keyMappingIdKey).toString();
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doGet(Utils.getAllApplicationSecretsURL(getBaseUrl(), appId, keyMappingId), devportalAuthHeaders());
-        TestContext.set("httpResponse", response);
+        String appId = TestContext.resolve(appIdKey).toString();
+        String keyMappingId = TestContext.resolve(keyMappingIdKey).toString();
+        HttpResponse response = Requests.get(Utils.getAllApplicationSecretsURL(getBaseUrl(), appId, keyMappingId), devportalAuthHeaders());
     }
 
     /** Revokes a consumer secret (by the id held under {@code secretIdKey}). Non-asserting. */
@@ -2419,28 +2247,23 @@ public class ApplicationBaseSteps {
     public void iRevokeConsumerSecret(String secretIdKey, String appIdKey, String keyMappingIdKey)
             throws IOException {
 
-        String appId = Utils.resolveFromContext(appIdKey).toString();
-        String keyMappingId = Utils.resolveFromContext(keyMappingIdKey).toString();
-        String secretId = Utils.resolveFromContext(secretIdKey).toString();
+        String appId = TestContext.resolve(appIdKey).toString();
+        String keyMappingId = TestContext.resolve(keyMappingIdKey).toString();
+        String secretId = TestContext.resolve(secretIdKey).toString();
 
         JSONObject request = new JSONObject();
         request.put("secretId", secretId);
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance().doPost(
+        HttpResponse response = Requests.post(
                 Utils.getRevokeApplicationSecretURL(getBaseUrl(), appId, keyMappingId), devportalAuthHeaders(),
                 request.toString(), Constants.CONTENT_TYPES.APPLICATION_JSON);
-        TestContext.set("httpResponse", response);
     }
 
     /** Fetches an application's OAuth key details by key-mapping id. */
     @When("I fetch the oauth key details for application {string} with key mapping {string}")
     public void iFetchKeyDetailsByKeyMappingId(String appIdKey, String keyMappingIdKey) throws IOException {
 
-        String appId = Utils.resolveFromContext(appIdKey).toString();
-        String keyMappingId = Utils.resolveFromContext(keyMappingIdKey).toString();
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doGet(Utils.getUpdateKey(getBaseUrl(), appId, keyMappingId), devportalAuthHeaders());
-        TestContext.set("httpResponse", response);
+        String appId = TestContext.resolve(appIdKey).toString();
+        String keyMappingId = TestContext.resolve(keyMappingIdKey).toString();
+        HttpResponse response = Requests.get(Utils.getUpdateKey(getBaseUrl(), appId, keyMappingId), devportalAuthHeaders());
     }
 }

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/ApplicationBaseSteps.java
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/ApplicationBaseSteps.java
@@ -824,8 +824,6 @@ public class ApplicationBaseSteps {
 
         HttpResponse response = Requests.get(Utils.getApplicationSearchURL(getBaseUrl(), applicationName), headers);
 
-        TestContext.set("httpResponse", response);
-
         JSONObject responseJson = new JSONObject(response.getData());
         if (responseJson.has("list") && !responseJson.getJSONArray("list").isEmpty()) {
             String applicationId = responseJson
@@ -1729,9 +1727,8 @@ public class ApplicationBaseSteps {
 
         JSONObject entry = new JSONObject().put("role", role).put("aliases", new JSONArray().put(alias));
         JSONObject payload = new JSONObject().put("count", 1).put("list", new JSONArray().put(entry));
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance().doPut(Utils.getRoleAliasesURL(getBaseUrl()),
-                adminAuthHeaders(), payload.toString(), Constants.CONTENT_TYPES.APPLICATION_JSON);
+        Requests.put(Utils.getRoleAliasesURL(getBaseUrl()), adminAuthHeaders(), payload.toString(),
+                Constants.CONTENT_TYPES.APPLICATION_JSON);
     }
 
     /** Retrieves the system-scope role-alias mappings (admin REST {@code GET /role-aliases}). Non-asserting. */
@@ -2106,9 +2103,8 @@ public class ApplicationBaseSteps {
     public void iUpdateTenantConfiguration(String contextKey) throws IOException {
 
         String payload = TestContext.resolve(contextKey).toString();
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance().doPut(Utils.getTenantConfigURL(getBaseUrl()),
-                adminAuthHeaders(), payload, Constants.CONTENT_TYPES.APPLICATION_JSON);
+        Requests.put(Utils.getTenantConfigURL(getBaseUrl()), adminAuthHeaders(), payload,
+                Constants.CONTENT_TYPES.APPLICATION_JSON);
     }
 
     /** Attempts to update the tenant configuration with a syntactically-invalid (bad-signature) bearer JWT. */

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/BaseSteps.java
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/BaseSteps.java
@@ -178,7 +178,7 @@ public class BaseSteps {
         json.addProperty("grant_type", "password");
         json.addProperty("username", actor.getUserName());
         json.addProperty("password", actor.getPassword());
-        json.addProperty("scope", "apim:api_view apim:api_create apim:api_publish apim:api_delete apim:api_manage apim:api_import_export apim:subscription_manage apim:client_certificates_add apim:client_certificates_update apim:shared_scope_manage apim:common_operation_policy_manage apim:api_generate_key apim:gateway_policy_manage");
+        json.addProperty("scope", "apim:api_view apim:api_create apim:api_publish apim:api_delete apim:api_manage apim:api_import_export apim:subscription_manage apim:client_certificates_add apim:client_certificates_update apim:shared_scope_manage apim:common_operation_policy_manage apim:api_generate_key apim:gateway_policy_manage apim:mcp_server_create apim:mcp_server_manage apim:mcp_server_publish apim:mcp_server_view apim:mcp_server_delete apim:mcp_server_list_view");
 
         HttpResponse response = SimpleHTTPClient.getInstance().doPost(Utils.getAPIMTokenEndpointURL(getBaseUrl()), headers,
             json.toString(), Constants.CONTENT_TYPES.APPLICATION_JSON);
@@ -252,7 +252,7 @@ public class BaseSteps {
         json.addProperty("grant_type", "password");
         json.addProperty("username", actor.getUserName());
         json.addProperty("password", actor.getPassword());
-        json.addProperty("scope", "apim:admin apim:tier_view apim:api_provider_change");
+        json.addProperty("scope", "apim:admin apim:tier_view apim:api_provider_change apim:llm_provider_manage apim:llm_provider_read");
 
         HttpResponse response = SimpleHTTPClient.getInstance().doPost(Utils.getAPIMTokenEndpointURL(getBaseUrl()), headers,
                 json.toString(), Constants.CONTENT_TYPES.APPLICATION_JSON);
@@ -261,6 +261,41 @@ public class BaseSteps {
         String accessToken = Utils.extractValueFromPayload(response.getData(), "access_token").toString();
         TestContext.set(Identity.adminTokenKey(actor), accessToken);
         log.info("Obtained Admin access token for user " + actor.getUserName()
+                + " with expires_in (seconds): "
+                + Utils.extractValueFromPayload(response.getData(), "expires_in"));
+    }
+
+    /**
+     * Obtains a valid Governance API access token for a named actor (must have governance rights). Requires the
+     * actor's DCR application to already exist (e.g. via "I have valid access tokens as ..."). Governance is its
+     * own product API with its own {@code apim:gov_*} scopes — not reachable with the admin token.
+     */
+    @Given("I have a valid Governance access token as {string}")
+    public void iHaveValidGovernanceAccessTokenAs(String actorRef) throws Exception {
+
+        mintGovernanceToken(Identity.resolveActor(actorRef));
+    }
+
+    private void mintGovernanceToken(User actor) throws Exception {
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION,
+                "Basic " + TestContext.get(Identity.dcrCredentialsKey(actor)).toString());
+
+        // create json payload to obtain governance access token
+        JsonObject json = new JsonObject();
+        json.addProperty("grant_type", "password");
+        json.addProperty("username", actor.getUserName());
+        json.addProperty("password", actor.getPassword());
+        json.addProperty("scope", "apim:gov_rule_read apim:gov_rule_manage apim:gov_policy_read apim:gov_policy_manage apim:gov_result_read openid");
+
+        HttpResponse response = SimpleHTTPClient.getInstance().doPost(Utils.getAPIMTokenEndpointURL(getBaseUrl()), headers,
+                json.toString(), Constants.CONTENT_TYPES.APPLICATION_JSON);
+        Assert.assertEquals(response.getResponseCode(), 200, response.getData());
+
+        String accessToken = Utils.extractValueFromPayload(response.getData(), "access_token").toString();
+        TestContext.set(Identity.governanceTokenKey(actor), accessToken);
+        log.info("Obtained Governance access token for user " + actor.getUserName()
                 + " with expires_in (seconds): "
                 + Utils.extractValueFromPayload(response.getData(), "expires_in"));
     }
@@ -349,6 +384,21 @@ public class BaseSteps {
      * @param value The raw string value or a context key to resolve
      * @param contextKey The key under which the value should be stored in TestContext
      */
+    /**
+     * Replaces a literal substring in a stored context value and writes it back. Used to resolve a server-side
+     * template placeholder that the publisher API returns verbatim — e.g. a version-first API's context is
+     * stored as {@code /{version}/ctx}, and the gateway invocation needs {@code /1.0.0/ctx}.
+     *
+     * @param token    literal substring to replace (e.g. {@code {version}})
+     * @param value    replacement value (e.g. {@code 1.0.0})
+     * @param key      context key whose value is rewritten in place
+     */
+    @When("I replace {string} with {string} in context {string}")
+    public void iReplaceInContext(String token, String value, String key) {
+        String resolved = Utils.resolveFromContext(key).toString().replace(token, value);
+        TestContext.set(Utils.normalizeContextKey(key), resolved);
+    }
+
     @When("I put value {string} in context as {string}")
     public void iPutValueInContextAs(String value, String contextKey) {
         // Resolve value if it's a reference to another context key
@@ -356,6 +406,29 @@ public class BaseSteps {
 
         log.info("Setting context key: " + contextKey + " with value: " + resolvedValue);
         TestContext.set(Utils.normalizeContextKey(contextKey), resolvedValue.toString());
+    }
+
+    /**
+     * Decodes the JWT stored under a context key (a {@code header.payload.signature} token) and asserts its
+     * payload segment contains the expected substring. Used to verify token claims such as the internal API
+     * key's {@code keytype}. Base64url-decodes tolerantly (falls back to standard base64).
+     *
+     * @param contextKey context key holding the JWT
+     * @param expected   substring expected in the decoded JWT payload (e.g. {@code "keytype":"SANDBOX"})
+     */
+    @Then("The JWT stored as {string} should contain {string}")
+    public void theJwtStoredShouldContain(String contextKey, String expected) {
+        String jwt = Utils.resolveFromContext(contextKey).toString();
+        String[] segments = jwt.split("\\.");
+        Assert.assertTrue(segments.length >= 2, "Malformed JWT (expected >= 2 segments): " + jwt);
+        String payload;
+        try {
+            payload = new String(Base64.getUrlDecoder().decode(segments[1]), StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException e) {
+            payload = new String(Base64.getDecoder().decode(segments[1]), StandardCharsets.UTF_8);
+        }
+        Assert.assertTrue(payload.contains(expected),
+                "Decoded JWT payload does not contain '" + expected + "': " + payload);
     }
 
     /**
@@ -386,6 +459,78 @@ public class BaseSteps {
     public void putJsonPayloadInContext(String key, String docStringJson)  {
 
         TestContext.set(Utils.normalizeContextKey(key), Utils.resolvePayloadPlaceholders(docStringJson));
+    }
+
+    /**
+     * Sets a top-level field of a JSON payload already in context to the given value, writing it back under the
+     * same key. Used to build create-validation negatives from a valid base payload (e.g. blank name/context/
+     * version, or an invalid context) without a separate fixture per case. An empty {@code value} sets the
+     * field to an empty string.
+     *
+     * @param field      the top-level JSON field to set
+     * @param value      the value to set (may be empty)
+     * @param contextKey the context key holding the JSON payload
+     */
+    @When("I set the field {string} to {string} in the payload {string}")
+    public void iSetFieldInPayload(String field, String value, String contextKey) {
+
+        org.json.JSONObject payload = new org.json.JSONObject(Utils.resolveFromContext(contextKey).toString());
+        // Resolve any {{contextKey}} placeholders in the value (e.g. reusing an existing API's context to build a
+        // duplicate-context negative). Values with no placeholders pass through unchanged; an unknown key throws.
+        payload.put(field, Utils.resolveContextPlaceholders(value));
+        TestContext.set(Utils.normalizeContextKey(contextKey), payload.toString());
+    }
+
+    /**
+     * Replaces every occurrence of a literal substring in a payload already in context, writing it back under
+     * the same key. A text-level edit for cases where a structured setter can't reach — e.g. a field whose value
+     * is itself a STRINGIFIED JSON blob (an MCP backend's {@code endpointConfig} is a JSON string, not a nested
+     * object), where changing a URL inside it means editing the raw text. {@code {{contextKey}}} placeholders in
+     * both arguments are resolved.
+     *
+     * @param target      the literal substring to replace
+     * @param replacement the replacement text
+     * @param contextKey  the context key holding the payload
+     */
+    @When("I replace {string} with {string} in the payload {string}")
+    public void iReplaceInPayload(String target, String replacement, String contextKey) {
+        String json = Utils.resolveFromContext(contextKey).toString();
+        String resolvedTarget = Utils.resolveContextPlaceholders(target);
+        String resolvedReplacement = Utils.resolveContextPlaceholders(replacement);
+        TestContext.set(Utils.normalizeContextKey(contextKey), json.replace(resolvedTarget, resolvedReplacement));
+    }
+
+    /**
+     * Removes a top-level field from a JSON payload already in context, writing it back under the same key.
+     * Used to build create-validation negatives where a field must be absent rather than blank.
+     *
+     * @param field      the top-level JSON field to remove
+     * @param contextKey the context key holding the JSON payload
+     */
+    @When("I remove the field {string} from the payload {string}")
+    public void iRemoveFieldFromPayload(String field, String contextKey) {
+
+        org.json.JSONObject payload = new org.json.JSONObject(Utils.resolveFromContext(contextKey).toString());
+        payload.remove(field);
+        TestContext.set(Utils.normalizeContextKey(contextKey), payload.toString());
+    }
+
+    /** Sets a top-level field of a JSON payload in context to an empty array, writing it back under the key. */
+    @When("I set the field {string} to an empty array in the payload {string}")
+    public void iSetFieldToEmptyArrayInPayload(String field, String contextKey) {
+
+        org.json.JSONObject payload = new org.json.JSONObject(Utils.resolveFromContext(contextKey).toString());
+        payload.put(field, new org.json.JSONArray());
+        TestContext.set(Utils.normalizeContextKey(contextKey), payload.toString());
+    }
+
+    /** Sets a top-level boolean field of a JSON payload in context, writing it back under the key. */
+    @When("I set the boolean field {string} to {string} in the payload {string}")
+    public void iSetBooleanFieldInPayload(String field, String value, String contextKey) {
+
+        org.json.JSONObject payload = new org.json.JSONObject(Utils.resolveFromContext(contextKey).toString());
+        payload.put(field, Boolean.parseBoolean(value));
+        TestContext.set(Utils.normalizeContextKey(contextKey), payload.toString());
     }
 
     /**
@@ -568,6 +713,17 @@ public class BaseSteps {
      * @param fieldName JSON field name to extract
      * @param targetKey TestContext key to store the extracted value
      */
+    /**
+     * Copies a context value from one key to another. Useful when a later composite step overwrites a shared key
+     * (e.g. {@code generatedAccessToken}) but an earlier value must be preserved — e.g. keeping a REST, GraphQL and
+     * WebSocket token side-by-side to invoke all three across a single server restart.
+     */
+    @And("I copy context value {string} to {string}")
+    public void iCopyContextValueTo(String fromKey, String toKey) {
+        Object value = Utils.resolveFromContext(fromKey);
+        TestContext.set(Utils.normalizeContextKey(toKey), value);
+    }
+
     @And("I extract field {string} from {string} and store it as {string}")
     public void iExtractFieldFromAndStoreItAs(String fieldName, String sourceKey, String targetKey) {
 
@@ -595,8 +751,12 @@ public class BaseSteps {
     @Then("The response should not contain {string}")
     public void responseShouldNotContainFieldValue(String unexpectedValue) {
 
+        // Resolve {{contextKey}} placeholders (mirrors "The response should contain") so a captured value — e.g.
+        // a deleted tier's name — is matched literally, not as the placeholder text (which would falsely pass).
+        String resolved = Utils.resolveContextPlaceholders(unexpectedValue);
         HttpResponse response = (HttpResponse) TestContext.get("httpResponse");
-        Assert.assertFalse(response.getData().contains(unexpectedValue));
+        Assert.assertFalse(response.getData().contains(resolved),
+                "Response unexpectedly contains \"" + resolved + "\"");
     }
 
     /**

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/BaseSteps.java
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/BaseSteps.java
@@ -395,14 +395,14 @@ public class BaseSteps {
      */
     @When("I replace {string} with {string} in context {string}")
     public void iReplaceInContext(String token, String value, String key) {
-        String resolved = Utils.resolveFromContext(key).toString().replace(token, value);
+        String resolved = TestContext.resolve(key).toString().replace(token, value);
         TestContext.set(Utils.normalizeContextKey(key), resolved);
     }
 
     @When("I put value {string} in context as {string}")
     public void iPutValueInContextAs(String value, String contextKey) {
         // Resolve value if it's a reference to another context key
-        Object resolvedValue = Utils.resolveFromContext(value);
+        Object resolvedValue = TestContext.resolve(value);
 
         log.info("Setting context key: " + contextKey + " with value: " + resolvedValue);
         TestContext.set(Utils.normalizeContextKey(contextKey), resolvedValue.toString());
@@ -418,7 +418,7 @@ public class BaseSteps {
      */
     @Then("The JWT stored as {string} should contain {string}")
     public void theJwtStoredShouldContain(String contextKey, String expected) {
-        String jwt = Utils.resolveFromContext(contextKey).toString();
+        String jwt = TestContext.resolve(contextKey).toString();
         String[] segments = jwt.split("\\.");
         Assert.assertTrue(segments.length >= 2, "Malformed JWT (expected >= 2 segments): " + jwt);
         String payload;
@@ -474,7 +474,7 @@ public class BaseSteps {
     @When("I set the field {string} to {string} in the payload {string}")
     public void iSetFieldInPayload(String field, String value, String contextKey) {
 
-        org.json.JSONObject payload = new org.json.JSONObject(Utils.resolveFromContext(contextKey).toString());
+        org.json.JSONObject payload = new org.json.JSONObject(TestContext.resolve(contextKey).toString());
         // Resolve any {{contextKey}} placeholders in the value (e.g. reusing an existing API's context to build a
         // duplicate-context negative). Values with no placeholders pass through unchanged; an unknown key throws.
         payload.put(field, Utils.resolveContextPlaceholders(value));
@@ -494,7 +494,7 @@ public class BaseSteps {
      */
     @When("I replace {string} with {string} in the payload {string}")
     public void iReplaceInPayload(String target, String replacement, String contextKey) {
-        String json = Utils.resolveFromContext(contextKey).toString();
+        String json = TestContext.resolve(contextKey).toString();
         String resolvedTarget = Utils.resolveContextPlaceholders(target);
         String resolvedReplacement = Utils.resolveContextPlaceholders(replacement);
         TestContext.set(Utils.normalizeContextKey(contextKey), json.replace(resolvedTarget, resolvedReplacement));
@@ -510,7 +510,7 @@ public class BaseSteps {
     @When("I remove the field {string} from the payload {string}")
     public void iRemoveFieldFromPayload(String field, String contextKey) {
 
-        org.json.JSONObject payload = new org.json.JSONObject(Utils.resolveFromContext(contextKey).toString());
+        org.json.JSONObject payload = new org.json.JSONObject(TestContext.resolve(contextKey).toString());
         payload.remove(field);
         TestContext.set(Utils.normalizeContextKey(contextKey), payload.toString());
     }
@@ -519,7 +519,7 @@ public class BaseSteps {
     @When("I set the field {string} to an empty array in the payload {string}")
     public void iSetFieldToEmptyArrayInPayload(String field, String contextKey) {
 
-        org.json.JSONObject payload = new org.json.JSONObject(Utils.resolveFromContext(contextKey).toString());
+        org.json.JSONObject payload = new org.json.JSONObject(TestContext.resolve(contextKey).toString());
         payload.put(field, new org.json.JSONArray());
         TestContext.set(Utils.normalizeContextKey(contextKey), payload.toString());
     }
@@ -528,7 +528,7 @@ public class BaseSteps {
     @When("I set the boolean field {string} to {string} in the payload {string}")
     public void iSetBooleanFieldInPayload(String field, String value, String contextKey) {
 
-        org.json.JSONObject payload = new org.json.JSONObject(Utils.resolveFromContext(contextKey).toString());
+        org.json.JSONObject payload = new org.json.JSONObject(TestContext.resolve(contextKey).toString());
         payload.put(field, Boolean.parseBoolean(value));
         TestContext.set(Utils.normalizeContextKey(contextKey), payload.toString());
     }
@@ -690,7 +690,7 @@ public class BaseSteps {
     public void iExtractFieldFromJsonPayloadAndStoreItAs(String fieldPath, String sourceContextKey,
                                                          String targetContextKey) throws IOException {
 
-        Object sourceValue = Utils.resolveFromContext(sourceContextKey);
+        Object sourceValue = TestContext.resolve(sourceContextKey);
 
         Object value = Utils.extractValueFromPayload(String.valueOf(sourceValue), fieldPath);
         if (value == null) {
@@ -720,14 +720,14 @@ public class BaseSteps {
      */
     @And("I copy context value {string} to {string}")
     public void iCopyContextValueTo(String fromKey, String toKey) {
-        Object value = Utils.resolveFromContext(fromKey);
+        Object value = TestContext.resolve(fromKey);
         TestContext.set(Utils.normalizeContextKey(toKey), value);
     }
 
     @And("I extract field {string} from {string} and store it as {string}")
     public void iExtractFieldFromAndStoreItAs(String fieldName, String sourceKey, String targetKey) {
 
-        Object contextValue = Utils.resolveFromContext(sourceKey);
+        Object contextValue = TestContext.resolve(sourceKey);
 
         if (!(contextValue instanceof JSONObject jsonObject)) {
             throw new IllegalStateException("Expected JSONObject in TestContext for key '" + sourceKey
@@ -805,7 +805,7 @@ public class BaseSteps {
         String tenantDomain = actor.getUserDomain();
 
         if ("endpointConfig".equals(config)){
-            expectedConfigValue = Utils.resolveFromContext(expectedConfigValue).toString();
+            expectedConfigValue = TestContext.resolve(expectedConfigValue).toString();
         }
 
         Object parsedExpectedValue = Utils.parseConfigValue(expectedConfigValue);
@@ -873,7 +873,7 @@ public class BaseSteps {
     public void theResourceShouldReflectTheUpdatedAsValueFromContext(String resourceType, String config,
                String configValueContextKey) throws IOException, InterruptedException {
 
-        Object ctxValue = Utils.resolveFromContext(configValueContextKey);
+        Object ctxValue = TestContext.resolve(configValueContextKey);
         theResourceShouldReflectTheUpdatedAs(resourceType, config, ctxValue.toString());
     }
 
@@ -936,7 +936,7 @@ public class BaseSteps {
     @Then("I wait for deployment of the resource in {string}")
     public void waitForAPIDeployment(String apiDetailsPayload) throws IOException, InterruptedException {
 
-        String actualApiDetailsPayload = Utils.resolveFromContext(apiDetailsPayload).toString();
+        String actualApiDetailsPayload = TestContext.resolve(apiDetailsPayload).toString();
 
         String apiName  = Utils.extractValueFromPayload(actualApiDetailsPayload, "name").toString();
         String apiVersion = Utils.extractValueFromPayload(actualApiDetailsPayload, "version").toString();
@@ -987,7 +987,7 @@ public class BaseSteps {
     @Then("I wait for undeployment of the previous API revision in {string}")
     public void waitForPreviousAPIRevisionUndeployment(String apiDetailsPayload) throws IOException {
 
-        String actualApiDetailsPayload = Utils.resolveFromContext(apiDetailsPayload).toString();
+        String actualApiDetailsPayload = TestContext.resolve(apiDetailsPayload).toString();
 
         String apiName  = Utils.extractValueFromPayload(actualApiDetailsPayload, "name").toString();
         String apiVersion = Utils.extractValueFromPayload(actualApiDetailsPayload, "version").toString();
@@ -1035,7 +1035,7 @@ public class BaseSteps {
     public void iGetTheValueFromPayloadAtPathAndStoreItAs(String payloadContextKey, String path,
                                                           String outputContextKey) throws IOException {
 
-        Object ctxValue = Utils.resolveFromContext(payloadContextKey);
+        Object ctxValue = TestContext.resolve(payloadContextKey);
         Object value = Utils.extractValueFromPayload(ctxValue.toString(), path);
         TestContext.set(Utils.normalizeContextKey(outputContextKey), String.valueOf(value));
     }
@@ -1049,7 +1049,7 @@ public class BaseSteps {
     @And("I append the following value to the json array {string}:")
     public void iAppendTheFollowingValueToTheJsonArray(String arrayContextKey, String valueToAppend) {
 
-        Object ctxValue = Utils.resolveFromContext(arrayContextKey);
+        Object ctxValue = TestContext.resolve(arrayContextKey);
         JSONArray jsonArray;
         // Convert the stored context value into a JSONArray
         if (ctxValue instanceof JSONArray) {
@@ -1077,7 +1077,7 @@ public class BaseSteps {
     public void iFindTheResourceWithFollowingPropertiesInAs(String contextKey, String outputKey,
                                                             DataTable propertiesTable) {
 
-        Object contextValue = Utils.resolveFromContext(contextKey);
+        Object contextValue = TestContext.resolve(contextKey);
         if (!(contextValue instanceof JSONArray jsonArray)) {
             throw new IllegalStateException(
                     "Expected JSONArray in TestContext for key '" + contextKey + "' but found: "
@@ -1108,7 +1108,7 @@ public class BaseSteps {
     @Then("the actual value of {string} should match the expected value:")
     public void theActualValueShouldMatchTheExpectedValue(String actualKey, String expectedValue) {
 
-        Object actualValue = Utils.resolveFromContext(actualKey);
+        Object actualValue = TestContext.resolve(actualKey);
         String finalExpectedValue = Utils.resolveIfContextKey(expectedValue).toString();
         Utils.assertConfigValueMatchesExpectedValue(actualValue, finalExpectedValue);
     }

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/MCPInvocationSteps.java
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/MCPInvocationSteps.java
@@ -1,0 +1,346 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.wso2.am.integration.cucumbertests.stepdefinitions;
+
+import io.cucumber.java.en.When;
+import org.testng.Assert;
+import org.wso2.am.integration.cucumbertests.utils.TestContext;
+import org.wso2.am.integration.cucumbertests.utils.Utils;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
+import java.time.Duration;
+
+/**
+ * Gateway MCP-server invocation glue (ports the invoke half of MCPServerTestCase). Drives the MCP JSON-RPC
+ * handshake through the gateway's {@code /mcp} path: initialize → tools/list → tools/call, PROPAGATING the
+ * {@code Mcp-Session-Id} the backend issues on initialize. This deliberately exercises a REAL session-stateful
+ * MCP server (the official-SDK node mock), closing the gap left by the legacy's stateless WireMock stub — it
+ * verifies the APIM gateway correctly proxies MCP session state and SSE-framed responses.
+ *
+ * <p>Uses the JDK {@link java.net.http.HttpClient} (with an explicit trust-all SSLContext for the https gateway)
+ * so it can read the {@code Mcp-Session-Id} response header and handle either an SSE ({@code data:} framed) or a
+ * plain-JSON response body.</p>
+ */
+public class MCPInvocationSteps {
+
+    private static final String INIT = "{\"jsonrpc\":\"2.0\",\"id\":0,\"method\":\"initialize\",\"params\":{"
+            + "\"protocolVersion\":\"2025-06-18\",\"capabilities\":{},"
+            + "\"clientInfo\":{\"name\":\"apim-it\",\"version\":\"1.0\"}}}";
+    private static final String INITIALIZED = "{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}";
+    private static final String TOOLS_LIST = "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\",\"params\":{}}";
+
+    private String getBaseGatewayUrl() {
+        Object url = TestContext.get("baseGatewayUrl");
+        if (url == null) {
+            throw new IllegalStateException("baseGatewayUrl is not available in the test context yet");
+        }
+        return url.toString();
+    }
+
+    /**
+     * Full MCP round-trip through the gateway: initialize (capture Mcp-Session-Id) → tools/list (must contain
+     * {@code toolName}) → tools/call {@code toolName}(args) (result must contain {@code expected}). Retries the
+     * whole flow until it succeeds or the deadline elapses (a freshly published MCP server takes a moment to
+     * become routable). The context already carries any {@code /t/<tenant>} prefix.
+     */
+    @When("I invoke the MCP tool {string} with arguments {string} at gateway context {string} version {string} using access token {string} expecting result containing {string} within {int} seconds")
+    public void invokeMcpTool(String toolName, String argsJson, String context, String version, String accessToken,
+                              String expected, int timeoutSeconds) throws Exception {
+
+        String resolvedContext = Utils.resolveContextPlaceholders(context);
+        String token = Utils.resolveFromContext(accessToken).toString();
+        String base = getBaseGatewayUrl();
+        if (base.endsWith("/")) {
+            base = base.substring(0, base.length() - 1);
+        }
+        String mcpUrl = base + (resolvedContext.startsWith("/") ? "" : "/") + resolvedContext + "/" + version + "/mcp";
+
+        long endTime = System.currentTimeMillis() + Math.max(timeoutSeconds * 1000L, 30000L);
+        String lastError = null;
+        String callResult = null;
+        while (System.currentTimeMillis() < endTime) {
+            try {
+                HttpClient client = HttpClient.newBuilder().sslContext(trustAll())
+                        .connectTimeout(Duration.ofSeconds(15)).build();
+                // 1) initialize — capture the session id the backend issues
+                HttpResponse<String> initResp = post(client, mcpUrl, token, null, INIT);
+                String sessionId = initResp.headers().firstValue("mcp-session-id").orElse(null);
+                if (initResp.statusCode() != 200 || !sseOrJson(initResp.body()).contains("serverInfo")) {
+                    lastError = "init status=" + initResp.statusCode() + " body=" + initResp.body();
+                    Thread.sleep(2000);
+                    continue;
+                }
+                // 2) notifications/initialized (best-effort, same session)
+                post(client, mcpUrl, token, sessionId, INITIALIZED);
+                // 3) tools/list — must advertise the tool (proves the session carried past initialize)
+                HttpResponse<String> listResp = post(client, mcpUrl, token, sessionId, TOOLS_LIST);
+                String listBody = sseOrJson(listResp.body());
+                if (!listBody.contains(toolName)) {
+                    lastError = "tools/list did not contain '" + toolName + "': " + listBody;
+                    Thread.sleep(2000);
+                    continue;
+                }
+                // 4) tools/call — the actual stateful round-trip to the real MCP server
+                String callPayload = "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{"
+                        + "\"name\":\"" + toolName + "\",\"arguments\":" + argsJson + "}}";
+                HttpResponse<String> callResp = post(client, mcpUrl, token, sessionId, callPayload);
+                callResult = sseOrJson(callResp.body());
+                if (callResp.statusCode() == 200 && callResult.contains(expected)) {
+                    return;
+                }
+                lastError = "tools/call status=" + callResp.statusCode() + " body=" + callResult;
+            } catch (Exception transientDuringWarmup) {
+                lastError = transientDuringWarmup.getMessage();
+            }
+            Thread.sleep(2000);
+        }
+        Assert.fail("MCP tool call did not return a result containing '" + expected + "' within the deadline; "
+                + "last: " + lastError);
+    }
+
+    /**
+     * Multi-call in ONE MCP session: initialize once (capture the session), send notifications/initialized, then
+     * run several tools/call on the SAME {@code Mcp-Session-Id}, asserting each result contains its expected
+     * marker. Proves the gateway PERSISTS MCP session state across calls — a check a stateless mock cannot do.
+     * {@code calls} format: {@code tool|argsJson|expected ; tool|argsJson|expected} (semicolon-separated).
+     */
+    @When("I invoke MCP tools in one session at gateway context {string} version {string} using access token {string} with calls {string} within {int} seconds")
+    public void invokeMcpMultiCall(String context, String version, String accessToken, String calls,
+                                   int timeoutSeconds) throws Exception {
+        String mcpUrl = buildMcpUrl(context, version);
+        String token = Utils.resolveFromContext(accessToken).toString();
+        String[] specs = calls.split(";");
+
+        long endTime = System.currentTimeMillis() + Math.max(timeoutSeconds * 1000L, 30000L);
+        String lastError = null;
+        while (System.currentTimeMillis() < endTime) {
+            try {
+                HttpClient client = HttpClient.newBuilder().sslContext(trustAll())
+                        .connectTimeout(Duration.ofSeconds(15)).build();
+                HttpResponse<String> initResp = post(client, mcpUrl, token, null, INIT);
+                String sessionId = initResp.headers().firstValue("mcp-session-id").orElse(null);
+                if (initResp.statusCode() != 200 || !sseOrJson(initResp.body()).contains("serverInfo")) {
+                    lastError = "init status=" + initResp.statusCode();
+                    Thread.sleep(2000);
+                    continue;
+                }
+                post(client, mcpUrl, token, sessionId, INITIALIZED);
+                boolean allOk = true;
+                String detail = "";
+                for (String spec : specs) {
+                    String[] p = spec.trim().split("\\|", 3);
+                    String payload = "{\"jsonrpc\":\"2.0\",\"id\":9,\"method\":\"tools/call\",\"params\":{"
+                            + "\"name\":\"" + p[0].trim() + "\",\"arguments\":" + p[1].trim() + "}}";
+                    String body = sseOrJson(post(client, mcpUrl, token, sessionId, payload).body());
+                    if (!body.contains(p[2].trim())) {
+                        allOk = false;
+                        detail = "call " + p[0].trim() + " missing '" + p[2].trim() + "': " + body;
+                        break;
+                    }
+                }
+                if (allOk) {
+                    return;
+                }
+                lastError = detail;
+            } catch (Exception transientDuringWarmup) {
+                lastError = transientDuringWarmup.getMessage();
+            }
+            Thread.sleep(2000);
+        }
+        Assert.fail("MCP multi-call session did not satisfy all calls within the deadline; last: " + lastError);
+    }
+
+    /**
+     * Invokes an MCP tool expecting a JSON-RPC ERROR (a method/tool error, not a result) — e.g. calling a tool
+     * that is not exposed. Asserts the response carries an error indicator (`error`/`isError`). Validates the
+     * gateway relays MCP error semantics end-to-end.
+     */
+    @When("I invoke the MCP tool {string} with arguments {string} at gateway context {string} version {string} using access token {string} expecting an error within {int} seconds")
+    public void invokeMcpToolExpectError(String toolName, String argsJson, String context, String version,
+                                         String accessToken, int timeoutSeconds) throws Exception {
+        String mcpUrl = buildMcpUrl(context, version);
+        String token = Utils.resolveFromContext(accessToken).toString();
+
+        long endTime = System.currentTimeMillis() + Math.max(timeoutSeconds * 1000L, 30000L);
+        String lastError = null;
+        while (System.currentTimeMillis() < endTime) {
+            try {
+                HttpClient client = HttpClient.newBuilder().sslContext(trustAll())
+                        .connectTimeout(Duration.ofSeconds(15)).build();
+                HttpResponse<String> initResp = post(client, mcpUrl, token, null, INIT);
+                String sessionId = initResp.headers().firstValue("mcp-session-id").orElse(null);
+                if (initResp.statusCode() != 200 || !sseOrJson(initResp.body()).contains("serverInfo")) {
+                    lastError = "init status=" + initResp.statusCode();
+                    Thread.sleep(2000);
+                    continue;
+                }
+                post(client, mcpUrl, token, sessionId, INITIALIZED);
+                String callPayload = "{\"jsonrpc\":\"2.0\",\"id\":8,\"method\":\"tools/call\",\"params\":{"
+                        + "\"name\":\"" + toolName + "\",\"arguments\":" + argsJson + "}}";
+                HttpResponse<String> callResp = post(client, mcpUrl, token, sessionId, callPayload);
+                String body = sseOrJson(callResp.body());
+                if (body.toLowerCase().contains("error") || callResp.statusCode() >= 400) {
+                    return;
+                }
+                lastError = "expected an error but got status=" + callResp.statusCode() + " body=" + body;
+            } catch (Exception transientDuringWarmup) {
+                lastError = transientDuringWarmup.getMessage();
+            }
+            Thread.sleep(2000);
+        }
+        Assert.fail("MCP tool call did not return an error within the deadline; last: " + lastError);
+    }
+
+    /**
+     * Negative auth: attempts a tool INVOCATION with an INVALID bearer token and asserts the gateway rejects it
+     * with the EXACT {@code expectedStatus} (strict — so a future change of code is caught as a regression).
+     * FINDINGS (verify-first): (a) the gateway does NOT authenticate the MCP {@code initialize} handshake (200
+     * even with a bad token) — auth is enforced at {@code tools/call}; (b) the rejection code differs by
+     * subtype — the proxy subtype returns 401, the DirectBackend (OpenAPI) subtype returns 403 — so each
+     * feature asserts its own exact code. Retries only to ride out warm-up.
+     */
+    @When("I invoke the MCP server at gateway context {string} version {string} with an invalid token expecting status {int} within {int} seconds")
+    public void invokeMcpInvalidToken(String context, String version, int expectedStatus, int timeoutSeconds)
+            throws Exception {
+        String mcpUrl = buildMcpUrl(context, version);
+        String badToken = "invalid-mcp-token-xyz";
+        String callPayload = "{\"jsonrpc\":\"2.0\",\"id\":7,\"method\":\"tools/call\",\"params\":{"
+                + "\"name\":\"echo\",\"arguments\":{\"message\":\"x\"}}}";
+        long endTime = System.currentTimeMillis() + Math.max(timeoutSeconds * 1000L, 30000L);
+        int last = -1;
+        while (System.currentTimeMillis() < endTime) {
+            try {
+                HttpClient client = HttpClient.newBuilder().sslContext(trustAll())
+                        .connectTimeout(Duration.ofSeconds(15)).build();
+                // A tool call with a bad token — the handshake may 200, but the invocation must be rejected.
+                HttpResponse<String> initResp = post(client, mcpUrl, badToken, null, INIT);
+                if (initResp.statusCode() == expectedStatus) {
+                    return; // rejected already at the handshake with the exact expected code
+                }
+                String sessionId = initResp.headers().firstValue("mcp-session-id").orElse(null);
+                post(client, mcpUrl, badToken, sessionId, INITIALIZED);
+                HttpResponse<String> callResp = post(client, mcpUrl, badToken, sessionId, callPayload);
+                last = callResp.statusCode();
+                if (last == expectedStatus) {
+                    return;
+                }
+            } catch (Exception transientDuringWarmup) {
+                // retry
+            }
+            Thread.sleep(2000);
+        }
+        Assert.fail("MCP invalid-token tool call expected status " + expectedStatus + " but last was " + last);
+    }
+
+    /**
+     * Invokes an MCP tool and asserts the gateway returns the expected HTTP status on the {@code tools/call}
+     * (e.g. 200 with the required scope, 403 without). Retries until the status matches or the deadline elapses
+     * (rides out warm-up, where a not-yet-routable server returns 404). Used by scope-enforcement.
+     */
+    @When("I invoke the MCP tool {string} with arguments {string} at gateway context {string} version {string} using access token {string} expecting status {int} within {int} seconds")
+    public void invokeMcpToolExpectStatus(String toolName, String argsJson, String context, String version,
+                                          String accessToken, int expectedStatus, int timeoutSeconds)
+            throws Exception {
+        String mcpUrl = buildMcpUrl(context, version);
+        String token = Utils.resolveFromContext(accessToken).toString();
+        String callPayload = "{\"jsonrpc\":\"2.0\",\"id\":6,\"method\":\"tools/call\",\"params\":{"
+                + "\"name\":\"" + toolName + "\",\"arguments\":" + argsJson + "}}";
+
+        long endTime = System.currentTimeMillis() + Math.max(timeoutSeconds * 1000L, 30000L);
+        int last = -1;
+        while (System.currentTimeMillis() < endTime) {
+            try {
+                HttpClient client = HttpClient.newBuilder().sslContext(trustAll())
+                        .connectTimeout(Duration.ofSeconds(15)).build();
+                HttpResponse<String> initResp = post(client, mcpUrl, token, null, INIT);
+                // Throttling (429) can trip on ANY /mcp request (the handshake counts too), so when a 429 is
+                // expected, a 429 at initialize is a valid "throttled" signal — don't require it on tools/call.
+                if (expectedStatus == 429 && initResp.statusCode() == 429) {
+                    return;
+                }
+                String sessionId = initResp.headers().firstValue("mcp-session-id").orElse(null);
+                post(client, mcpUrl, token, sessionId, INITIALIZED);
+                HttpResponse<String> callResp = post(client, mcpUrl, token, sessionId, callPayload);
+                last = callResp.statusCode();
+                if (last == expectedStatus) {
+                    return;
+                }
+            } catch (Exception transientDuringWarmup) {
+                // retry
+            }
+            Thread.sleep(2000);
+        }
+        Assert.fail("MCP tool call expected status " + expectedStatus + " but last was " + last);
+    }
+
+    /** Builds the gateway MCP endpoint URL: {@code <gatewayWs-less base>/<context>/<version>/mcp}. */
+    private String buildMcpUrl(String context, String version) {
+        String resolvedContext = Utils.resolveContextPlaceholders(context);
+        String base = getBaseGatewayUrl();
+        if (base.endsWith("/")) {
+            base = base.substring(0, base.length() - 1);
+        }
+        return base + (resolvedContext.startsWith("/") ? "" : "/") + resolvedContext + "/" + version + "/mcp";
+    }
+
+    private HttpResponse<String> post(HttpClient client, String url, String token, String sessionId, String body)
+            throws Exception {
+        HttpRequest.Builder b = HttpRequest.newBuilder(URI.create(url))
+                .timeout(Duration.ofSeconds(20))
+                .header("Authorization", "Bearer " + token)
+                .header("Content-Type", "application/json")
+                .header("Accept", "application/json, text/event-stream")
+                .POST(HttpRequest.BodyPublishers.ofString(body));
+        if (sessionId != null) {
+            b.header("Mcp-Session-Id", sessionId);
+        }
+        return client.send(b.build(), HttpResponse.BodyHandlers.ofString());
+    }
+
+    /** Extracts the JSON payload from an SSE ({@code data:} framed) body, or returns the body unchanged. */
+    private String sseOrJson(String body) {
+        if (body == null) {
+            return "";
+        }
+        int idx = body.lastIndexOf("data:");
+        if (idx < 0) {
+            return body;
+        }
+        String rest = body.substring(idx + "data:".length());
+        int nl = rest.indexOf('\n');
+        return (nl >= 0 ? rest.substring(0, nl) : rest).trim();
+    }
+
+    private SSLContext trustAll() throws Exception {
+        SSLContext sslContext = SSLContext.getInstance("TLS");
+        sslContext.init(null, new TrustManager[]{new X509TrustManager() {
+            public void checkClientTrusted(X509Certificate[] chain, String authType) { }
+            public void checkServerTrusted(X509Certificate[] chain, String authType) { }
+            public X509Certificate[] getAcceptedIssuers() { return new X509Certificate[0]; }
+        }}, new SecureRandom());
+        return sslContext;
+    }
+}

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/MCPInvocationSteps.java
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/MCPInvocationSteps.java
@@ -71,7 +71,7 @@ public class MCPInvocationSteps {
                               String expected, int timeoutSeconds) throws Exception {
 
         String resolvedContext = Utils.resolveContextPlaceholders(context);
-        String token = Utils.resolveFromContext(accessToken).toString();
+        String token = TestContext.resolve(accessToken).toString();
         String base = getBaseGatewayUrl();
         if (base.endsWith("/")) {
             base = base.substring(0, base.length() - 1);
@@ -131,7 +131,7 @@ public class MCPInvocationSteps {
     public void invokeMcpMultiCall(String context, String version, String accessToken, String calls,
                                    int timeoutSeconds) throws Exception {
         String mcpUrl = buildMcpUrl(context, version);
-        String token = Utils.resolveFromContext(accessToken).toString();
+        String token = TestContext.resolve(accessToken).toString();
         String[] specs = calls.split(";");
 
         long endTime = System.currentTimeMillis() + Math.max(timeoutSeconds * 1000L, 30000L);
@@ -182,7 +182,7 @@ public class MCPInvocationSteps {
     public void invokeMcpToolExpectError(String toolName, String argsJson, String context, String version,
                                          String accessToken, int timeoutSeconds) throws Exception {
         String mcpUrl = buildMcpUrl(context, version);
-        String token = Utils.resolveFromContext(accessToken).toString();
+        String token = TestContext.resolve(accessToken).toString();
 
         long endTime = System.currentTimeMillis() + Math.max(timeoutSeconds * 1000L, 30000L);
         String lastError = null;
@@ -265,7 +265,7 @@ public class MCPInvocationSteps {
                                           String accessToken, int expectedStatus, int timeoutSeconds)
             throws Exception {
         String mcpUrl = buildMcpUrl(context, version);
-        String token = Utils.resolveFromContext(accessToken).toString();
+        String token = TestContext.resolve(accessToken).toString();
         String callPayload = "{\"jsonrpc\":\"2.0\",\"id\":6,\"method\":\"tools/call\",\"params\":{"
                 + "\"name\":\"" + toolName + "\",\"arguments\":" + argsJson + "}}";
 

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/MCPServerSteps.java
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/MCPServerSteps.java
@@ -1,0 +1,441 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.wso2.am.integration.cucumbertests.stepdefinitions;
+
+import io.cucumber.java.en.When;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.wso2.am.integration.cucumbertests.utils.Identity;
+import org.wso2.am.integration.cucumbertests.utils.TestContext;
+import org.wso2.am.integration.cucumbertests.utils.Utils;
+import org.wso2.am.integration.cucumbertests.utils.clients.SimpleHTTPClient;
+import org.wso2.am.integration.test.utils.Constants;
+import org.wso2.carbon.automation.test.utils.http.client.HttpResponse;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Publisher-plane MCP-server glue (ports the create/proxy half of MCPServerTestCase). Focuses on the PROXY
+ * subtype: create an MCP server that fronts a third-party MCP server (the node mock MCP server built on the
+ * official SDK) — this is the mode that exercises the gateway proxying a REAL, session-stateful MCP server
+ * (the legacy used a stateless WireMock, a coverage gap this closes).
+ */
+public class MCPServerSteps {
+
+    private String getBaseUrl() {
+        return TestContext.get("baseUrl").toString();
+    }
+
+    /**
+     * Creates an MCP server by PROXYING a third-party MCP server (POST /mcp-servers/generate-from-mcp-server),
+     * exposing the given comma-separated tool set. The gateway discovers the tools from {@code backendUrl} at
+     * create time and, once deployed, proxies client MCP JSON-RPC to it. Non-asserting; stores the created id on
+     * 2xx. The exposed operations control which discovered tools become MCP tools (docs "select tools to
+     * import"); they are REQUIRED or the create returns "no URI templates were produced".
+     *
+     * @param backendUrl the third-party MCP server BASE URL (APIM appends {@code /mcp}); e.g. http://nodebackend:3020
+     * @param tools      comma-separated tool names to expose (e.g. {@code echo,add})
+     * @param idKey      context key to store the created MCP-server id under
+     */
+    @When("I create an MCP server proxy to {string} exposing tools {string} as {string}")
+    public void iCreateMcpServerProxy(String backendUrl, String tools, String idKey) throws IOException {
+        String requestJson = Utils.resolvePayloadPlaceholders(
+                "{"
+                        + "\"url\":\"" + backendUrl + "\","
+                        + "\"securityInfo\":{\"isSecure\":false},"
+                        + "\"additionalProperties\":{"
+                        + "  \"name\":\"${UNIQUE:MCPProxy}\","
+                        + "  \"displayName\":\"${UNIQUE:MCPProxy}\","
+                        + "  \"version\":\"1.0.0\","
+                        + "  \"context\":\"${UNIQUE:mcpProxyContext}\","
+                        + "  \"policies\":[\"Unlimited\"],"
+                        + "  \"endpointConfig\":{\"endpoint_type\":\"http\","
+                        + "     \"production_endpoints\":{\"url\":\"" + backendUrl + "\"},"
+                        + "     \"sandbox_endpoints\":{\"url\":\"" + backendUrl + "\"}},"
+                        + "  \"operations\":" + buildToolOperations(tools)
+                        + "}}");
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doPost(Utils.getMCPServerProxyURL(getBaseUrl()), headers, requestJson,
+                        Constants.CONTENT_TYPES.APPLICATION_JSON);
+        TestContext.set("httpResponse", response);
+        if (response.getResponseCode() >= 200 && response.getResponseCode() < 300) {
+            Object createdId = Utils.extractValueFromPayload(response.getData(), "id");
+            TestContext.set(idKey, createdId);
+        }
+    }
+
+    /**
+     * Updates an MCP server's exposed tool set (PUT /mcp-servers/{id}): fetches the server, replaces its
+     * {@code operations} with the given comma-separated tools, and PUTs it back. Non-asserting; stores the
+     * response (which reflects the persisted operations). Ports the tool-update half of MCPServerTestCase.
+     *
+     * @param idKey context key holding the MCP-server id
+     * @param tools comma-separated tool set the server should now expose
+     */
+    @When("I update the MCP server {string} to expose tools {string}")
+    public void iUpdateMcpServerTools(String idKey, String tools) throws IOException {
+        String id = Utils.resolveFromContext(idKey).toString();
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
+
+        HttpResponse getResp = SimpleHTTPClient.getInstance()
+                .doGet(Utils.getMCPServerByIdURL(getBaseUrl(), id), headers);
+        JSONObject dto = new JSONObject(getResp.getData());
+        dto.put("operations", new org.json.JSONArray(buildToolOperations(tools)));
+
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doPut(Utils.getMCPServerByIdURL(getBaseUrl(), id), headers, dto.toString(),
+                        Constants.CONTENT_TYPES.APPLICATION_JSON);
+        TestContext.set("httpResponse", response);
+    }
+
+    /**
+     * Gates an MCP tool with a scope (PUT /mcp-servers/{id}): defines the scope on the MCP server (name +
+     * role binding) and assigns it to the operation whose backend target is {@code tool}. Ports the scope half
+     * of testScopesForProxySubtype. Non-asserting. After redeploy, a token WITHOUT the scope is refused (403)
+     * at the tool call and one WITH it succeeds (200).
+     *
+     * @param idKey     context key holding the MCP-server id
+     * @param tool      the tool (backend target) to gate
+     * @param scopeName the scope name
+     * @param role      role bound to the scope (e.g. {@code admin})
+     */
+    @When("I gate the MCP server {string} tool {string} with scope {string} bound to role {string}")
+    public void iGateMcpTool(String idKey, String tool, String scopeName, String role) throws IOException {
+        String id = Utils.resolveFromContext(idKey).toString();
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
+
+        JSONObject dto = new JSONObject(SimpleHTTPClient.getInstance()
+                .doGet(Utils.getMCPServerByIdURL(getBaseUrl(), id), headers).getData());
+
+        // Define the scope on the MCP server (inline local scope, bound to a role).
+        JSONObject scopeDef = new JSONObject().put("scope", new JSONObject()
+                .put("name", scopeName).put("displayName", scopeName)
+                .put("description", "mcp scope enforcement")
+                .put("bindings", new JSONArray().put(role)));
+        dto.put("scopes", new JSONArray().put(scopeDef));
+
+        // Assign the scope to the matching tool operation (the top-level target is the tool name for both the
+        // proxy and DirectBackend subtypes).
+        JSONArray ops = dto.getJSONArray("operations");
+        for (int i = 0; i < ops.length(); i++) {
+            JSONObject op = ops.getJSONObject(i);
+            if (tool.equals(op.optString("target"))) {
+                op.put("scopes", new JSONArray().put(scopeName));
+            }
+        }
+
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doPut(Utils.getMCPServerByIdURL(getBaseUrl(), id), headers, dto.toString(),
+                        Constants.CONTENT_TYPES.APPLICATION_JSON);
+        TestContext.set("httpResponse", response);
+    }
+
+    /**
+     * Updates the business plans (subscription policies) an MCP server OFFERS (PUT /mcp-servers/{id}). Needed
+     * before a subscription can use a bespoke low policy (a subscription may only use a tier the resource
+     * offers). The policy list may contain {@code {{contextKey}}} placeholders (e.g. a runtime-created policy
+     * name). Non-asserting.
+     *
+     * @param idKey        context key holding the MCP-server id
+     * @param csvPolicies  comma-separated policy names (e.g. {@code Unlimited,{{subThrottlePolicyName}}})
+     */
+    @When("I update the MCP server {string} to offer policies {string}")
+    public void iUpdateMcpServerPolicies(String idKey, String csvPolicies) throws IOException {
+        String id = Utils.resolveFromContext(idKey).toString();
+        String resolved = Utils.resolveContextPlaceholders(csvPolicies);
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
+
+        JSONObject dto = new JSONObject(SimpleHTTPClient.getInstance()
+                .doGet(Utils.getMCPServerByIdURL(getBaseUrl(), id), headers).getData());
+        JSONArray policies = new JSONArray();
+        for (String p : resolved.split(",")) {
+            policies.put(p.trim());
+        }
+        dto.put("policies", policies);
+
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doPut(Utils.getMCPServerByIdURL(getBaseUrl(), id), headers, dto.toString(),
+                        Constants.CONTENT_TYPES.APPLICATION_JSON);
+        TestContext.set("httpResponse", response);
+    }
+
+    /** Builds the MCP operations JSON array (one TOOL op per name) from a comma-separated tool list. */
+    private String buildToolOperations(String csvTools) {
+        StringBuilder sb = new StringBuilder("[");
+        String[] names = csvTools.split(",");
+        for (int i = 0; i < names.length; i++) {
+            String t = names[i].trim();
+            if (i > 0) {
+                sb.append(",");
+            }
+            sb.append("{\"feature\":\"TOOL\",\"backendOperationMapping\":{\"backendOperation\":{\"verb\":\"TOOL\",\"target\":\"")
+                    .append(t).append("\"}}}");
+        }
+        return sb.append("]").toString();
+    }
+
+    /**
+     * Creates an MCP server FROM an OpenAPI definition (POST /mcp-servers/generate-from-openapi, multipart
+     * {@code file} = OAS + {@code additionalProperties}). The gateway generates a TOOL per OAS operation and, at
+     * runtime, translates each {@code tools/call} into an HTTP request to the configured REST {@code backendUrl}
+     * (MCP↔HTTP). Non-asserting; stores the created id on 2xx. Ports createMCPServerUsingOpenAPIDefinition.
+     *
+     * @param oasPath    classpath path to the OpenAPI definition
+     * @param backendUrl the REST backend base URL the generated tools call at runtime
+     * @param idKey      context key to store the created MCP-server id under
+     */
+    @When("I create an MCP server from openapi {string} with backend {string} as {string}")
+    public void iCreateMcpFromOpenApi(String oasPath, String backendUrl, String idKey) throws IOException {
+        File oasFile;
+        try (java.io.InputStream in = getClass().getClassLoader().getResourceAsStream(oasPath)) {
+            if (in == null) {
+                throw new java.io.FileNotFoundException("OAS not found: " + oasPath);
+            }
+            oasFile = File.createTempFile("mcp-oas", ".json");
+            oasFile.deleteOnExit();
+            java.nio.file.Files.copy(in, oasFile.toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+        }
+        // The create maps selected OAS operations to tools; each op's backendOperation.target is the REST PATH
+        // and verb is the HTTP method (DirectBackend shape). Without operations: "no URI templates were
+        // produced". The petstore OAS exposes GET /pets (tool get_pets) and GET /pets/{petId} (get_pets_by_petId).
+        String additionalProperties = Utils.resolvePayloadPlaceholders(
+                "{"
+                        + "\"name\":\"${UNIQUE:MCPFromOAS}\","
+                        + "\"version\":\"1.0.0\","
+                        + "\"context\":\"${UNIQUE:mcpOasContext}\","
+                        + "\"policies\":[\"Unlimited\"],"
+                        + "\"endpointConfig\":{\"endpoint_type\":\"http\","
+                        + "  \"production_endpoints\":{\"url\":\"" + backendUrl + "\"},"
+                        + "  \"sandbox_endpoints\":{\"url\":\"" + backendUrl + "\"}},"
+                        + "\"operations\":["
+                        + "  {\"feature\":\"TOOL\",\"backendOperationMapping\":{\"backendOperation\":{\"target\":\"/pets\",\"verb\":\"GET\"}}},"
+                        + "  {\"feature\":\"TOOL\",\"backendOperationMapping\":{\"backendOperation\":{\"target\":\"/pets/{petId}\",\"verb\":\"GET\"}}}"
+                        + "]"
+                        + "}");
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
+        Map<String, File> files = new HashMap<>();
+        files.put("file", oasFile);
+        Map<String, String> formFields = new HashMap<>();
+        formFields.put("additionalProperties", additionalProperties);
+
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doPostMultipartWithFiles(Utils.getMCPServerFromOpenAPIURL(getBaseUrl()), headers, files, formFields);
+        TestContext.set("httpResponse", response);
+        if (response.getResponseCode() >= 200 && response.getResponseCode() < 300) {
+            Object createdId = Utils.extractValueFromPayload(response.getData(), "id");
+            TestContext.set(idKey, createdId);
+        }
+    }
+
+    /**
+     * Creates an MCP server FROM an existing (published/deployed) API (POST /mcp-servers/generate-from-api,
+     * JSON MCPServer body). Each tool maps to one of the API's resources via
+     * {@code apiOperationMapping{apiId, backendOperation{target:<path>, verb}}}; at runtime the gateway routes
+     * the tool call through that API to its backend. Non-asserting; stores the created id on 2xx. Ports
+     * createMCPServerUsingAPI.
+     *
+     * @param apiKey context key holding the existing API id
+     * @param paths  comma-separated GET resource paths to expose as tools (e.g. {@code /pets,/pets/{petId}})
+     * @param idKey  context key to store the created MCP-server id under
+     */
+    @When("I create an MCP server from api {string} exposing paths {string} as {string}")
+    public void iCreateMcpFromApi(String apiKey, String paths, String idKey) throws IOException {
+        String apiId = Utils.resolveFromContext(apiKey).toString();
+        StringBuilder ops = new StringBuilder("[");
+        String[] targets = paths.split(",");
+        for (int i = 0; i < targets.length; i++) {
+            if (i > 0) {
+                ops.append(",");
+            }
+            ops.append("{\"feature\":\"TOOL\",\"apiOperationMapping\":{\"apiId\":\"").append(apiId)
+                    .append("\",\"backendOperation\":{\"target\":\"").append(targets[i].trim())
+                    .append("\",\"verb\":\"GET\"}}}");
+        }
+        ops.append("]");
+        String requestJson = Utils.resolvePayloadPlaceholders(
+                "{"
+                        + "\"name\":\"${UNIQUE:MCPFromAPI}\","
+                        + "\"version\":\"1.0.0\","
+                        + "\"context\":\"${UNIQUE:mcpApiContext}\","
+                        + "\"policies\":[\"Unlimited\"],"
+                        + "\"operations\":" + ops
+                        + "}");
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doPost(Utils.getMCPServerFromAPIURL(getBaseUrl()), headers, requestJson,
+                        Constants.CONTENT_TYPES.APPLICATION_JSON);
+        TestContext.set("httpResponse", response);
+        if (response.getResponseCode() >= 200 && response.getResponseCode() < 300) {
+            Object createdId = Utils.extractValueFromPayload(response.getData(), "id");
+            TestContext.set(idKey, createdId);
+        }
+    }
+
+    /**
+     * Removes a tool from an MCP server (PUT /mcp-servers/{id}) by dropping the operation whose tool name
+     * ({@code target}) matches — preserving the generated shape of the remaining operations (works for any
+     * subtype). Non-asserting. Used to narrow the exposed tool set (docs "select tools to import").
+     *
+     * @param idKey context key holding the MCP-server id
+     * @param tool  the tool name to remove
+     */
+    @When("I update the MCP server {string} removing tool {string}")
+    public void iRemoveMcpTool(String idKey, String tool) throws IOException {
+        String id = Utils.resolveFromContext(idKey).toString();
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
+
+        JSONObject dto = new JSONObject(SimpleHTTPClient.getInstance()
+                .doGet(Utils.getMCPServerByIdURL(getBaseUrl(), id), headers).getData());
+        JSONArray ops = dto.getJSONArray("operations");
+        JSONArray kept = new JSONArray();
+        for (int i = 0; i < ops.length(); i++) {
+            JSONObject op = ops.getJSONObject(i);
+            // Match by the operation's serialized JSON containing the tool name — robust across subtypes (the
+            // tool name may sit in `target` or be derived; a substring match on the op is unambiguous here).
+            if (op.toString().contains(tool)) {
+                // Capture the removed operation verbatim so it can be re-added later (preserving its exact
+                // subtype shape) — enables testing tool-update ADD as the inverse of REMOVE on any subtype.
+                TestContext.set("removedMcpTool", op.toString());
+            } else {
+                kept.put(op);
+            }
+        }
+        dto.put("operations", kept);
+
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doPut(Utils.getMCPServerByIdURL(getBaseUrl(), id), headers, dto.toString(),
+                        Constants.CONTENT_TYPES.APPLICATION_JSON);
+        TestContext.set("httpResponse", response);
+    }
+
+    /**
+     * Re-adds the operation most recently removed by {@code I update the MCP server … removing tool …} back to
+     * an MCP server (PUT /mcp-servers/{id}) — the inverse of remove, preserving the operation's exact subtype
+     * shape (proxy TOOL-verb, DirectBackend path+verb, or API apiOperationMapping). Tests tool-update ADD on any
+     * subtype. Non-asserting.
+     *
+     * @param idKey context key holding the MCP-server id
+     */
+    @When("I re-add the removed tool to the MCP server {string}")
+    public void iReAddMcpTool(String idKey) throws IOException {
+        String id = Utils.resolveFromContext(idKey).toString();
+        String removed = Utils.resolveFromContext("removedMcpTool").toString();
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
+
+        JSONObject dto = new JSONObject(SimpleHTTPClient.getInstance()
+                .doGet(Utils.getMCPServerByIdURL(getBaseUrl(), id), headers).getData());
+        dto.getJSONArray("operations").put(new JSONObject(removed));
+
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doPut(Utils.getMCPServerByIdURL(getBaseUrl(), id), headers, dto.toString(),
+                        Constants.CONTENT_TYPES.APPLICATION_JSON);
+        TestContext.set("httpResponse", response);
+    }
+
+    /** Deletes an MCP server (DELETE /mcp-servers/{id}). Best-effort teardown (no ResourceCleanup hook). */
+    @When("I delete the MCP server {string}")
+    public void iDeleteMcpServer(String idKey) throws IOException {
+        Object id = TestContext.get(idKey);
+        if (id == null) {
+            return;
+        }
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doDelete(Utils.getMCPServerByIdURL(getBaseUrl(), id.toString()), headers);
+        TestContext.set("httpResponse", response);
+    }
+
+    // ---- MCP backend-endpoint management (/mcp-servers/{id}/backends) ----
+    // An MCP server's backend endpoint is created implicitly with the server (proxy → the upstream MCP URL;
+    // from-OpenAPI → the OpenAPI backend). The backends resource exposes list/get/update (there is no separate
+    // add/delete — the backend's lifecycle is bound to the server). from-API MCP servers have NO own backend
+    // (they proxy an existing API), so this resource applies only to the proxy and from-OpenAPI subtypes.
+
+    private Map<String, String> publisherHeaders() {
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
+        return headers;
+    }
+
+    /**
+     * GET /mcp-servers/{id}/backends — lists the MCP server's backend endpoints and stores the first backend's
+     * id under {@code idKey} (for the subsequent get/update). Sets httpResponse for list assertions.
+     */
+    @When("I retrieve the backends of MCP server {string} and store the first backend id as {string}")
+    public void iRetrieveMcpServerBackends(String mcpServerId, String idKey) throws IOException {
+        String actualId = Utils.resolveFromContext(mcpServerId).toString();
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doGet(Utils.getMCPServerBackendsURL(getBaseUrl(), actualId), publisherHeaders());
+        TestContext.set("httpResponse", response);
+        if (response.getResponseCode() >= 200 && response.getResponseCode() < 300) {
+            // The MCP backends collection is a BARE JSON array ([{id,name,endpointConfig,...}]), not a
+            // {"list":[…]} envelope — index the array root directly.
+            TestContext.set(idKey, Utils.extractValueFromPayload(response.getData(), "[0].id"));
+        }
+    }
+
+    /** GET /mcp-servers/{id}/backends/{backendId} — retrieves a single MCP backend endpoint by id. */
+    @When("I retrieve backend {string} of MCP server {string}")
+    public void iRetrieveMcpServerBackend(String backendId, String mcpServerId) throws IOException {
+        String actualId = Utils.resolveFromContext(mcpServerId).toString();
+        String actualBackendId = Utils.resolveFromContext(backendId).toString();
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doGet(Utils.getMCPServerBackendByIdURL(getBaseUrl(), actualId, actualBackendId), publisherHeaders());
+        TestContext.set("httpResponse", response);
+    }
+
+    /** PUT /mcp-servers/{id}/backends/{backendId} — updates a single MCP backend endpoint (body = BackendDTO). */
+    @When("I update backend {string} of MCP server {string} with payload {string}")
+    public void iUpdateMcpServerBackend(String backendId, String mcpServerId, String payload) throws IOException {
+        String actualId = Utils.resolveFromContext(mcpServerId).toString();
+        String actualBackendId = Utils.resolveFromContext(backendId).toString();
+        String jsonPayload = Utils.resolveFromContext(payload).toString();
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doPut(Utils.getMCPServerBackendByIdURL(getBaseUrl(), actualId, actualBackendId), publisherHeaders(),
+                        jsonPayload, Constants.CONTENT_TYPES.APPLICATION_JSON);
+        TestContext.set("httpResponse", response);
+    }
+}

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/MCPServerSteps.java
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/MCPServerSteps.java
@@ -21,6 +21,8 @@ import io.cucumber.java.en.When;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.wso2.am.integration.cucumbertests.utils.Identity;
+import org.wso2.am.integration.cucumbertests.utils.Requests;
+import org.wso2.am.integration.cucumbertests.utils.ResourceCleanup;
 import org.wso2.am.integration.cucumbertests.utils.TestContext;
 import org.wso2.am.integration.cucumbertests.utils.Utils;
 import org.wso2.am.integration.cucumbertests.utils.clients.SimpleHTTPClient;
@@ -75,14 +77,14 @@ public class MCPServerSteps {
 
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPost(Utils.getMCPServerProxyURL(getBaseUrl()), headers, requestJson,
-                        Constants.CONTENT_TYPES.APPLICATION_JSON);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.post(Utils.getMCPServerProxyURL(getBaseUrl()), headers, requestJson,
+                Constants.CONTENT_TYPES.APPLICATION_JSON);
         if (response.getResponseCode() >= 200 && response.getResponseCode() < 300) {
             Object createdId = Utils.extractValueFromPayload(response.getData(), "id");
             TestContext.set(idKey, createdId);
+            // Register for teardown so a scenario that fails before its explicit delete step still has the MCP
+            // server swept by the @cleanup / @AfterClass hook.
+            ResourceCleanup.register(ResourceCleanup.CREATED_MCP_SERVER_IDS, createdId);
         }
     }
 
@@ -96,7 +98,7 @@ public class MCPServerSteps {
      */
     @When("I update the MCP server {string} to expose tools {string}")
     public void iUpdateMcpServerTools(String idKey, String tools) throws IOException {
-        String id = Utils.resolveFromContext(idKey).toString();
+        String id = TestContext.resolve(idKey).toString();
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
 
@@ -105,11 +107,8 @@ public class MCPServerSteps {
         JSONObject dto = new JSONObject(getResp.getData());
         dto.put("operations", new org.json.JSONArray(buildToolOperations(tools)));
 
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPut(Utils.getMCPServerByIdURL(getBaseUrl(), id), headers, dto.toString(),
-                        Constants.CONTENT_TYPES.APPLICATION_JSON);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.put(Utils.getMCPServerByIdURL(getBaseUrl(), id), headers, dto.toString(),
+                Constants.CONTENT_TYPES.APPLICATION_JSON);
     }
 
     /**
@@ -125,7 +124,7 @@ public class MCPServerSteps {
      */
     @When("I gate the MCP server {string} tool {string} with scope {string} bound to role {string}")
     public void iGateMcpTool(String idKey, String tool, String scopeName, String role) throws IOException {
-        String id = Utils.resolveFromContext(idKey).toString();
+        String id = TestContext.resolve(idKey).toString();
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
 
@@ -149,11 +148,8 @@ public class MCPServerSteps {
             }
         }
 
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPut(Utils.getMCPServerByIdURL(getBaseUrl(), id), headers, dto.toString(),
-                        Constants.CONTENT_TYPES.APPLICATION_JSON);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.put(Utils.getMCPServerByIdURL(getBaseUrl(), id), headers, dto.toString(),
+                Constants.CONTENT_TYPES.APPLICATION_JSON);
     }
 
     /**
@@ -167,7 +163,7 @@ public class MCPServerSteps {
      */
     @When("I update the MCP server {string} to offer policies {string}")
     public void iUpdateMcpServerPolicies(String idKey, String csvPolicies) throws IOException {
-        String id = Utils.resolveFromContext(idKey).toString();
+        String id = TestContext.resolve(idKey).toString();
         String resolved = Utils.resolveContextPlaceholders(csvPolicies);
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
@@ -180,11 +176,8 @@ public class MCPServerSteps {
         }
         dto.put("policies", policies);
 
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPut(Utils.getMCPServerByIdURL(getBaseUrl(), id), headers, dto.toString(),
-                        Constants.CONTENT_TYPES.APPLICATION_JSON);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.put(Utils.getMCPServerByIdURL(getBaseUrl(), id), headers, dto.toString(),
+                Constants.CONTENT_TYPES.APPLICATION_JSON);
     }
 
     /** Builds the MCP operations JSON array (one TOOL op per name) from a comma-separated tool list. */
@@ -248,13 +241,14 @@ public class MCPServerSteps {
         Map<String, String> formFields = new HashMap<>();
         formFields.put("additionalProperties", additionalProperties);
 
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPostMultipartWithFiles(Utils.getMCPServerFromOpenAPIURL(getBaseUrl()), headers, files, formFields);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.postMultipart(Utils.getMCPServerFromOpenAPIURL(getBaseUrl()), headers,
+                files, formFields);
         if (response.getResponseCode() >= 200 && response.getResponseCode() < 300) {
             Object createdId = Utils.extractValueFromPayload(response.getData(), "id");
             TestContext.set(idKey, createdId);
+            // Register for teardown so a scenario that fails before its explicit delete step still has the MCP
+            // server swept by the @cleanup / @AfterClass hook.
+            ResourceCleanup.register(ResourceCleanup.CREATED_MCP_SERVER_IDS, createdId);
         }
     }
 
@@ -271,7 +265,7 @@ public class MCPServerSteps {
      */
     @When("I create an MCP server from api {string} exposing paths {string} as {string}")
     public void iCreateMcpFromApi(String apiKey, String paths, String idKey) throws IOException {
-        String apiId = Utils.resolveFromContext(apiKey).toString();
+        String apiId = TestContext.resolve(apiKey).toString();
         StringBuilder ops = new StringBuilder("[");
         String[] targets = paths.split(",");
         for (int i = 0; i < targets.length; i++) {
@@ -294,14 +288,14 @@ public class MCPServerSteps {
 
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPost(Utils.getMCPServerFromAPIURL(getBaseUrl()), headers, requestJson,
-                        Constants.CONTENT_TYPES.APPLICATION_JSON);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.post(Utils.getMCPServerFromAPIURL(getBaseUrl()), headers, requestJson,
+                Constants.CONTENT_TYPES.APPLICATION_JSON);
         if (response.getResponseCode() >= 200 && response.getResponseCode() < 300) {
             Object createdId = Utils.extractValueFromPayload(response.getData(), "id");
             TestContext.set(idKey, createdId);
+            // Register for teardown so a scenario that fails before its explicit delete step still has the MCP
+            // server swept by the @cleanup / @AfterClass hook.
+            ResourceCleanup.register(ResourceCleanup.CREATED_MCP_SERVER_IDS, createdId);
         }
     }
 
@@ -315,7 +309,7 @@ public class MCPServerSteps {
      */
     @When("I update the MCP server {string} removing tool {string}")
     public void iRemoveMcpTool(String idKey, String tool) throws IOException {
-        String id = Utils.resolveFromContext(idKey).toString();
+        String id = TestContext.resolve(idKey).toString();
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
 
@@ -337,11 +331,8 @@ public class MCPServerSteps {
         }
         dto.put("operations", kept);
 
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPut(Utils.getMCPServerByIdURL(getBaseUrl(), id), headers, dto.toString(),
-                        Constants.CONTENT_TYPES.APPLICATION_JSON);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.put(Utils.getMCPServerByIdURL(getBaseUrl(), id), headers, dto.toString(),
+                Constants.CONTENT_TYPES.APPLICATION_JSON);
     }
 
     /**
@@ -354,8 +345,8 @@ public class MCPServerSteps {
      */
     @When("I re-add the removed tool to the MCP server {string}")
     public void iReAddMcpTool(String idKey) throws IOException {
-        String id = Utils.resolveFromContext(idKey).toString();
-        String removed = Utils.resolveFromContext("removedMcpTool").toString();
+        String id = TestContext.resolve(idKey).toString();
+        String removed = TestContext.resolve("removedMcpTool").toString();
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
 
@@ -363,14 +354,12 @@ public class MCPServerSteps {
                 .doGet(Utils.getMCPServerByIdURL(getBaseUrl(), id), headers).getData());
         dto.getJSONArray("operations").put(new JSONObject(removed));
 
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPut(Utils.getMCPServerByIdURL(getBaseUrl(), id), headers, dto.toString(),
-                        Constants.CONTENT_TYPES.APPLICATION_JSON);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.put(Utils.getMCPServerByIdURL(getBaseUrl(), id), headers, dto.toString(),
+                Constants.CONTENT_TYPES.APPLICATION_JSON);
     }
 
-    /** Deletes an MCP server (DELETE /mcp-servers/{id}). Best-effort teardown (no ResourceCleanup hook). */
+    /** Deletes an MCP server (DELETE /mcp-servers/{id}) — the explicit delete scenarios use to assert removal.
+     *  Teardown is additionally covered by ResourceCleanup (the create side registers the server). */
     @When("I delete the MCP server {string}")
     public void iDeleteMcpServer(String idKey) throws IOException {
         Object id = TestContext.get(idKey);
@@ -379,10 +368,7 @@ public class MCPServerSteps {
         }
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doDelete(Utils.getMCPServerByIdURL(getBaseUrl(), id.toString()), headers);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.delete(Utils.getMCPServerByIdURL(getBaseUrl(), id.toString()), headers);
     }
 
     // ---- MCP backend-endpoint management (/mcp-servers/{id}/backends) ----
@@ -403,11 +389,9 @@ public class MCPServerSteps {
      */
     @When("I retrieve the backends of MCP server {string} and store the first backend id as {string}")
     public void iRetrieveMcpServerBackends(String mcpServerId, String idKey) throws IOException {
-        String actualId = Utils.resolveFromContext(mcpServerId).toString();
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doGet(Utils.getMCPServerBackendsURL(getBaseUrl(), actualId), publisherHeaders());
-        TestContext.set("httpResponse", response);
+        String actualId = TestContext.resolve(mcpServerId).toString();
+        HttpResponse response = Requests.get(Utils.getMCPServerBackendsURL(getBaseUrl(), actualId),
+                publisherHeaders());
         if (response.getResponseCode() >= 200 && response.getResponseCode() < 300) {
             // The MCP backends collection is a BARE JSON array ([{id,name,endpointConfig,...}]), not a
             // {"list":[…]} envelope — index the array root directly.
@@ -418,24 +402,19 @@ public class MCPServerSteps {
     /** GET /mcp-servers/{id}/backends/{backendId} — retrieves a single MCP backend endpoint by id. */
     @When("I retrieve backend {string} of MCP server {string}")
     public void iRetrieveMcpServerBackend(String backendId, String mcpServerId) throws IOException {
-        String actualId = Utils.resolveFromContext(mcpServerId).toString();
-        String actualBackendId = Utils.resolveFromContext(backendId).toString();
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doGet(Utils.getMCPServerBackendByIdURL(getBaseUrl(), actualId, actualBackendId), publisherHeaders());
-        TestContext.set("httpResponse", response);
+        String actualId = TestContext.resolve(mcpServerId).toString();
+        String actualBackendId = TestContext.resolve(backendId).toString();
+        HttpResponse response = Requests.get(Utils.getMCPServerBackendByIdURL(getBaseUrl(), actualId, actualBackendId),
+                publisherHeaders());
     }
 
     /** PUT /mcp-servers/{id}/backends/{backendId} — updates a single MCP backend endpoint (body = BackendDTO). */
     @When("I update backend {string} of MCP server {string} with payload {string}")
     public void iUpdateMcpServerBackend(String backendId, String mcpServerId, String payload) throws IOException {
-        String actualId = Utils.resolveFromContext(mcpServerId).toString();
-        String actualBackendId = Utils.resolveFromContext(backendId).toString();
-        String jsonPayload = Utils.resolveFromContext(payload).toString();
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPut(Utils.getMCPServerBackendByIdURL(getBaseUrl(), actualId, actualBackendId), publisherHeaders(),
-                        jsonPayload, Constants.CONTENT_TYPES.APPLICATION_JSON);
-        TestContext.set("httpResponse", response);
+        String actualId = TestContext.resolve(mcpServerId).toString();
+        String actualBackendId = TestContext.resolve(backendId).toString();
+        String jsonPayload = TestContext.resolve(payload).toString();
+        HttpResponse response = Requests.put(Utils.getMCPServerBackendByIdURL(getBaseUrl(), actualId, actualBackendId),
+                publisherHeaders(), jsonPayload, Constants.CONTENT_TYPES.APPLICATION_JSON);
     }
 }

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/PublisherBaseSteps.java
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/PublisherBaseSteps.java
@@ -111,6 +111,22 @@ public class PublisherBaseSteps {
     }
 
     /**
+     * Attempts to create a resource with NO Authorization header — the unauthenticated-create negative (401).
+     * Non-asserting; the feature asserts the status.
+     */
+    @When("I attempt to create an {string} resource with payload {string} without authentication")
+    public void iAttemptToCreateAnAPIWithoutAuth(String resourceType, String payload) throws IOException {
+
+        String jsonPayload = Utils.resolveFromContext(payload).toString();
+
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doPost(Utils.getAPICreateEndpointURL(getBaseUrl(), resourceType), new HashMap<>(), jsonPayload,
+                        Constants.CONTENT_TYPES.APPLICATION_JSON);
+        TestContext.set("httpResponse", response);
+    }
+
+    /**
      * Updates an existing resource using a JSON payload stored in the test context.
      *
      * @param resourceType Type of resource to update (e.g., "apis", "api-products")
@@ -162,6 +178,28 @@ public class PublisherBaseSteps {
     }
 
     /**
+     * Attempts to create a revision without asserting success — for negatives (e.g. a revision expected to be
+     * blocked by a governance BLOCK-on-deploy policy with 903300). The feature asserts the resulting status
+     * and error code.
+     */
+    @When("I attempt to create a revision for {string} resource {string} with payload {string}")
+    public void iAttemptToCreateResourceRevision(String resourceType, String resourceId, String contextKey)
+            throws IOException {
+
+        String actualResourceId = Utils.resolveFromContext(resourceId).toString();
+        String jsonPayload = Utils.resolveFromContext(contextKey).toString();
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
+
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doPost(Utils.getRevisionURL(getBaseUrl(), resourceType, actualResourceId), headers, jsonPayload,
+                        Constants.CONTENT_TYPES.APPLICATION_JSON);
+        TestContext.set("httpResponse", response);
+    }
+
+    /**
      * Deploys a specific revision of a resource to the gateway environment.
      *
      * @param revisionId Context key containing the revision ID to deploy
@@ -176,6 +214,9 @@ public class PublisherBaseSteps {
         String actualRevisionId = Utils.resolveFromContext(revisionId).toString();
         String jsonPayload = Utils.resolveFromContext(payload).toString();
         jsonPayload = jsonPayload.replace("{{gatewayEnvironment}}", System.getenv(Constants.GATEWAY_ENVIRONMENT));
+        // Resolve any remaining {{contextKey}} placeholders (e.g. a captured custom environment name for a
+        // deploy-to-vhost scenario). No-op when the payload has none; fails fast on an unknown key.
+        jsonPayload = Utils.resolveContextPlaceholders(jsonPayload);
 
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION,
@@ -214,6 +255,80 @@ public class PublisherBaseSteps {
      * @param resourceType Type of resource to publish (e.g., "apis", "api-products")
      * @param resourceId Context key containing the resource ID to publish
      */
+    /**
+     * Generates the inline mock implementation script for an API (POST /apis/{id}/generate-mock-scripts).
+     * Ports the generateMockScript call of PrototypedAPITestcase inline-mock tests. Non-asserting.
+     *
+     * @param apiId context key holding the API id
+     */
+    @When("I generate the mock implementation script for API {string}")
+    public void iGenerateMockScript(String apiId) throws IOException {
+
+        String actualApiId = Utils.resolveFromContext(apiId).toString();
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doPost(Utils.getGenerateMockScriptsURL(getBaseUrl(), actualApiId), headers, "", null);
+        TestContext.set("httpResponse", response);
+    }
+
+    /**
+     * Retrieves the generated inline mock implementation script for an API
+     * (GET /apis/{id}/generate-mock-scripts). Ports getGenerateMockScript. Non-asserting.
+     *
+     * @param apiId context key holding the API id
+     */
+    @When("I retrieve the mock implementation script for API {string}")
+    public void iRetrieveMockScript(String apiId) throws IOException {
+
+        String actualApiId = Utils.resolveFromContext(apiId).toString();
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doGet(Utils.getGeneratedMockScriptsURL(getBaseUrl(), actualApiId), headers);
+        TestContext.set("httpResponse", response);
+    }
+
+    /**
+     * Validates a system role via the publisher {@code GET /roles/{base64url(role)}} endpoint. Ports APIM638.
+     * Non-asserting — the feature asserts 200 (existing role) or 404 (non-existing).
+     *
+     * @param role the role name (e.g. {@code admin}, {@code Internal/publisher})
+     */
+    @When("I validate the role {string}")
+    public void iValidateRole(String role) throws IOException {
+        Map<String, String> headers = new HashMap<>();
+        // Legacy validates roles with a publisher token (api_create/publish/manage) → 200; the earlier 401 was
+        // a padded-base64 path bug, not a scope issue (see Utils.getValidateRoleURL).
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doHead(Utils.getValidateRoleURL(getBaseUrl(), role), headers);
+        TestContext.set("httpResponse", response);
+    }
+
+    /**
+     * Force-changes a subscription's business plan via the publisher endpoint
+     * (POST /subscriptions/change-business-plan?subscriptionId=&throttlingPolicy=). Unlike the devportal
+     * subscription PUT (which silently ignores an invalid plan → 200), this endpoint validates the plan.
+     * Ports ChangeSubscriptionBusinessPlanForcefullyTestCase. Non-asserting.
+     *
+     * @param subId context key holding the subscription id
+     * @param plan  the throttling policy / business plan to set
+     */
+    @When("I change the subscription business plan of {string} to {string}")
+    public void iChangeSubscriptionBusinessPlan(String subId, String plan) throws IOException {
+        String actualSubId = Utils.resolveFromContext(subId).toString();
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doPost(Utils.getChangeSubscriptionBusinessPlanURL(getBaseUrl(), actualSubId, plan), headers, "", null);
+        TestContext.set("httpResponse", response);
+    }
+
     @When("I publish the {string} resource with id {string}")
     public void iPublishTheResource(String resourceType, String resourceId) throws IOException {
 
@@ -362,11 +477,21 @@ public class PublisherBaseSteps {
      */
     @Given("I deploy the API with id {string}")
     public void iDeployAPI(String apiID) throws IOException, InterruptedException{
+        iDeployResource("apis", apiID);
+    }
+
+    /**
+     * Resource-typed deploy (create a revision + deploy it to the gateway env) — the general form of
+     * {@link #iDeployAPI(String)} for other deployable resource types, e.g. {@code "mcp-servers"}. The revision
+     * and deploy-revision endpoints are path-typed by resourceType, so the same payloads apply.
+     */
+    @Given("I deploy the {string} resource with id {string}")
+    public void iDeployResource(String resourceType, String resourceID) throws IOException, InterruptedException {
         baseSteps.putJsonPayloadInContext("<createRevisionPayload>","{\"description\":\"new Revision\"}");
-        iCreateResourceRevision("apis", apiID , "<createRevisionPayload>");
+        iCreateResourceRevision(resourceType, resourceID , "<createRevisionPayload>");
         baseSteps.putJsonPayloadInContext("<deployRevisionPayload>",
                 "[{\"name\":\"{{gatewayEnvironment}}\",\"vhost\":\"localhost\",\"displayOnDevportal\":true}]");
-        iDeployApiRevisionGivenPayload("<revisionId>", "apis" ,apiID, "<deployRevisionPayload>");
+        iDeployApiRevisionGivenPayload("<revisionId>", resourceType ,resourceID, "<deployRevisionPayload>");
     }
 
     /**
@@ -617,6 +742,64 @@ public class PublisherBaseSteps {
                         Constants.CONTENT_TYPES.APPLICATION_JSON);
 
         TestContext.set("httpResponse", documentUpdateResponse);
+    }
+
+    /**
+     * Prepares a document payload for any doc type / source, built programmatically so the source-specific field
+     * is set correctly: INLINE/MARKDOWN → {@code inlineContent}, URL → {@code sourceUrl}, FILE → no content
+     * field (uploaded separately). An OTHER type sets {@code otherTypeName}. The name is resolved for
+     * {@code ${UNIQUE:...}} so several documents can be added to one API without name collisions.
+     */
+    @When("I prepare a document named {string} of type {string} with sourceType {string} and content {string}")
+    public void iPrepareDocumentOfTypeAndSource(String name, String type, String sourceType, String content) {
+
+        JSONObject doc = new JSONObject();
+        doc.put("name", Utils.resolvePayloadPlaceholders(name));
+        doc.put("type", type);
+        doc.put("summary", "Summary of test Documentation");
+        doc.put("sourceType", sourceType);
+        doc.put("visibility", "API_LEVEL");
+        if ("URL".equals(sourceType)) {
+            doc.put("sourceUrl", content);
+        } else if ("INLINE".equals(sourceType) || "MARKDOWN".equals(sourceType)) {
+            doc.put("inlineContent", content);
+        }
+        if ("OTHER".equals(type)) {
+            doc.put("otherTypeName", "CustomDocType");
+        }
+        TestContext.set(Utils.normalizeContextKey("<newDocumentPayload>"), doc.toString());
+    }
+
+    /**
+     * Uploads a file as the content of a FILE-source document (multipart, form field {@code file}). The document
+     * must already exist (created with sourceType FILE via the add step).
+     */
+    @When("I upload the document file {string} for document {string} of API {string}")
+    public void iUploadDocumentFile(String resourcePath, String documentID, String apiID) throws IOException {
+
+        String docId = Utils.resolveFromContext(documentID).toString();
+        String actualApiId = Utils.resolveFromContext(apiID).toString();
+
+        File temp;
+        String suffix = resourcePath.substring(resourcePath.lastIndexOf('.'));
+        try (InputStream inputStream = getClass().getClassLoader().getResourceAsStream(resourcePath)) {
+            if (inputStream == null) {
+                throw new FileNotFoundException("Resource not found: " + resourcePath);
+            }
+            temp = File.createTempFile("doc-content", suffix);
+            temp.deleteOnExit();
+            Files.copy(inputStream, temp.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        }
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
+        Map<String, File> files = new HashMap<>();
+        files.put("file", temp);
+
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance().doPostMultipartWithFiles(
+                Utils.getAPIDocumentContent(getBaseUrl(), actualApiId, docId), headers, files, new HashMap<>());
+        TestContext.set("httpResponse", response);
     }
 
     // Helper to parse the values correctly for update document steps
@@ -936,6 +1119,96 @@ public class PublisherBaseSteps {
         ResourceCleanup.register(Constants.CREATED_API_IDS, createdId);
     }
 
+    /**
+     * Creates a GraphQL API from an ENDPOINT URL (import-graphql-schema with a {@code url} form field instead of a
+     * schema file) — the gateway derives the schema from the URL (introspection of a live endpoint, or fetching an
+     * SDL served at that URL). Ports GraphqlTestCase's "create using endpoint" / SDL-URL paths. Non-asserting on the
+     * create status so the feature can assert it; stores the id on 2xx.
+     *
+     * @param endpointUrl the GraphQL endpoint (introspection) or SDL URL, reachable from the gateway
+     * @param additionalPropertiesKey context key holding the additionalProperties JSON
+     * @param apiID context key to store the created API id under
+     */
+    @When("I create a GraphQL API from endpoint URL {string} with additional properties {string} as {string}")
+    public void iCreateAGraphQLAPIFromEndpointURL(String endpointUrl, String additionalPropertiesKey, String apiID)
+            throws IOException {
+        String url = Utils.resolveContextPlaceholders(endpointUrl);
+        String additionalProperties = Utils.resolveFromContext(additionalPropertiesKey).toString();
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
+
+        Map<String, String> formFields = new HashMap<>();
+        formFields.put("type", "GRAPHQL");
+        formFields.put("url", url);
+        formFields.put("additionalProperties", additionalProperties);
+
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doPostMultipartWithFiles(Utils.getGraphQLSchema(getBaseUrl()), headers, new HashMap<>(), formFields);
+        TestContext.set("httpResponse", response);
+        if (response.getResponseCode() >= 200 && response.getResponseCode() < 300) {
+            Object createdId = Utils.extractValueFromPayload(response.getData(), "id");
+            TestContext.set(apiID, createdId);
+            ResourceCleanup.register(Constants.CREATED_API_IDS, createdId);
+        }
+    }
+
+    /**
+     * Validates a GraphQL schema obtained from an endpoint URL — via INTROSPECTION of a live endpoint
+     * ({@code useIntrospection=true}) or by fetching an SDL at the URL ({@code false}) — and stores the derived
+     * SDL (from {@code graphQLInfo.graphQLSchema.schemaDefinition}) under {@code schemaKey}. Ports the
+     * validateGraphqlSchemaDefinitionByURL step of GraphqlTestCase (the create-using-endpoint / SDL-URL paths).
+     */
+    @When("I validate the GraphQL schema from endpoint URL {string} with introspection {string} and store schema as {string}")
+    public void iValidateGraphQLSchemaFromURL(String endpointUrl, String useIntrospection, String schemaKey)
+            throws IOException {
+        String url = Utils.resolveContextPlaceholders(endpointUrl);
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
+        Map<String, String> formFields = new HashMap<>();
+        formFields.put("url", url);
+
+        String validateUrl = Utils.getValidateGraphQLSchemaURL(getBaseUrl()) + "?useIntrospection=" + useIntrospection;
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doPostMultipartWithFiles(validateUrl, headers, new HashMap<>(), formFields);
+        TestContext.set("httpResponse", response);
+        String sdl = new org.json.JSONObject(response.getData())
+                .getJSONObject("graphQLInfo").getJSONObject("graphQLSchema").getString("schemaDefinition");
+        TestContext.set(Utils.normalizeContextKey(schemaKey), sdl);
+    }
+
+    /**
+     * Creates a GraphQL API from a schema STRING held in context (e.g. an SDL derived by introspecting an
+     * endpoint) — import-graphql-schema with the schema uploaded as a file. Non-asserting; stores the id on 2xx.
+     */
+    @When("I create a GraphQL API with schema {string} and additional properties {string} as {string}")
+    public void iCreateAGraphQLAPIWithSchemaStringAs(String schemaKey, String additionalPropertiesKey, String apiID)
+            throws IOException {
+        String schema = Utils.resolveFromContext(schemaKey).toString();
+        String additionalProperties = Utils.resolveFromContext(additionalPropertiesKey).toString();
+
+        File schemaFile = File.createTempFile("graphql-derived", ".graphql");
+        schemaFile.deleteOnExit();
+        Files.writeString(schemaFile.toPath(), schema);
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
+        Map<String, String> formFields = new HashMap<>();
+        formFields.put("type", "GRAPHQL");
+        formFields.put("additionalProperties", additionalProperties);
+        Map<String, File> files = new HashMap<>();
+        files.put("file", schemaFile);
+
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doPostMultipartWithFiles(Utils.getGraphQLSchema(getBaseUrl()), headers, files, formFields);
+        TestContext.set("httpResponse", response);
+        if (response.getResponseCode() >= 200 && response.getResponseCode() < 300) {
+            Object createdId = Utils.extractValueFromPayload(response.getData(), "id");
+            TestContext.set(apiID, createdId);
+            ResourceCleanup.register(Constants.CREATED_API_IDS, createdId);
+        }
+    }
+
     /** Loads a .graphql (or any) resource off the classpath into a temp file for multipart upload. */
     private File loadResourceAsTempFile(String resourcePath) throws IOException {
         try (InputStream inputStream = getClass().getClassLoader().getResourceAsStream(resourcePath)) {
@@ -1204,6 +1477,251 @@ public class PublisherBaseSteps {
     }
 
     /**
+     * Imports an API from an OpenAPI ARCHIVE (.zip, may contain remote $refs) — POST /apis/import-openapi,
+     * multipart {@code file} (the .zip, extension preserved) + {@code additionalProperties} (name/context/
+     * endpoint/policies, ${UNIQUE} resolved). Non-asserting — the feature asserts (valid archive → 201;
+     * incorrect archive → the observed error). On 2xx the created id is stored + registered for teardown.
+     * Ports APIM18 testCreateApiWithArchivesWithRemoteReferences[WithIncorrectSwagger].
+     *
+     * @param archivePath    classpath path to the .zip archive
+     * @param additionalData classpath path to the additional-properties JSON
+     * @param resourceId     context key to store the created API id under (on success)
+     */
+    @When("I import api from archive {string} with additional properties {string} as {string}")
+    public void iImportApiFromArchive(String archivePath, String additionalData, String resourceId) throws IOException {
+
+        File archiveFile = loadResourceAsTempFile(archivePath, ".zip");
+
+        String additionalProperties;
+        try (InputStream inputStream = getClass().getClassLoader().getResourceAsStream(additionalData)) {
+            if (inputStream == null) {
+                throw new FileNotFoundException("Additional properties file not found: " + additionalData);
+            }
+            additionalProperties = Utils.resolvePayloadPlaceholders(
+                    IOUtils.toString(inputStream, StandardCharsets.UTF_8));
+        }
+        File additionalPropertiesFile = File.createTempFile("data", ".json");
+        additionalPropertiesFile.deleteOnExit();
+        Files.write(additionalPropertiesFile.toPath(), additionalProperties.getBytes(StandardCharsets.UTF_8));
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
+        Map<String, File> files = new HashMap<>();
+        files.put("file", archiveFile);
+        files.put("additionalProperties", additionalPropertiesFile);
+
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doPostMultipartWithFiles(Utils.getAPIDefinitionURL(getBaseUrl()), headers, files, null);
+        TestContext.set("httpResponse", response);
+        if (response.getResponseCode() >= 200 && response.getResponseCode() < 300) {
+            Object createdId = Utils.extractValueFromPayload(response.getData(), "id");
+            TestContext.set(resourceId, createdId);
+            ResourceCleanup.register(Constants.CREATED_API_IDS, createdId);
+        }
+    }
+
+    /** Loads a classpath resource into a temp .json file (for multipart OAS upload). */
+    private File loadJsonResourceAsTempFile(String resourcePath) throws IOException {
+        return loadResourceAsTempFile(resourcePath, ".json");
+    }
+
+    /** Loads a classpath resource into a temp file PRESERVING a given suffix — needed when the server cares
+     *  about the uploaded file's extension (e.g. {@code .png} thumbnails, {@code .zip} OpenAPI archives). */
+    private File loadResourceAsTempFile(String resourcePath, String suffix) throws IOException {
+        try (InputStream inputStream = getClass().getClassLoader().getResourceAsStream(resourcePath)) {
+            if (inputStream == null) {
+                throw new FileNotFoundException("Resource not found: " + resourcePath);
+            }
+            File temp = File.createTempFile("res", suffix);
+            temp.deleteOnExit();
+            Files.copy(inputStream, temp.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            return temp;
+        }
+    }
+
+    /**
+     * Uploads a thumbnail image for an API (POST /apis/{id}/thumbnail, multipart form field {@code file}).
+     * Ports the thumbnail-set half of APIMANAGER5872. Non-asserting.
+     *
+     * @param imagePath classpath path to the image (e.g. artifacts/images/thumbnail.png)
+     * @param apiId     context key holding the API id
+     */
+    @When("I upload thumbnail {string} for API {string}")
+    public void iUploadThumbnail(String imagePath, String apiId) throws IOException {
+        String actualApiId = Utils.resolveFromContext(apiId).toString();
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
+        Map<String, File> files = new HashMap<>();
+        files.put("file", loadResourceAsTempFile(imagePath, ".png"));
+        TestContext.remove("httpResponse");
+        // Thumbnail upload is a PUT (updateAPIThumbnail), not POST — a POST returns 405.
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doPutMultipartWithFiles(Utils.getThumbnailURL(getBaseUrl(), actualApiId), headers, files,
+                        new HashMap<>());
+        TestContext.set("httpResponse", response);
+    }
+
+    /**
+     * Downloads an API's thumbnail (GET /apis/{id}/thumbnail) — 200 when a thumbnail is set. Non-asserting.
+     *
+     * @param apiId context key holding the API id
+     */
+    @When("I retrieve the thumbnail for API {string}")
+    public void iRetrieveThumbnail(String apiId) throws IOException {
+        String actualApiId = Utils.resolveFromContext(apiId).toString();
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doGet(Utils.getThumbnailURL(getBaseUrl(), actualApiId), headers);
+        TestContext.set("httpResponse", response);
+    }
+
+    /**
+     * Updates an API's OpenAPI definition (PUT /apis/{id}/swagger, form field {@code apiDefinition}) from a
+     * classpath OAS file. Non-asserting — the feature asserts the status (a valid definition → 200; an invalid
+     * one, e.g. empty resource paths, → 400).
+     */
+    @When("I update the swagger of {string} resource {string} from file {string}")
+    public void iUpdateSwaggerFromFile(String resourceType, String resourceId, String filepath) throws IOException {
+
+        String actualId = Utils.resolveFromContext(resourceId).toString();
+        String definition;
+        try (InputStream in = getClass().getClassLoader().getResourceAsStream(filepath)) {
+            if (in == null) {
+                throw new FileNotFoundException("OAS file not found: " + filepath);
+            }
+            definition = IOUtils.toString(in, StandardCharsets.UTF_8);
+        }
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
+        // The swagger PUT is multipart/form-data with the definition as the text field "apiDefinition".
+        Map<String, String> formFields = new HashMap<>();
+        formFields.put("apiDefinition", definition);
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance().doPutMultipartWithFiles(
+                Utils.getSwaggerURL(getBaseUrl(), resourceType, actualId), headers, new HashMap<>(), formFields);
+        TestContext.set("httpResponse", response);
+    }
+
+    /** Retrieves the publisher linter custom rules. */
+    @When("I retrieve the linter custom rules")
+    public void iRetrieveLinterCustomRules() throws IOException {
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doGet(Utils.getLinterCustomRulesURL(getBaseUrl()), headers);
+        TestContext.set("httpResponse", response);
+    }
+
+    /** Retrieves the available publisher throttling policies for a policy level (subscription / api / application). */
+    @When("I retrieve the publisher {string} throttling policies")
+    public void iRetrievePublisherThrottlingPolicies(String policyLevel) throws IOException {
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doGet(Utils.getPublisherThrottlingPoliciesURL(getBaseUrl(), policyLevel), headers);
+        TestContext.set("httpResponse", response);
+    }
+
+    /** Retrieves an API's OpenAPI definition (GET /apis/{id}/swagger). */
+    @When("I retrieve the swagger of {string} resource {string}")
+    public void iRetrieveSwagger(String resourceType, String resourceId) throws IOException {
+
+        String actualId = Utils.resolveFromContext(resourceId).toString();
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doGet(Utils.getSwaggerURL(getBaseUrl(), resourceType, actualId), headers);
+        TestContext.set("httpResponse", response);
+    }
+
+    /**
+     * Validates an OpenAPI definition file (POST /apis/validate-openapi, multipart {@code file}). The response
+     * carries an {@code isValid} flag; the feature asserts it (a valid def → isValid true; an invalid one →
+     * isValid false).
+     */
+    @When("I validate the openapi definition from file {string}")
+    public void iValidateOpenApiFromFile(String filepath) throws IOException {
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
+        Map<String, File> files = new HashMap<>();
+        files.put("file", loadJsonResourceAsTempFile(filepath));
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doPostMultipartWithFiles(Utils.getValidateOpenAPIURL(getBaseUrl()), headers, files, new HashMap<>());
+        TestContext.set("httpResponse", response);
+    }
+
+    /**
+     * Attempts to import an OpenAPI definition without asserting success — for the invalid-definition negative
+     * (an empty-resource-path OAS import → 400). Mirrors the positive import step but neither asserts nor
+     * registers (nothing is created on failure).
+     */
+    @When("I attempt to import openapi definition from {string} with additional properties from {string}")
+    public void iAttemptImportOpenApi(String filepath, String additionalData) throws IOException {
+        importOpenApiDefinition(filepath, additionalData, null);
+    }
+
+    /**
+     * Imports an API from an OpenAPI DEFINITION file (.json/.yaml, not an archive) and STORES the created API id
+     * for the deploy/publish/subscribe/invoke arc that follows. Non-asserting (the feature asserts 201); on a
+     * 2xx the id is stored under {@code resourceId} and registered for teardown. Used by the gateway
+     * schema-validation port, which must import an OAS carrying the request/response schemas (a create-from-
+     * payload API has only operation targets, not the body schemas the gateway validates against).
+     *
+     * @param filepath       classpath path to the OpenAPI definition
+     * @param additionalData classpath path to the additional-properties JSON (name/context/endpoint/
+     *                       enableSchemaValidation, ${UNIQUE} resolved)
+     * @param resourceId     context key to store the created API id under (on success)
+     */
+    @When("I import openapi definition from {string} with additional properties {string} as {string}")
+    public void iImportOpenApiAsResource(String filepath, String additionalData, String resourceId)
+            throws IOException {
+        importOpenApiDefinition(filepath, additionalData, resourceId);
+    }
+
+    /** Shared OpenAPI-definition import (multipart {@code file} + {@code additionalProperties}); when
+     *  {@code resourceId} is non-null and the import succeeds, stores + registers the created API id. */
+    private void importOpenApiDefinition(String filepath, String additionalData, String resourceId)
+            throws IOException {
+
+        File openapiFile = loadJsonResourceAsTempFile(filepath);
+        File additionalPropertiesFile;
+        try (InputStream inputStream = getClass().getClassLoader().getResourceAsStream(additionalData)) {
+            if (inputStream == null) {
+                throw new FileNotFoundException("Additional properties file not found: " + additionalData);
+            }
+            String additionalProperties = Utils.resolvePayloadPlaceholders(
+                    IOUtils.toString(inputStream, StandardCharsets.UTF_8));
+            additionalPropertiesFile = File.createTempFile("data", ".json");
+            additionalPropertiesFile.deleteOnExit();
+            Files.write(additionalPropertiesFile.toPath(), additionalProperties.getBytes(StandardCharsets.UTF_8));
+        }
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
+        Map<String, File> files = new HashMap<>();
+        files.put("file", openapiFile);
+        files.put("additionalProperties", additionalPropertiesFile);
+        TestContext.remove("httpResponse");
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doPostMultipartWithFiles(Utils.getAPIDefinitionURL(getBaseUrl()), headers, files, null);
+        TestContext.set("httpResponse", response);
+        if (resourceId != null && response.getResponseCode() >= 200 && response.getResponseCode() < 300) {
+            Object createdId = Utils.extractValueFromPayload(response.getData(), "id");
+            TestContext.set(resourceId, createdId);
+            ResourceCleanup.register(Constants.CREATED_API_IDS, createdId);
+        }
+    }
+
+    /**
      * Transitions an API through an arbitrary lifecycle action (e.g. {@code Block}, {@code Deprecate},
      * {@code Retire}, {@code Re-Publish}) via the publisher change-lifecycle API — the general form of the
      * publish-only {@code I publish the … resource} step. Does not assert the status itself, so the feature can
@@ -1211,14 +1729,128 @@ public class PublisherBaseSteps {
      */
     @When("I change the lifecycle of API {string} with action {string}")
     public void iChangeTheLifecycleOfApi(String apiId, String action) throws IOException {
+        changeLifecycle("apis", apiId, action);
+    }
 
-        String actualApiId = Utils.resolveFromContext(apiId).toString();
+    /**
+     * Resource-typed variant of the lifecycle transition (e.g. {@code "api-products"}) — the change-lifecycle
+     * endpoint keys on {@code apiProductId} for products. Non-asserting; the feature confirms the status.
+     */
+    @When("I change the lifecycle of {string} resource {string} with action {string}")
+    public void iChangeTheLifecycleOfResource(String resourceType, String resourceId, String action) throws IOException {
+        changeLifecycle(resourceType, resourceId, action);
+    }
+
+    private void changeLifecycle(String resourceType, String resourceId, String action) throws IOException {
+        String actualId = Utils.resolveFromContext(resourceId).toString();
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doPost(Utils.getChangeLifecycleURL(getBaseUrl(), resourceType, actualId, action, null), headers,
+                        null, null);
+        TestContext.set("httpResponse", response);
+    }
+
+    /**
+     * Builds an API-Product create payload that aggregates an existing API's operations: retrieves the API,
+     * embeds its {@code operations} under a single {@code ProductAPIDTO}, and wraps it with the product's
+     * name/context/version/policies. (Products reference existing APIs + a selected set of their resources.)
+     */
+    private String buildApiProductPayload(String name, String context, String apiId) throws IOException {
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
+        HttpResponse apiResp = SimpleHTTPClient.getInstance()
+                .doGet(Utils.getResourceEndpointURL(getBaseUrl(), "apis", apiId), headers);
+        JSONObject api = new JSONObject(apiResp.getData());
+        JSONArray operations = api.optJSONArray("operations");
+        JSONObject productApi = new JSONObject()
+                .put("apiId", apiId)
+                .put("name", api.optString("name"))
+                .put("operations", operations == null ? new JSONArray() : operations);
+        return new JSONObject()
+                .put("name", name)
+                .put("context", context)
+                .put("version", "1.0.0")
+                // Offer the standard business plans so the shared "set up application …" composite (which
+                // subscribes with Bronze) can subscribe to the product.
+                .put("policies", new JSONArray().put("Gold").put("Bronze").put("Unlimited"))
+                .put("apis", new JSONArray().put(productApi))
+                .toString();
+    }
+
+    /**
+     * Creates an API Product aggregating the resources of an existing API, and stores its id
+     * (registered for owner-aware teardown — swept before the underlying APIs). Asserts 201.
+     */
+    @When("I create an API product {string} with context {string} from API {string} as {string}")
+    public void iCreateApiProduct(String nameBase, String contextBase, String apiIdKey, String productIdKey)
+            throws IOException {
+
+        String apiId = Utils.resolveFromContext(apiIdKey).toString();
+        String payload = buildApiProductPayload(Utils.resolvePayloadPlaceholders(nameBase),
+                Utils.resolvePayloadPlaceholders(contextBase), apiId);
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
 
         HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPost(Utils.getChangeLifecycleURL(getBaseUrl(), "apis", actualApiId, action, null), headers,
-                        null, null);
+                .doPost(Utils.getAPICreateEndpointURL(getBaseUrl(), "api-products"), headers, payload,
+                        Constants.CONTENT_TYPES.APPLICATION_JSON);
+        TestContext.set("httpResponse", response);
+        Assert.assertEquals(response.getResponseCode(), 201, response.getData());
+        Object productId = Utils.extractValueFromPayload(response.getData(), "id");
+        TestContext.set(productIdKey, productId);
+        ResourceCleanup.register(Constants.CREATED_API_PRODUCT_IDS, productId);
+    }
+
+    /**
+     * Non-asserting API-Product create (for negatives such as a malformed context → 400): stores the raw
+     * response for the feature to assert; does not extract an id or register anything.
+     */
+    @When("I attempt to create an API product {string} with context {string} from API {string}")
+    public void iAttemptToCreateApiProduct(String nameBase, String contextBase, String apiIdKey) throws IOException {
+
+        String apiId = Utils.resolveFromContext(apiIdKey).toString();
+        String payload = buildApiProductPayload(Utils.resolvePayloadPlaceholders(nameBase),
+                Utils.resolvePayloadPlaceholders(contextBase), apiId);
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
+
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doPost(Utils.getAPICreateEndpointURL(getBaseUrl(), "api-products"), headers, payload,
+                        Constants.CONTENT_TYPES.APPLICATION_JSON);
+        TestContext.set("httpResponse", response);
+    }
+
+    /** Creates a new version (copy) of an API Product; stores the new product's id and registers it for teardown. */
+    @When("I create a new version {string} of API product {string} with default version {string} as {string}")
+    public void iCreateNewApiProductVersion(String newVersion, String productIdKey, String isDefault,
+                                            String newProductIdKey) throws IOException {
+
+        String productId = Utils.resolveFromContext(productIdKey).toString();
+        boolean defaultVersion = Boolean.parseBoolean(isDefault);
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
+
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doPost(Utils.getAPIProductNewVersionURL(getBaseUrl(), newVersion, defaultVersion, productId),
+                        headers, null, null);
+        TestContext.set("httpResponse", response);
+        if (response.getResponseCode() >= 200 && response.getResponseCode() < 300) {
+            Object newId = Utils.extractValueFromPayload(response.getData(), "id");
+            TestContext.set(newProductIdKey, newId);
+            ResourceCleanup.register(Constants.CREATED_API_PRODUCT_IDS, newId);
+        }
+    }
+
+    /** Retrieves an API Product's swagger/OpenAPI definition, storing the raw response for assertions. */
+    @When("I retrieve the API product swagger of {string}")
+    public void iRetrieveApiProductSwagger(String productIdKey) throws IOException {
+
+        String productId = Utils.resolveFromContext(productIdKey).toString();
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doGet(Utils.getAPIProductSwaggerURL(getBaseUrl(), productId), headers);
         TestContext.set("httpResponse", response);
     }
 
@@ -1266,6 +1898,30 @@ public class PublisherBaseSteps {
         HttpResponse response = SimpleHTTPClient.getInstance()
                 .doPost(Utils.getRevisionUnDeploymentURL(getBaseUrl(), resourceType, actualResourceId, actualRevisionId),
                         headers, payload, Constants.CONTENT_TYPES.APPLICATION_JSON);
+        TestContext.set("httpResponse", response);
+    }
+
+    /**
+     * Undeploys a revision using a caller-supplied deployment payload — needed to undeploy from a specific
+     * (e.g. custom) environment/vhost rather than the default. Resolves {@code {{gatewayEnvironment}}} and any
+     * {@code {{contextKey}}} placeholders (e.g. a captured custom environment name). Non-asserting.
+     */
+    @When("I undeploy revision {string} of {string} resource {string} with payload {string}")
+    public void iUndeployRevisionGivenPayload(String revisionId, String resourceType, String resourceId,
+                                              String payload) throws IOException {
+
+        String actualResourceId = Utils.resolveFromContext(resourceId).toString();
+        String actualRevisionId = Utils.resolveFromContext(revisionId).toString();
+        String jsonPayload = Utils.resolveFromContext(payload).toString();
+        jsonPayload = jsonPayload.replace("{{gatewayEnvironment}}", System.getenv(Constants.GATEWAY_ENVIRONMENT));
+        jsonPayload = Utils.resolveContextPlaceholders(jsonPayload);
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
+
+        HttpResponse response = SimpleHTTPClient.getInstance()
+                .doPost(Utils.getRevisionUnDeploymentURL(getBaseUrl(), resourceType, actualResourceId, actualRevisionId),
+                        headers, jsonPayload, Constants.CONTENT_TYPES.APPLICATION_JSON);
         TestContext.set("httpResponse", response);
     }
 

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/PublisherBaseSteps.java
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/PublisherBaseSteps.java
@@ -30,6 +30,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.testng.Assert;
 import org.wso2.am.integration.cucumbertests.utils.Identity;
+import org.wso2.am.integration.cucumbertests.utils.Requests;
 import org.wso2.am.integration.cucumbertests.utils.ResourceCleanup;
 import org.wso2.am.integration.cucumbertests.utils.TestContext;
 import org.wso2.am.integration.cucumbertests.utils.Utils;
@@ -68,17 +69,14 @@ public class PublisherBaseSteps {
     @And("I create an {string} resource with payload {string} as {string}")
     public void iCreateAnAPIWithPayloadAs(String resourceType, String payload, String resourceID) throws IOException {
 
-        String jsonPayload = Utils.resolveFromContext(payload).toString();
+        String jsonPayload = TestContext.resolve(payload).toString();
 
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION,
                 "Bearer " + Identity.publisherToken());
 
-        HttpResponse apiCreateResponse = SimpleHTTPClient.getInstance()
-                .doPost(Utils.getAPICreateEndpointURL(getBaseUrl(), resourceType), headers, jsonPayload,
+        HttpResponse apiCreateResponse = Requests.post(Utils.getAPICreateEndpointURL(getBaseUrl(), resourceType), headers, jsonPayload,
                         Constants.CONTENT_TYPES.APPLICATION_JSON);
-
-        TestContext.set("httpResponse", apiCreateResponse);
 
         Assert.assertEquals(apiCreateResponse.getResponseCode(), 201, apiCreateResponse.getData());
         Object createdId = Utils.extractValueFromPayload(apiCreateResponse.getData(), "id");
@@ -97,17 +95,14 @@ public class PublisherBaseSteps {
     @When("I attempt to create an {string} resource with payload {string}")
     public void iAttemptToCreateAnAPIWithPayload(String resourceType, String payload) throws IOException {
 
-        String jsonPayload = Utils.resolveFromContext(payload).toString();
+        String jsonPayload = TestContext.resolve(payload).toString();
 
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION,
                 "Bearer " + Identity.publisherToken());
 
-        HttpResponse apiCreateResponse = SimpleHTTPClient.getInstance()
-                .doPost(Utils.getAPICreateEndpointURL(getBaseUrl(), resourceType), headers, jsonPayload,
+        HttpResponse apiCreateResponse = Requests.post(Utils.getAPICreateEndpointURL(getBaseUrl(), resourceType), headers, jsonPayload,
                         Constants.CONTENT_TYPES.APPLICATION_JSON);
-
-        TestContext.set("httpResponse", apiCreateResponse);
     }
 
     /**
@@ -117,13 +112,10 @@ public class PublisherBaseSteps {
     @When("I attempt to create an {string} resource with payload {string} without authentication")
     public void iAttemptToCreateAnAPIWithoutAuth(String resourceType, String payload) throws IOException {
 
-        String jsonPayload = Utils.resolveFromContext(payload).toString();
+        String jsonPayload = TestContext.resolve(payload).toString();
 
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPost(Utils.getAPICreateEndpointURL(getBaseUrl(), resourceType), new HashMap<>(), jsonPayload,
+        HttpResponse response = Requests.post(Utils.getAPICreateEndpointURL(getBaseUrl(), resourceType), new HashMap<>(), jsonPayload,
                         Constants.CONTENT_TYPES.APPLICATION_JSON);
-        TestContext.set("httpResponse", response);
     }
 
     /**
@@ -136,17 +128,16 @@ public class PublisherBaseSteps {
     @When("I update {string} resource of id {string} with payload {string}")
     public void iUpdateResourceWithJsonPayloadFromContext(String resourceType, String resourceId, String payload) throws IOException {
 
-        String actualResourceId = Utils.resolveFromContext(resourceId).toString();
-        String jsonPayload = Utils.resolveFromContext(payload).toString();
+        String actualResourceId = TestContext.resolve(resourceId).toString();
+        String jsonPayload = TestContext.resolve(payload).toString();
 
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION,
                 "Bearer " + Identity.publisherToken());
 
-        HttpResponse apiUpdateResponse = SimpleHTTPClient.getInstance().doPut(
+        HttpResponse apiUpdateResponse = Requests.put(
                 Utils.getResourceEndpointURL(getBaseUrl(),resourceType ,actualResourceId), headers, jsonPayload,
                 Constants.CONTENT_TYPES.APPLICATION_JSON);
-        TestContext.set("httpResponse", apiUpdateResponse);
     }
 
     /**
@@ -160,19 +151,17 @@ public class PublisherBaseSteps {
     @When("I make a request to create a revision for {string} resource {string} with payload {string}")
     public void iCreateResourceRevision(String resourceType, String resourceId, String contextKey) throws IOException, InterruptedException {
 
-        String actualResourceId = Utils.resolveFromContext(resourceId).toString();
-        String jsonPayload = Utils.resolveFromContext(contextKey).toString();
+        String actualResourceId = TestContext.resolve(resourceId).toString();
+        String jsonPayload = TestContext.resolve(contextKey).toString();
 
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION,
                 "Bearer " + Identity.publisherToken());
 
-        HttpResponse createRevisionResponse = SimpleHTTPClient.getInstance()
-                .doPost(Utils.getRevisionURL(getBaseUrl(),resourceType, actualResourceId), headers, jsonPayload,
+        HttpResponse createRevisionResponse = Requests.post(Utils.getRevisionURL(getBaseUrl(),resourceType, actualResourceId), headers, jsonPayload,
                         Constants.CONTENT_TYPES.APPLICATION_JSON);
 
         Assert.assertEquals(createRevisionResponse.getResponseCode(), 201, createRevisionResponse.getData());
-        TestContext.set("httpResponse", createRevisionResponse);
         TestContext.set("revisionId", Utils.extractValueFromPayload(createRevisionResponse.getData(), "id"));
         Thread.sleep(3000);
     }
@@ -186,17 +175,14 @@ public class PublisherBaseSteps {
     public void iAttemptToCreateResourceRevision(String resourceType, String resourceId, String contextKey)
             throws IOException {
 
-        String actualResourceId = Utils.resolveFromContext(resourceId).toString();
-        String jsonPayload = Utils.resolveFromContext(contextKey).toString();
+        String actualResourceId = TestContext.resolve(resourceId).toString();
+        String jsonPayload = TestContext.resolve(contextKey).toString();
 
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
 
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPost(Utils.getRevisionURL(getBaseUrl(), resourceType, actualResourceId), headers, jsonPayload,
+        HttpResponse response = Requests.post(Utils.getRevisionURL(getBaseUrl(), resourceType, actualResourceId), headers, jsonPayload,
                         Constants.CONTENT_TYPES.APPLICATION_JSON);
-        TestContext.set("httpResponse", response);
     }
 
     /**
@@ -210,9 +196,9 @@ public class PublisherBaseSteps {
     @When("I make a request to deploy revision {string} of {string} resource {string} with payload {string}")
     public void iDeployApiRevisionGivenPayload(String revisionId, String resourceType, String resourceId, String payload) throws IOException {
 
-        String actualResourceId= Utils.resolveFromContext(resourceId).toString();
-        String actualRevisionId = Utils.resolveFromContext(revisionId).toString();
-        String jsonPayload = Utils.resolveFromContext(payload).toString();
+        String actualResourceId= TestContext.resolve(resourceId).toString();
+        String actualRevisionId = TestContext.resolve(revisionId).toString();
+        String jsonPayload = TestContext.resolve(payload).toString();
         jsonPayload = jsonPayload.replace("{{gatewayEnvironment}}", System.getenv(Constants.GATEWAY_ENVIRONMENT));
         // Resolve any remaining {{contextKey}} placeholders (e.g. a captured custom environment name for a
         // deploy-to-vhost scenario). No-op when the payload has none; fails fast on an unknown key.
@@ -222,11 +208,8 @@ public class PublisherBaseSteps {
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION,
                 "Bearer " + Identity.publisherToken());
 
-        HttpResponse deployRevisionResponse = SimpleHTTPClient.getInstance()
-                .doPost(Utils.getRevisionDeploymentURL(getBaseUrl(), resourceType, actualResourceId, actualRevisionId), headers, jsonPayload,
+        HttpResponse deployRevisionResponse = Requests.post(Utils.getRevisionDeploymentURL(getBaseUrl(), resourceType, actualResourceId, actualRevisionId), headers, jsonPayload,
                         Constants.CONTENT_TYPES.APPLICATION_JSON);
-
-        TestContext.set("httpResponse", deployRevisionResponse);
     }
 
      /**
@@ -238,14 +221,13 @@ public class PublisherBaseSteps {
     @When("I delete the {string} resource with id {string}")
     public void iDeleteTheResource(String resourceType, String resourceId) throws IOException {
 
-        String actualResourceId= Utils.resolveFromContext(resourceId).toString();
+        String actualResourceId= TestContext.resolve(resourceId).toString();
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION,
                 "Bearer " + Identity.publisherToken());
 
-        HttpResponse apiDeleteResponse = SimpleHTTPClient.getInstance().doDelete(Utils.getResourceEndpointURL(getBaseUrl(), resourceType,
+        HttpResponse apiDeleteResponse = Requests.delete(Utils.getResourceEndpointURL(getBaseUrl(), resourceType,
                 actualResourceId), headers);
-        TestContext.set("httpResponse", apiDeleteResponse);
     }
 
     /**
@@ -264,13 +246,10 @@ public class PublisherBaseSteps {
     @When("I generate the mock implementation script for API {string}")
     public void iGenerateMockScript(String apiId) throws IOException {
 
-        String actualApiId = Utils.resolveFromContext(apiId).toString();
+        String actualApiId = TestContext.resolve(apiId).toString();
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPost(Utils.getGenerateMockScriptsURL(getBaseUrl(), actualApiId), headers, "", null);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.post(Utils.getGenerateMockScriptsURL(getBaseUrl(), actualApiId), headers, "", null);
     }
 
     /**
@@ -282,13 +261,10 @@ public class PublisherBaseSteps {
     @When("I retrieve the mock implementation script for API {string}")
     public void iRetrieveMockScript(String apiId) throws IOException {
 
-        String actualApiId = Utils.resolveFromContext(apiId).toString();
+        String actualApiId = TestContext.resolve(apiId).toString();
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doGet(Utils.getGeneratedMockScriptsURL(getBaseUrl(), actualApiId), headers);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.get(Utils.getGeneratedMockScriptsURL(getBaseUrl(), actualApiId), headers);
     }
 
     /**
@@ -303,10 +279,7 @@ public class PublisherBaseSteps {
         // Legacy validates roles with a publisher token (api_create/publish/manage) → 200; the earlier 401 was
         // a padded-base64 path bug, not a scope issue (see Utils.getValidateRoleURL).
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doHead(Utils.getValidateRoleURL(getBaseUrl(), role), headers);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.head(Utils.getValidateRoleURL(getBaseUrl(), role), headers);
     }
 
     /**
@@ -320,25 +293,20 @@ public class PublisherBaseSteps {
      */
     @When("I change the subscription business plan of {string} to {string}")
     public void iChangeSubscriptionBusinessPlan(String subId, String plan) throws IOException {
-        String actualSubId = Utils.resolveFromContext(subId).toString();
+        String actualSubId = TestContext.resolve(subId).toString();
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPost(Utils.getChangeSubscriptionBusinessPlanURL(getBaseUrl(), actualSubId, plan), headers, "", null);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.post(Utils.getChangeSubscriptionBusinessPlanURL(getBaseUrl(), actualSubId, plan), headers, "", null);
     }
 
     @When("I publish the {string} resource with id {string}")
     public void iPublishTheResource(String resourceType, String resourceId) throws IOException {
 
-        String actualResourceId = Utils.resolveFromContext(resourceId).toString();
+        String actualResourceId = TestContext.resolve(resourceId).toString();
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION,
                 "Bearer " + Identity.publisherToken());
-        HttpResponse publishResponse = SimpleHTTPClient.getInstance()
-                .doPost(Utils.getChangeLifecycleURL(getBaseUrl(), resourceType, actualResourceId, "Publish", null), headers, null, null);
-        TestContext.set("httpResponse", publishResponse);
+        HttpResponse publishResponse = Requests.post(Utils.getChangeLifecycleURL(getBaseUrl(), resourceType, actualResourceId, "Publish", null), headers, null, null);
     }
 
     /**
@@ -350,14 +318,12 @@ public class PublisherBaseSteps {
     @When("I retrieve the {string} resource with id {string}")
     public void iRetrieveTheResource(String resourceType, String resourceId) throws IOException {
 
-        String actualResourceId = Utils.resolveFromContext(resourceId).toString();
+        String actualResourceId = TestContext.resolve(resourceId).toString();
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION,
                 "Bearer " + Identity.publisherToken());
 
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doGet(Utils.getResourceEndpointURL(getBaseUrl(), resourceType, actualResourceId), headers);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.get(Utils.getResourceEndpointURL(getBaseUrl(), resourceType, actualResourceId), headers);
     }
 
     /**
@@ -371,8 +337,7 @@ public class PublisherBaseSteps {
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION,
                 "Bearer " + Identity.publisherToken());
 
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doGet(Utils.getAPISearchEndpointURL(getBaseUrl(), null, null, null), headers);
+        HttpResponse response = Requests.get(Utils.getAPISearchEndpointURL(getBaseUrl(), null, null, null), headers);
 
         TestContext.set("httpResponse", response);
     }
@@ -385,7 +350,7 @@ public class PublisherBaseSteps {
     @Then("The API with id {string} should be in the list of all APIS")
     public void theApiShouldBeInTheListOfAllApis(String apiId) {
 
-        String actualApiId = Utils.resolveFromContext(apiId).toString();
+        String actualApiId = TestContext.resolve(apiId).toString();
         HttpResponse response = (HttpResponse) TestContext.get("httpResponse");
         JSONArray apisList = new JSONObject(response.getData()).getJSONArray("list");
 
@@ -405,7 +370,7 @@ public class PublisherBaseSteps {
     @Then("The lifecycle status of API {string} should be {string}")
     public void theLifecycleStatusShouldBe(String apiId, String status) throws IOException {
 
-        String actualApiId = Utils.resolveFromContext(apiId).toString();
+        String actualApiId = TestContext.resolve(apiId).toString();
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION,
                 "Bearer " + Identity.publisherToken());
@@ -417,8 +382,7 @@ public class PublisherBaseSteps {
         HttpResponse lifecycleStatusResponse = null;
         String actualState = null;
         for (int attempt = 1; attempt <= Constants.MAX_RETRIES; attempt++) {
-            lifecycleStatusResponse = SimpleHTTPClient.getInstance().doGet(url, headers);
-            TestContext.set("httpResponse", lifecycleStatusResponse);
+            lifecycleStatusResponse = Requests.get(url, headers);
             actualState = new JSONObject(lifecycleStatusResponse.getData()).optString("state", null);
             if (status.equals(actualState)) {
                 return;
@@ -505,8 +469,8 @@ public class PublisherBaseSteps {
     @Then("I wait until {string} {string} revision is deployed in the gateway")
     public void waitUntilRevisionIsDeployed(String resourceType, String resourceId) throws IOException {
 
-        String actualResourceId = Utils.resolveFromContext(resourceId).toString();
-        String revisionId = Utils.resolveFromContext("revisionId").toString();
+        String actualResourceId = TestContext.resolve(resourceId).toString();
+        String revisionId = TestContext.resolve("revisionId").toString();
 
         String url = Utils.getRevisionDeployments(getBaseUrl(), resourceType, actualResourceId);
 
@@ -520,7 +484,7 @@ public class PublisherBaseSteps {
         while (System.currentTimeMillis() < endTime) {
 
             try {
-                HttpResponse response = SimpleHTTPClient.getInstance().doGet(url, headers);
+                HttpResponse response = Requests.get(url, headers);
 
                 if (response != null && response.getResponseCode() == 200) {
                     JSONObject responseJson = new JSONObject(response.getData());
@@ -569,7 +533,7 @@ public class PublisherBaseSteps {
     @When("I create a new version {string} of {string} resource {string} with default version {string} as {string}")
     public void iCreateANewVersionOfAPI(String newVersion, String resourceType, String resourceID, String isDefault, String newVersionID) throws IOException{
 
-        String actualResourceID = Utils.resolveFromContext(resourceID).toString();
+        String actualResourceID = TestContext.resolve(resourceID).toString();
         Boolean defaultVersion = false;
         if (isDefault != null && !isDefault.isEmpty()) {
             defaultVersion = Boolean.parseBoolean(isDefault);
@@ -579,10 +543,7 @@ public class PublisherBaseSteps {
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION,
                 "Bearer " + Identity.publisherToken());
 
-        HttpResponse apiNewVersionResponse = SimpleHTTPClient.getInstance()
-                .doPost(Utils.getNewAPIVersionURL(getBaseUrl(), resourceType, newVersion, defaultVersion, actualResourceID), headers, null, null);
-
-        TestContext.set("httpResponse", apiNewVersionResponse);
+        HttpResponse apiNewVersionResponse = Requests.post(Utils.getNewAPIVersionURL(getBaseUrl(), resourceType, newVersion, defaultVersion, actualResourceID), headers, null, null);
         Object newVersionId = Utils.extractValueFromPayload(apiNewVersionResponse.getData(), "id");
         TestContext.set(newVersionID, newVersionId);
         // Register for scenario teardown so the version copy is cleaned up alongside the base API.
@@ -599,7 +560,7 @@ public class PublisherBaseSteps {
     public void iAttemptToCreateANewVersionOfAPI(String newVersion, String resourceType, String resourceID,
                                                  String isDefault) throws IOException {
 
-        String actualResourceID = Utils.resolveFromContext(resourceID).toString();
+        String actualResourceID = TestContext.resolve(resourceID).toString();
         boolean defaultVersion = isDefault != null && !isDefault.isEmpty() && Boolean.parseBoolean(isDefault);
 
         Map<String, String> headers = new HashMap<>();
@@ -609,7 +570,6 @@ public class PublisherBaseSteps {
         HttpResponse response = SimpleHTTPClient.getInstance()
                 .doPost(Utils.getNewAPIVersionURL(getBaseUrl(), resourceType, newVersion, defaultVersion,
                         actualResourceID), headers, null, null);
-        TestContext.set("httpResponse", response);
     }
 
     /**
@@ -643,18 +603,15 @@ public class PublisherBaseSteps {
     @And("I add the document to API {string}")
     public void iAddTheDocumentToAPI(String apiID) throws IOException{
 
-        String jsonPayload = Utils.resolveFromContext("<newDocumentPayload>").toString();
-        String actualApiId = Utils.resolveFromContext(apiID).toString();
+        String jsonPayload = TestContext.resolve("<newDocumentPayload>").toString();
+        String actualApiId = TestContext.resolve(apiID).toString();
 
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION,
                 "Bearer " + Identity.publisherToken());
 
-        HttpResponse documentCreationResponse = SimpleHTTPClient.getInstance()
-                .doPost(Utils.getAPIDocuments(getBaseUrl(), actualApiId), headers, jsonPayload,
+        HttpResponse documentCreationResponse = Requests.post(Utils.getAPIDocuments(getBaseUrl(), actualApiId), headers, jsonPayload,
                         Constants.CONTENT_TYPES.APPLICATION_JSON);
-
-        TestContext.set("httpResponse", documentCreationResponse);
         TestContext.set("documentID", Utils.extractValueFromPayload(documentCreationResponse.getData(), "documentId"));
     }
 
@@ -666,15 +623,13 @@ public class PublisherBaseSteps {
     @When("I retrieve all available documents for {string}")
     public void iRetrieveAllAvailableDocumentsFor(String apiID) throws IOException{
 
-        String actualApiId = Utils.resolveFromContext(apiID).toString();
+        String actualApiId = TestContext.resolve(apiID).toString();
 
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION,
                 "Bearer " + Identity.publisherToken());
 
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doGet(Utils.getAPIDocuments(getBaseUrl(), actualApiId), headers);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.get(Utils.getAPIDocuments(getBaseUrl(), actualApiId), headers);
     }
 
     /**
@@ -686,16 +641,14 @@ public class PublisherBaseSteps {
     @When("I retrieve document with {string} for {string}")
     public void iRetrieveDocumentWithFor(String documentID, String apiID) throws IOException{
 
-        String documentId = Utils.resolveFromContext(documentID).toString();
-        String actualApiId = Utils.resolveFromContext(apiID).toString();
+        String documentId = TestContext.resolve(documentID).toString();
+        String actualApiId = TestContext.resolve(apiID).toString();
 
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION,
                 "Bearer " + Identity.publisherToken());
 
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doGet(Utils.getAPIDocument(getBaseUrl(), actualApiId, documentId), headers);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.get(Utils.getAPIDocument(getBaseUrl(), actualApiId, documentId), headers);
 
     }
 
@@ -708,16 +661,14 @@ public class PublisherBaseSteps {
     @When("I delete the document with {string} for {string}")
     public void iDeleteTheDocumentWithFor(String documentID, String apiID) throws IOException{
 
-        String documentId = Utils.resolveFromContext(documentID).toString();
-        String actualApiId = Utils.resolveFromContext(apiID).toString();
+        String documentId = TestContext.resolve(documentID).toString();
+        String actualApiId = TestContext.resolve(apiID).toString();
 
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION,
                 "Bearer " + Identity.publisherToken());
 
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doDelete(Utils.getAPIDocument(getBaseUrl(), actualApiId, documentId), headers);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.delete(Utils.getAPIDocument(getBaseUrl(), actualApiId, documentId), headers);
     }
 
     /**
@@ -729,19 +680,16 @@ public class PublisherBaseSteps {
     @And("I update the document with {string} for API {string}")
     public void iUpdateTheDocumentWithForAPI(String documentID, String apiID) throws IOException {
 
-        String jsonPayload = Utils.resolveFromContext("<newDocumentPayload>").toString();
-        String actualApiId = Utils.resolveFromContext(apiID).toString();
-        String documentId = Utils.resolveFromContext(documentID).toString();
+        String jsonPayload = TestContext.resolve("<newDocumentPayload>").toString();
+        String actualApiId = TestContext.resolve(apiID).toString();
+        String documentId = TestContext.resolve(documentID).toString();
 
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION,
                 "Bearer " + Identity.publisherToken());
 
-        HttpResponse documentUpdateResponse = SimpleHTTPClient.getInstance()
-                .doPut(Utils.getAPIDocument(getBaseUrl(), actualApiId, documentId), headers, jsonPayload,
+        HttpResponse documentUpdateResponse = Requests.put(Utils.getAPIDocument(getBaseUrl(), actualApiId, documentId), headers, jsonPayload,
                         Constants.CONTENT_TYPES.APPLICATION_JSON);
-
-        TestContext.set("httpResponse", documentUpdateResponse);
     }
 
     /**
@@ -777,8 +725,8 @@ public class PublisherBaseSteps {
     @When("I upload the document file {string} for document {string} of API {string}")
     public void iUploadDocumentFile(String resourcePath, String documentID, String apiID) throws IOException {
 
-        String docId = Utils.resolveFromContext(documentID).toString();
-        String actualApiId = Utils.resolveFromContext(apiID).toString();
+        String docId = TestContext.resolve(documentID).toString();
+        String actualApiId = TestContext.resolve(apiID).toString();
 
         File temp;
         String suffix = resourcePath.substring(resourcePath.lastIndexOf('.'));
@@ -796,10 +744,8 @@ public class PublisherBaseSteps {
         Map<String, File> files = new HashMap<>();
         files.put("file", temp);
 
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance().doPostMultipartWithFiles(
+        HttpResponse response = Requests.postMultipart(
                 Utils.getAPIDocumentContent(getBaseUrl(), actualApiId, docId), headers, files, new HashMap<>());
-        TestContext.set("httpResponse", response);
     }
 
     // Helper to parse the values correctly for update document steps
@@ -840,13 +786,13 @@ public class PublisherBaseSteps {
     public void iUpdateTheResourceWithConfigurationTypeAndValue(String resourceType, String resourceID, String resourceUpdatePayload, String configType, String configValue) throws IOException, InterruptedException {
 
         // Retrieve a JSON object safely
-        Object ctxValue = Utils.resolveFromContext(resourceUpdatePayload);
+        Object ctxValue = TestContext.resolve(resourceUpdatePayload);
         JSONObject jsonPayload = (ctxValue instanceof JSONObject)
                 ? (JSONObject) ctxValue
                 : new JSONObject(ctxValue.toString());
 
         if ("endpointConfig".equals(configType)){
-            configValue = Utils.resolveFromContext(configValue).toString();
+            configValue = TestContext.resolve(configValue).toString();
         } else {
             // Resolve any {{contextKey}} placeholders in the value (e.g. a custom throttle-tier name captured
             // into context, when setting an API's business-plan "policies"). No-op when the value has none.
@@ -871,16 +817,13 @@ public class PublisherBaseSteps {
     @When("I block the subscription with {string} for the resource")
     public void iBlockTheSubscriptionWithForTheResource(String subscriptionID) throws IOException {
 
-        String subscriptionId = Utils.resolveFromContext(subscriptionID).toString();
+        String subscriptionId = TestContext.resolve(subscriptionID).toString();
 
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION,
                 "Bearer " + Identity.publisherToken());
 
-        HttpResponse documentUpdateResponse = SimpleHTTPClient.getInstance()
-                .doPost(Utils.getSubscriptionBlockingURL(getBaseUrl(), subscriptionId), headers, null, null);
-
-        TestContext.set("httpResponse", documentUpdateResponse);
+        HttpResponse documentUpdateResponse = Requests.post(Utils.getSubscriptionBlockingURL(getBaseUrl(), subscriptionId), headers, null, null);
     }
 
     /**
@@ -891,16 +834,13 @@ public class PublisherBaseSteps {
     @When("I unblock the subscription with {string} for the resource")
     public void iUnblockTheSubscriptionWithForTheResource(String subscriptionID) throws IOException {
 
-        String subscriptionId = Utils.resolveFromContext(subscriptionID).toString();
+        String subscriptionId = TestContext.resolve(subscriptionID).toString();
 
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION,
                 "Bearer " + Identity.publisherToken());
 
-        HttpResponse documentUpdateResponse = SimpleHTTPClient.getInstance()
-                .doPost(Utils.getSubscriptionUnBlockingURL(getBaseUrl(), subscriptionId), headers, null, null);
-
-        TestContext.set("httpResponse", documentUpdateResponse);
+        HttpResponse documentUpdateResponse = Requests.post(Utils.getSubscriptionUnBlockingURL(getBaseUrl(), subscriptionId), headers, null, null);
     }
 
     /**
@@ -924,17 +864,14 @@ public class PublisherBaseSteps {
             TestContext.set(Utils.normalizeContextKey("<newSharedScope>"), jsonPayload);
         }
 
-        String jsonPayload = Utils.resolveFromContext("<newSharedScope>").toString();
+        String jsonPayload = TestContext.resolve("<newSharedScope>").toString();
 
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION,
                 "Bearer " + Identity.publisherToken());
 
-        HttpResponse scopeCreationResponse = SimpleHTTPClient.getInstance()
-                .doPost(Utils.getAPIScopes(getBaseUrl()), headers, jsonPayload,
+        HttpResponse scopeCreationResponse = Requests.post(Utils.getAPIScopes(getBaseUrl()), headers, jsonPayload,
                         Constants.CONTENT_TYPES.APPLICATION_JSON);
-
-        TestContext.set("httpResponse", scopeCreationResponse);
         Object scopeId = Utils.extractValueFromPayload(scopeCreationResponse.getData(), "id");
         TestContext.set("scopeID", scopeId);
         // Register for teardown: a shared scope is a tenant-wide resource that ResourceCleanup must remove so
@@ -967,10 +904,8 @@ public class PublisherBaseSteps {
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION,
                 "Bearer " + Identity.publisherToken());
 
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPost(Utils.getAPIScopes(getBaseUrl()), headers, jsonPayload,
+        HttpResponse response = Requests.post(Utils.getAPIScopes(getBaseUrl()), headers, jsonPayload,
                         Constants.CONTENT_TYPES.APPLICATION_JSON);
-        TestContext.set("httpResponse", response);
     }
 
     /**
@@ -981,15 +916,13 @@ public class PublisherBaseSteps {
     @When("I delete shared scope with {string}")
     public void iDeleteSharedScopeWith(String scopeID) throws IOException {
 
-        String scopeId = Utils.resolveFromContext(scopeID).toString();
+        String scopeId = TestContext.resolve(scopeID).toString();
 
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION,
                 "Bearer " + Identity.publisherToken());
 
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doDelete(Utils.getAPIScopesById(getBaseUrl(), scopeId), headers);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.delete(Utils.getAPIScopesById(getBaseUrl(), scopeId), headers);
     }
 
     /**
@@ -1003,7 +936,7 @@ public class PublisherBaseSteps {
     @When("I update the shared scope {string} setting its description to {string}")
     public void iUpdateSharedScopeDescription(String scopeIdKey, String newDescription) throws IOException {
 
-        String scopeId = Utils.resolveFromContext(scopeIdKey).toString();
+        String scopeId = TestContext.resolve(scopeIdKey).toString();
 
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION,
@@ -1021,10 +954,8 @@ public class PublisherBaseSteps {
         JSONObject scope = new JSONObject(current.getData());
         scope.put("description", newDescription);
 
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPut(Utils.getAPIScopesById(getBaseUrl(), scopeId), headers, scope.toString(),
+        HttpResponse response = Requests.put(Utils.getAPIScopesById(getBaseUrl(), scopeId), headers, scope.toString(),
                         Constants.CONTENT_TYPES.APPLICATION_JSON);
-        TestContext.set("httpResponse", response);
     }
 
     /**
@@ -1040,10 +971,7 @@ public class PublisherBaseSteps {
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION,
                 "Bearer " + Identity.publisherToken());
 
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doGet(Utils.getAPIScopes(getBaseUrl()), headers);
-
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.get(Utils.getAPIScopes(getBaseUrl()), headers);
 
         // Confirm the GET succeeded with a body BEFORE parsing — otherwise new JSONObject(null/"") throws an
         // opaque JSONException/NPE instead of a clear failure.
@@ -1095,7 +1023,7 @@ public class PublisherBaseSteps {
             Files.copy(inputStream, schemaFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
         }
 
-        String additionalProperties = Utils.resolveFromContext(additionalPropertiesKey).toString();
+        String additionalProperties = TestContext.resolve(additionalPropertiesKey).toString();
 
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION,
@@ -1108,10 +1036,8 @@ public class PublisherBaseSteps {
         Map<String, File> files = new HashMap<>();
         files.put("file", schemaFile);
 
-        HttpResponse apiCreateResponse = SimpleHTTPClient.getInstance()
-                .doPostMultipartWithFiles(Utils.getGraphQLSchema(getBaseUrl()), headers, files, formFields);
-
-        TestContext.set("httpResponse", apiCreateResponse);
+        HttpResponse apiCreateResponse = Requests.postMultipart(Utils.getGraphQLSchema(getBaseUrl()), headers,
+                files, formFields);
         Assert.assertEquals(apiCreateResponse.getResponseCode(), 201, apiCreateResponse.getData());
         Object createdId = Utils.extractValueFromPayload(apiCreateResponse.getData(), "id");
         TestContext.set(apiID, createdId);
@@ -1133,7 +1059,7 @@ public class PublisherBaseSteps {
     public void iCreateAGraphQLAPIFromEndpointURL(String endpointUrl, String additionalPropertiesKey, String apiID)
             throws IOException {
         String url = Utils.resolveContextPlaceholders(endpointUrl);
-        String additionalProperties = Utils.resolveFromContext(additionalPropertiesKey).toString();
+        String additionalProperties = TestContext.resolve(additionalPropertiesKey).toString();
 
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
@@ -1143,9 +1069,8 @@ public class PublisherBaseSteps {
         formFields.put("url", url);
         formFields.put("additionalProperties", additionalProperties);
 
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPostMultipartWithFiles(Utils.getGraphQLSchema(getBaseUrl()), headers, new HashMap<>(), formFields);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.postMultipart(Utils.getGraphQLSchema(getBaseUrl()), headers,
+                new HashMap<>(), formFields);
         if (response.getResponseCode() >= 200 && response.getResponseCode() < 300) {
             Object createdId = Utils.extractValueFromPayload(response.getData(), "id");
             TestContext.set(apiID, createdId);
@@ -1169,9 +1094,13 @@ public class PublisherBaseSteps {
         formFields.put("url", url);
 
         String validateUrl = Utils.getValidateGraphQLSchemaURL(getBaseUrl()) + "?useIntrospection=" + useIntrospection;
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPostMultipartWithFiles(validateUrl, headers, new HashMap<>(), formFields);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.postMultipart(validateUrl, headers, new HashMap<>(), formFields);
+        // Confirm the validate call succeeded with a body BEFORE parsing — otherwise the graphQLInfo drill-down
+        // throws an opaque JSONException/NPE instead of a clear failure.
+        Assert.assertTrue(response != null && response.getResponseCode() >= 200 && response.getResponseCode() < 300
+                        && response.getData() != null && !response.getData().isEmpty(),
+                "Failed to validate the GraphQL schema from '" + url + "': expected a 2xx response with a body, got "
+                        + (response == null ? "no response" : response.getResponseCode() + " / body=" + response.getData()));
         String sdl = new org.json.JSONObject(response.getData())
                 .getJSONObject("graphQLInfo").getJSONObject("graphQLSchema").getString("schemaDefinition");
         TestContext.set(Utils.normalizeContextKey(schemaKey), sdl);
@@ -1184,8 +1113,8 @@ public class PublisherBaseSteps {
     @When("I create a GraphQL API with schema {string} and additional properties {string} as {string}")
     public void iCreateAGraphQLAPIWithSchemaStringAs(String schemaKey, String additionalPropertiesKey, String apiID)
             throws IOException {
-        String schema = Utils.resolveFromContext(schemaKey).toString();
-        String additionalProperties = Utils.resolveFromContext(additionalPropertiesKey).toString();
+        String schema = TestContext.resolve(schemaKey).toString();
+        String additionalProperties = TestContext.resolve(additionalPropertiesKey).toString();
 
         File schemaFile = File.createTempFile("graphql-derived", ".graphql");
         schemaFile.deleteOnExit();
@@ -1199,9 +1128,8 @@ public class PublisherBaseSteps {
         Map<String, File> files = new HashMap<>();
         files.put("file", schemaFile);
 
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPostMultipartWithFiles(Utils.getGraphQLSchema(getBaseUrl()), headers, files, formFields);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.postMultipart(Utils.getGraphQLSchema(getBaseUrl()), headers, files,
+                formFields);
         if (response.getResponseCode() >= 200 && response.getResponseCode() < 300) {
             Object createdId = Utils.extractValueFromPayload(response.getData(), "id");
             TestContext.set(apiID, createdId);
@@ -1226,30 +1154,26 @@ public class PublisherBaseSteps {
     @When("I retrieve the GraphQL schema of API {string}")
     public void iRetrieveGraphQLSchemaOfApi(String apiIdKey) throws IOException {
 
-        String apiId = Utils.resolveFromContext(apiIdKey).toString();
+        String apiId = TestContext.resolve(apiIdKey).toString();
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
 
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doGet(Utils.getGraphQLSchemaOfApiURL(getBaseUrl(), apiId), headers);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.get(Utils.getGraphQLSchemaOfApiURL(getBaseUrl(), apiId), headers);
     }
 
     /** Updates a GraphQL API's schema definition (publisher, PUT multipart {@code schemaDefinition}). */
     @When("I update the GraphQL schema of API {string} with schema file {string}")
     public void iUpdateGraphQLSchemaOfApi(String apiIdKey, String schemaFilePath) throws IOException {
 
-        String apiId = Utils.resolveFromContext(apiIdKey).toString();
+        String apiId = TestContext.resolve(apiIdKey).toString();
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
 
         Map<String, File> files = new HashMap<>();
         files.put("schemaDefinition", loadResourceAsTempFile(schemaFilePath));
 
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPutMultipartWithFiles(Utils.getGraphQLSchemaOfApiURL(getBaseUrl(), apiId), headers, files,
-                        new HashMap<>());
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.putMultipart(Utils.getGraphQLSchemaOfApiURL(getBaseUrl(), apiId), headers,
+                files, new HashMap<>());
     }
 
     /** Validates a GraphQL schema file (publisher, POST multipart {@code file}), storing the raw response. */
@@ -1262,10 +1186,8 @@ public class PublisherBaseSteps {
         Map<String, File> files = new HashMap<>();
         files.put("file", loadResourceAsTempFile(schemaFilePath));
 
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPostMultipartWithFiles(Utils.getValidateGraphQLSchemaURL(getBaseUrl()), headers, files,
-                        new HashMap<>());
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.postMultipart(Utils.getValidateGraphQLSchemaURL(getBaseUrl()), headers,
+                files, new HashMap<>());
     }
 
     /**
@@ -1292,7 +1214,7 @@ public class PublisherBaseSteps {
      */
     @And("I create a new API specific policy for api {string} with spec {string} and {string} as {string}")
     public void iCreateANewAPISpecificPolicyWithSpecAndSynapse(String apiId, String synapsePolicyJ2, String policySpecYaml, String policyId) throws IOException {
-        String actualApiId = Utils.resolveFromContext(apiId).toString();
+        String actualApiId = TestContext.resolve(apiId).toString();
         iCreateANewPolicyWithSpecAndSynapse(actualApiId, synapsePolicyJ2, policySpecYaml, policyId);
     }
 
@@ -1349,10 +1271,7 @@ public class PublisherBaseSteps {
             endpointUrl = Utils.getAPISpecificPolicy(getBaseUrl(), apiId);
         }
 
-        HttpResponse policyCreateResponse = SimpleHTTPClient.getInstance()
-                .doPostMultipartWithFiles(endpointUrl, headers, files, null);
-
-        TestContext.set("httpResponse", policyCreateResponse);
+        HttpResponse policyCreateResponse = Requests.postMultipart(endpointUrl, headers, files, null);
 
         // Extract and store the policy ID from response if available
         if (policyId != null && policyCreateResponse.getResponseCode() == 201) {
@@ -1387,10 +1306,7 @@ public class PublisherBaseSteps {
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION,
                 "Bearer " + Identity.publisherToken());
 
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doGet(Utils.getCommonPolicy(getBaseUrl()), headers);
-
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.get(Utils.getCommonPolicy(getBaseUrl()), headers);
     }
 
     /**
@@ -1402,8 +1318,8 @@ public class PublisherBaseSteps {
     @When("I delete the api {string} specific policy {string}")
     public void iDeleteTheApiSpecificPolicy(String apiId, String policyId) throws IOException {
 
-        String actualApiId = Utils.resolveFromContext(apiId).toString();
-        String policyID = Utils.resolveFromContext(policyId).toString();
+        String actualApiId = TestContext.resolve(apiId).toString();
+        String policyID = TestContext.resolve(policyId).toString();
 
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION,
@@ -1411,7 +1327,6 @@ public class PublisherBaseSteps {
 
         HttpResponse response = SimpleHTTPClient.getInstance()
                 .doDelete(Utils.getAPISpecificPolicyById(getBaseUrl(), actualApiId, policyID), headers);
-        TestContext.set("httpResponse", response);
     }
 
     /**
@@ -1465,10 +1380,7 @@ public class PublisherBaseSteps {
         files.put("file", openapiFile);
         files.put("additionalProperties", additionalPropertiesFile);
 
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPostMultipartWithFiles(Utils.getAPIDefinitionURL(getBaseUrl()), headers, files, null);
-
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.postMultipart(Utils.getAPIDefinitionURL(getBaseUrl()), headers, files, null);
         Assert.assertEquals(response.getResponseCode(), 201, response.getData());
         Object createdId = Utils.extractValueFromPayload(response.getData(), "id");
         TestContext.set(resourceId, createdId);
@@ -1510,10 +1422,8 @@ public class PublisherBaseSteps {
         files.put("file", archiveFile);
         files.put("additionalProperties", additionalPropertiesFile);
 
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPostMultipartWithFiles(Utils.getAPIDefinitionURL(getBaseUrl()), headers, files, null);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.postMultipart(Utils.getAPIDefinitionURL(getBaseUrl()), headers, files,
+                null);
         if (response.getResponseCode() >= 200 && response.getResponseCode() < 300) {
             Object createdId = Utils.extractValueFromPayload(response.getData(), "id");
             TestContext.set(resourceId, createdId);
@@ -1549,17 +1459,14 @@ public class PublisherBaseSteps {
      */
     @When("I upload thumbnail {string} for API {string}")
     public void iUploadThumbnail(String imagePath, String apiId) throws IOException {
-        String actualApiId = Utils.resolveFromContext(apiId).toString();
+        String actualApiId = TestContext.resolve(apiId).toString();
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
         Map<String, File> files = new HashMap<>();
         files.put("file", loadResourceAsTempFile(imagePath, ".png"));
-        TestContext.remove("httpResponse");
         // Thumbnail upload is a PUT (updateAPIThumbnail), not POST — a POST returns 405.
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPutMultipartWithFiles(Utils.getThumbnailURL(getBaseUrl(), actualApiId), headers, files,
-                        new HashMap<>());
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.putMultipart(Utils.getThumbnailURL(getBaseUrl(), actualApiId), headers,
+                files, new HashMap<>());
     }
 
     /**
@@ -1569,13 +1476,10 @@ public class PublisherBaseSteps {
      */
     @When("I retrieve the thumbnail for API {string}")
     public void iRetrieveThumbnail(String apiId) throws IOException {
-        String actualApiId = Utils.resolveFromContext(apiId).toString();
+        String actualApiId = TestContext.resolve(apiId).toString();
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doGet(Utils.getThumbnailURL(getBaseUrl(), actualApiId), headers);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.get(Utils.getThumbnailURL(getBaseUrl(), actualApiId), headers);
     }
 
     /**
@@ -1586,7 +1490,7 @@ public class PublisherBaseSteps {
     @When("I update the swagger of {string} resource {string} from file {string}")
     public void iUpdateSwaggerFromFile(String resourceType, String resourceId, String filepath) throws IOException {
 
-        String actualId = Utils.resolveFromContext(resourceId).toString();
+        String actualId = TestContext.resolve(resourceId).toString();
         String definition;
         try (InputStream in = getClass().getClassLoader().getResourceAsStream(filepath)) {
             if (in == null) {
@@ -1599,10 +1503,8 @@ public class PublisherBaseSteps {
         // The swagger PUT is multipart/form-data with the definition as the text field "apiDefinition".
         Map<String, String> formFields = new HashMap<>();
         formFields.put("apiDefinition", definition);
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance().doPutMultipartWithFiles(
+        HttpResponse response = Requests.putMultipart(
                 Utils.getSwaggerURL(getBaseUrl(), resourceType, actualId), headers, new HashMap<>(), formFields);
-        TestContext.set("httpResponse", response);
     }
 
     /** Retrieves the publisher linter custom rules. */
@@ -1611,10 +1513,7 @@ public class PublisherBaseSteps {
 
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doGet(Utils.getLinterCustomRulesURL(getBaseUrl()), headers);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.get(Utils.getLinterCustomRulesURL(getBaseUrl()), headers);
     }
 
     /** Retrieves the available publisher throttling policies for a policy level (subscription / api / application). */
@@ -1623,23 +1522,17 @@ public class PublisherBaseSteps {
 
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doGet(Utils.getPublisherThrottlingPoliciesURL(getBaseUrl(), policyLevel), headers);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.get(Utils.getPublisherThrottlingPoliciesURL(getBaseUrl(), policyLevel), headers);
     }
 
     /** Retrieves an API's OpenAPI definition (GET /apis/{id}/swagger). */
     @When("I retrieve the swagger of {string} resource {string}")
     public void iRetrieveSwagger(String resourceType, String resourceId) throws IOException {
 
-        String actualId = Utils.resolveFromContext(resourceId).toString();
+        String actualId = TestContext.resolve(resourceId).toString();
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doGet(Utils.getSwaggerURL(getBaseUrl(), resourceType, actualId), headers);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.get(Utils.getSwaggerURL(getBaseUrl(), resourceType, actualId), headers);
     }
 
     /**
@@ -1654,10 +1547,8 @@ public class PublisherBaseSteps {
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
         Map<String, File> files = new HashMap<>();
         files.put("file", loadJsonResourceAsTempFile(filepath));
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPostMultipartWithFiles(Utils.getValidateOpenAPIURL(getBaseUrl()), headers, files, new HashMap<>());
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.postMultipart(Utils.getValidateOpenAPIURL(getBaseUrl()), headers, files,
+                new HashMap<>());
     }
 
     /**
@@ -1710,10 +1601,8 @@ public class PublisherBaseSteps {
         Map<String, File> files = new HashMap<>();
         files.put("file", openapiFile);
         files.put("additionalProperties", additionalPropertiesFile);
-        TestContext.remove("httpResponse");
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPostMultipartWithFiles(Utils.getAPIDefinitionURL(getBaseUrl()), headers, files, null);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.postMultipart(Utils.getAPIDefinitionURL(getBaseUrl()), headers, files,
+                null);
         if (resourceId != null && response.getResponseCode() >= 200 && response.getResponseCode() < 300) {
             Object createdId = Utils.extractValueFromPayload(response.getData(), "id");
             TestContext.set(resourceId, createdId);
@@ -1742,13 +1631,11 @@ public class PublisherBaseSteps {
     }
 
     private void changeLifecycle(String resourceType, String resourceId, String action) throws IOException {
-        String actualId = Utils.resolveFromContext(resourceId).toString();
+        String actualId = TestContext.resolve(resourceId).toString();
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPost(Utils.getChangeLifecycleURL(getBaseUrl(), resourceType, actualId, action, null), headers,
+        HttpResponse response = Requests.post(Utils.getChangeLifecycleURL(getBaseUrl(), resourceType, actualId, action, null), headers,
                         null, null);
-        TestContext.set("httpResponse", response);
     }
 
     /**
@@ -1786,16 +1673,14 @@ public class PublisherBaseSteps {
     public void iCreateApiProduct(String nameBase, String contextBase, String apiIdKey, String productIdKey)
             throws IOException {
 
-        String apiId = Utils.resolveFromContext(apiIdKey).toString();
+        String apiId = TestContext.resolve(apiIdKey).toString();
         String payload = buildApiProductPayload(Utils.resolvePayloadPlaceholders(nameBase),
                 Utils.resolvePayloadPlaceholders(contextBase), apiId);
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
 
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPost(Utils.getAPICreateEndpointURL(getBaseUrl(), "api-products"), headers, payload,
+        HttpResponse response = Requests.post(Utils.getAPICreateEndpointURL(getBaseUrl(), "api-products"), headers, payload,
                         Constants.CONTENT_TYPES.APPLICATION_JSON);
-        TestContext.set("httpResponse", response);
         Assert.assertEquals(response.getResponseCode(), 201, response.getData());
         Object productId = Utils.extractValueFromPayload(response.getData(), "id");
         TestContext.set(productIdKey, productId);
@@ -1809,16 +1694,14 @@ public class PublisherBaseSteps {
     @When("I attempt to create an API product {string} with context {string} from API {string}")
     public void iAttemptToCreateApiProduct(String nameBase, String contextBase, String apiIdKey) throws IOException {
 
-        String apiId = Utils.resolveFromContext(apiIdKey).toString();
+        String apiId = TestContext.resolve(apiIdKey).toString();
         String payload = buildApiProductPayload(Utils.resolvePayloadPlaceholders(nameBase),
                 Utils.resolvePayloadPlaceholders(contextBase), apiId);
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
 
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPost(Utils.getAPICreateEndpointURL(getBaseUrl(), "api-products"), headers, payload,
+        HttpResponse response = Requests.post(Utils.getAPICreateEndpointURL(getBaseUrl(), "api-products"), headers, payload,
                         Constants.CONTENT_TYPES.APPLICATION_JSON);
-        TestContext.set("httpResponse", response);
     }
 
     /** Creates a new version (copy) of an API Product; stores the new product's id and registers it for teardown. */
@@ -1826,15 +1709,13 @@ public class PublisherBaseSteps {
     public void iCreateNewApiProductVersion(String newVersion, String productIdKey, String isDefault,
                                             String newProductIdKey) throws IOException {
 
-        String productId = Utils.resolveFromContext(productIdKey).toString();
+        String productId = TestContext.resolve(productIdKey).toString();
         boolean defaultVersion = Boolean.parseBoolean(isDefault);
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
 
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPost(Utils.getAPIProductNewVersionURL(getBaseUrl(), newVersion, defaultVersion, productId),
+        HttpResponse response = Requests.post(Utils.getAPIProductNewVersionURL(getBaseUrl(), newVersion, defaultVersion, productId),
                         headers, null, null);
-        TestContext.set("httpResponse", response);
         if (response.getResponseCode() >= 200 && response.getResponseCode() < 300) {
             Object newId = Utils.extractValueFromPayload(response.getData(), "id");
             TestContext.set(newProductIdKey, newId);
@@ -1846,38 +1727,32 @@ public class PublisherBaseSteps {
     @When("I retrieve the API product swagger of {string}")
     public void iRetrieveApiProductSwagger(String productIdKey) throws IOException {
 
-        String productId = Utils.resolveFromContext(productIdKey).toString();
+        String productId = TestContext.resolve(productIdKey).toString();
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doGet(Utils.getAPIProductSwaggerURL(getBaseUrl(), productId), headers);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.get(Utils.getAPIProductSwaggerURL(getBaseUrl(), productId), headers);
     }
 
     /** Lists an API's revisions (no filter). Non-asserting — the feature confirms the 200. */
     @When("I retrieve the revisions of {string} resource {string}")
     public void iRetrieveTheRevisions(String resourceType, String resourceId) throws IOException {
 
-        String actualResourceId = Utils.resolveFromContext(resourceId).toString();
+        String actualResourceId = TestContext.resolve(resourceId).toString();
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
 
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doGet(Utils.getRevisionURL(getBaseUrl(), resourceType, actualResourceId), headers);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.get(Utils.getRevisionURL(getBaseUrl(), resourceType, actualResourceId), headers);
     }
 
     /** Lists an API's currently-deployed revisions ({@code query=deployed:true}). Non-asserting. */
     @When("I retrieve the deployed revisions of {string} resource {string}")
     public void iRetrieveTheDeployedRevisions(String resourceType, String resourceId) throws IOException {
 
-        String actualResourceId = Utils.resolveFromContext(resourceId).toString();
+        String actualResourceId = TestContext.resolve(resourceId).toString();
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
 
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doGet(Utils.getRevisionDeployments(getBaseUrl(), resourceType, actualResourceId), headers);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.get(Utils.getRevisionDeployments(getBaseUrl(), resourceType, actualResourceId), headers);
     }
 
     /**
@@ -1887,18 +1762,16 @@ public class PublisherBaseSteps {
     @When("I undeploy revision {string} of {string} resource {string}")
     public void iUndeployRevision(String revisionId, String resourceType, String resourceId) throws IOException {
 
-        String actualResourceId = Utils.resolveFromContext(resourceId).toString();
-        String actualRevisionId = Utils.resolveFromContext(revisionId).toString();
+        String actualResourceId = TestContext.resolve(resourceId).toString();
+        String actualRevisionId = TestContext.resolve(revisionId).toString();
         String payload = "[{\"name\":\"" + System.getenv(Constants.GATEWAY_ENVIRONMENT)
                 + "\",\"vhost\":\"localhost\",\"displayOnDevportal\":true}]";
 
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
 
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPost(Utils.getRevisionUnDeploymentURL(getBaseUrl(), resourceType, actualResourceId, actualRevisionId),
+        HttpResponse response = Requests.post(Utils.getRevisionUnDeploymentURL(getBaseUrl(), resourceType, actualResourceId, actualRevisionId),
                         headers, payload, Constants.CONTENT_TYPES.APPLICATION_JSON);
-        TestContext.set("httpResponse", response);
     }
 
     /**
@@ -1910,34 +1783,30 @@ public class PublisherBaseSteps {
     public void iUndeployRevisionGivenPayload(String revisionId, String resourceType, String resourceId,
                                               String payload) throws IOException {
 
-        String actualResourceId = Utils.resolveFromContext(resourceId).toString();
-        String actualRevisionId = Utils.resolveFromContext(revisionId).toString();
-        String jsonPayload = Utils.resolveFromContext(payload).toString();
+        String actualResourceId = TestContext.resolve(resourceId).toString();
+        String actualRevisionId = TestContext.resolve(revisionId).toString();
+        String jsonPayload = TestContext.resolve(payload).toString();
         jsonPayload = jsonPayload.replace("{{gatewayEnvironment}}", System.getenv(Constants.GATEWAY_ENVIRONMENT));
         jsonPayload = Utils.resolveContextPlaceholders(jsonPayload);
 
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
 
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPost(Utils.getRevisionUnDeploymentURL(getBaseUrl(), resourceType, actualResourceId, actualRevisionId),
+        HttpResponse response = Requests.post(Utils.getRevisionUnDeploymentURL(getBaseUrl(), resourceType, actualResourceId, actualRevisionId),
                         headers, jsonPayload, Constants.CONTENT_TYPES.APPLICATION_JSON);
-        TestContext.set("httpResponse", response);
     }
 
     /** Restores the API's working copy from a revision. Non-asserting (a successful restore returns 201). */
     @When("I restore revision {string} of {string} resource {string}")
     public void iRestoreRevision(String revisionId, String resourceType, String resourceId) throws IOException {
 
-        String actualResourceId = Utils.resolveFromContext(resourceId).toString();
-        String actualRevisionId = Utils.resolveFromContext(revisionId).toString();
+        String actualResourceId = TestContext.resolve(resourceId).toString();
+        String actualRevisionId = TestContext.resolve(revisionId).toString();
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
 
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPost(Utils.getRevisionRestoreURL(getBaseUrl(), resourceType, actualResourceId, actualRevisionId),
+        HttpResponse response = Requests.post(Utils.getRevisionRestoreURL(getBaseUrl(), resourceType, actualResourceId, actualRevisionId),
                         headers, null, null);
-        TestContext.set("httpResponse", response);
     }
 
     /**
@@ -1947,14 +1816,12 @@ public class PublisherBaseSteps {
     @When("I delete revision {string} of {string} resource {string}")
     public void iDeleteRevision(String revisionId, String resourceType, String resourceId) throws IOException {
 
-        String actualResourceId = Utils.resolveFromContext(resourceId).toString();
-        String actualRevisionId = Utils.resolveFromContext(revisionId).toString();
+        String actualResourceId = TestContext.resolve(resourceId).toString();
+        String actualRevisionId = TestContext.resolve(revisionId).toString();
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
 
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doDelete(Utils.getRevisionByID(getBaseUrl(), resourceType, actualResourceId, actualRevisionId), headers);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.delete(Utils.getRevisionByID(getBaseUrl(), resourceType, actualResourceId, actualRevisionId), headers);
     }
 
     /**
@@ -1965,13 +1832,11 @@ public class PublisherBaseSteps {
     @When("I generate an internal API key for API {string} and store it as {string}")
     public void iGenerateInternalApiKey(String apiId, String keyContextKey) throws IOException {
 
-        String actualApiId = Utils.resolveFromContext(apiId).toString();
+        String actualApiId = TestContext.resolve(apiId).toString();
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
 
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPost(Utils.getInternalAPIKey(getBaseUrl(), actualApiId), headers, null, null);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.post(Utils.getInternalAPIKey(getBaseUrl(), actualApiId), headers, null, null);
         // Assert success before extracting: generate-key returns 200 (APIKey). Without this, a non-2xx body has no
         // "apikey" field and surfaces as a confusing "Path 'apikey' not found" IOException instead of the status.
         Assert.assertEquals(response.getResponseCode(), 200, response.getData());

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/PublisherBaseSteps.java
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/PublisherBaseSteps.java
@@ -337,9 +337,7 @@ public class PublisherBaseSteps {
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION,
                 "Bearer " + Identity.publisherToken());
 
-        HttpResponse response = Requests.get(Utils.getAPISearchEndpointURL(getBaseUrl(), null, null, null), headers);
-
-        TestContext.set("httpResponse", response);
+        Requests.get(Utils.getAPISearchEndpointURL(getBaseUrl(), null, null, null), headers);
     }
 
     /**
@@ -567,9 +565,8 @@ public class PublisherBaseSteps {
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION,
                 "Bearer " + Identity.publisherToken());
 
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doPost(Utils.getNewAPIVersionURL(getBaseUrl(), resourceType, newVersion, defaultVersion,
-                        actualResourceID), headers, null, null);
+        Requests.post(Utils.getNewAPIVersionURL(getBaseUrl(), resourceType, newVersion, defaultVersion,
+                actualResourceID), headers, null, null);
     }
 
     /**
@@ -1325,8 +1322,7 @@ public class PublisherBaseSteps {
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION,
                 "Bearer " + Identity.publisherToken());
 
-        HttpResponse response = SimpleHTTPClient.getInstance()
-                .doDelete(Utils.getAPISpecificPolicyById(getBaseUrl(), actualApiId, policyID), headers);
+        Requests.delete(Utils.getAPISpecificPolicyById(getBaseUrl(), actualApiId, policyID), headers);
     }
 
     /**
@@ -1648,6 +1644,13 @@ public class PublisherBaseSteps {
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.publisherToken());
         HttpResponse apiResp = SimpleHTTPClient.getInstance()
                 .doGet(Utils.getResourceEndpointURL(getBaseUrl(), "apis", apiId), headers);
+        // Confirm the GET succeeded with a body BEFORE parsing — otherwise new JSONObject(null/"") throws an
+        // opaque JSONException/NPE instead of a clear failure.
+        Assert.assertTrue(apiResp != null && apiResp.getResponseCode() >= 200 && apiResp.getResponseCode() < 300
+                        && apiResp.getData() != null && !apiResp.getData().isEmpty(),
+                "Failed to fetch API '" + apiId + "' while building the API-product payload: expected a 2xx response "
+                        + "with a body, got " + (apiResp == null ? "no response" : apiResp.getResponseCode()
+                        + " / body=" + apiResp.getData()));
         JSONObject api = new JSONObject(apiResp.getData());
         JSONArray operations = api.optJSONArray("operations");
         JSONObject productApi = new JSONObject()

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/RemoteLoggingSteps.java
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/RemoteLoggingSteps.java
@@ -21,6 +21,8 @@ import com.sun.net.httpserver.HttpServer;
 import io.cucumber.java.After;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.testng.Assert;
 import org.wso2.am.integration.cucumbertests.utils.Identity;
 import org.wso2.am.integration.cucumbertests.utils.Requests;
@@ -60,9 +62,15 @@ public class RemoteLoggingSteps {
     private static final String DATA_NS = "http://data.service.logging.carbon.wso2.org/xsd";
     private static final String SERVICE_PATH = "services/RemoteLoggingConfig";
 
+    private static final Log log = LogFactory.getLog(RemoteLoggingSteps.class);
+
     /* Mock HTTP sink shared across steps + the teardown hook. */
     private static HttpServer sinkServer;
     private static final List<String> sinkPayloads = new CopyOnWriteArrayList<>();
+
+    /* Log types enabled via addRemoteServerConfig, reset in teardown — failure-safe, since the inline "disable"
+       step is skipped if a scenario fails after enabling. */
+    private static final List<String> enabledLogTypes = new CopyOnWriteArrayList<>();
 
     private String baseUrl() {
         return TestContext.get("baseUrl").toString();
@@ -81,12 +89,16 @@ public class RemoteLoggingSteps {
     public void enableRemoteLogging(String logType, String url) throws Exception {
         sendConfigOp("addRemoteServerConfig", "urn:addRemoteServerConfig", logType,
                 Utils.resolveContextPlaceholders(url));
+        if (!enabledLogTypes.contains(logType)) {
+            enabledLogTypes.add(logType);
+        }
     }
 
     /** Resets (disables) remote logging for a log type — its appender reverts to the local RollingFile. */
     @When("I disable remote logging for log type {string}")
     public void disableRemoteLogging(String logType) throws Exception {
         sendConfigOp("resetRemoteServerConfig", "urn:resetRemoteServerConfig", logType, "");
+        enabledLogTypes.remove(logType);
     }
 
     private void sendConfigOp(String op, String soapAction, String logType, String url) throws Exception {
@@ -207,6 +219,17 @@ public class RemoteLoggingSteps {
     /** Stops the host mock sink after the remote-logging scenarios (idempotent). */
     @After("@remote-logging")
     public void stopMockSink() {
+        // Failure-safe teardown: if a scenario failed before its inline "disable remote logging" step, the server
+        // is still redirecting logs — reset every type we enabled (idempotent) so this block's container isn't
+        // left mutated. On the happy path the disable step already cleared enabledLogTypes, so this no-ops.
+        for (String logType : enabledLogTypes) {
+            try {
+                sendConfigOp("resetRemoteServerConfig", "urn:resetRemoteServerConfig", logType, "");
+            } catch (Exception e) {
+                log.warn("Teardown: failed to reset remote logging for type '" + logType + "': " + e.getMessage());
+            }
+        }
+        enabledLogTypes.clear();
         if (sinkServer != null) {
             sinkServer.stop(0);
             sinkServer = null;

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/RemoteLoggingSteps.java
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/RemoteLoggingSteps.java
@@ -23,9 +23,9 @@ import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import org.testng.Assert;
 import org.wso2.am.integration.cucumbertests.utils.Identity;
+import org.wso2.am.integration.cucumbertests.utils.Requests;
 import org.wso2.am.integration.cucumbertests.utils.TestContext;
 import org.wso2.am.integration.cucumbertests.utils.Utils;
-import org.wso2.am.integration.cucumbertests.utils.clients.SimpleHTTPClient;
 import org.wso2.am.integration.test.utils.Constants;
 import org.wso2.am.testcontainers.DynamicApimContainer;
 import org.wso2.carbon.automation.engine.context.beans.User;
@@ -102,9 +102,8 @@ public class RemoteLoggingSteps {
                 + "</soapenv:Body></soapenv:Envelope>";
 
         User admin = Identity.resolveActor("admin");
-        HttpResponse response = SimpleHTTPClient.getInstance().sendSoapRequest(baseUrl() + SERVICE_PATH, envelope,
+        HttpResponse response = Requests.soap(baseUrl() + SERVICE_PATH, envelope,
                 soapAction, admin.getUserName(), admin.getPassword());
-        TestContext.set("httpResponse", response);
         // These are one-way (Robust In-Only) SOAP ops — Axis2 acknowledges with 202 Accepted (no response body),
         // not 200. A SOAP fault would surface as 500, so 202 confirms the config was accepted.
         Assert.assertEquals(response.getResponseCode(), 202, op + " SOAP call failed: " + response.getData());
@@ -157,8 +156,7 @@ public class RemoteLoggingSteps {
     public void triggerAuditLogEntry() throws Exception {
         Map<String, String> headers = new HashMap<>();
         headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.adminToken());
-        HttpResponse response = SimpleHTTPClient.getInstance().doGet(Utils.getKeyManagersURL(baseUrl()), headers);
-        TestContext.set("httpResponse", response);
+        HttpResponse response = Requests.get(Utils.getKeyManagersURL(baseUrl()), headers);
     }
 
     /** Asserts the mock sink receives at least one payload within the deadline, re-triggering audit actions. */

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/RemoteLoggingSteps.java
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/RemoteLoggingSteps.java
@@ -1,0 +1,218 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.wso2.am.integration.cucumbertests.stepdefinitions;
+
+import com.sun.net.httpserver.HttpServer;
+import io.cucumber.java.After;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import org.testng.Assert;
+import org.wso2.am.integration.cucumbertests.utils.Identity;
+import org.wso2.am.integration.cucumbertests.utils.TestContext;
+import org.wso2.am.integration.cucumbertests.utils.Utils;
+import org.wso2.am.integration.cucumbertests.utils.clients.SimpleHTTPClient;
+import org.wso2.am.integration.test.utils.Constants;
+import org.wso2.am.testcontainers.DynamicApimContainer;
+import org.wso2.carbon.automation.engine.context.beans.User;
+import org.wso2.carbon.automation.test.utils.http.client.HttpResponse;
+
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Remote-server-logging glue (ports RemoteLoggingAppenderTest). Configures the Carbon
+ * {@code RemoteLoggingConfig} Axis2 admin service over hand-rolled SOAP (the same approach the
+ * user-store/org-claim provisioning uses — there is no REST equivalent) to redirect a log type's appender to
+ * a remote HTTP endpoint, and asserts the effect two ways: (1) the {@code log4j2.properties} appender flips
+ * type (RollingFile ⇄ SecuredHttp), read straight from the running container; (2) end-to-end, an audit action's
+ * log entry is delivered to a host mock sink the container reaches via {@code host.docker.internal}.
+ *
+ * <p>Remote logging is a super-tenant, server-global setting (not per-tenant), so these scenarios run once as
+ * the super-tenant admin, in a dedicated thread-count=1 block (they mutate the shared server's log config).</p>
+ */
+public class RemoteLoggingSteps {
+
+    /* Axis2 namespaces from the RemoteLoggingConfig service WSDL. */
+    private static final String OP_NS = "http://org.apache.axis2/xsd";
+    private static final String DATA_NS = "http://data.service.logging.carbon.wso2.org/xsd";
+    private static final String SERVICE_PATH = "services/RemoteLoggingConfig";
+
+    /* Mock HTTP sink shared across steps + the teardown hook. */
+    private static HttpServer sinkServer;
+    private static final List<String> sinkPayloads = new CopyOnWriteArrayList<>();
+
+    private String baseUrl() {
+        return TestContext.get("baseUrl").toString();
+    }
+
+    private DynamicApimContainer container() {
+        Object c = TestContext.get("blockApimContainer");
+        if (!(c instanceof DynamicApimContainer)) {
+            throw new IllegalStateException("Block APIM container is not available in the test context");
+        }
+        return (DynamicApimContainer) c;
+    }
+
+    /** Enables remote logging for a log type (AUDIT/CARBON/API) by pointing its appender at {@code url}. */
+    @When("I enable remote logging for log type {string} pointing at URL {string}")
+    public void enableRemoteLogging(String logType, String url) throws Exception {
+        sendConfigOp("addRemoteServerConfig", "urn:addRemoteServerConfig", logType,
+                Utils.resolveContextPlaceholders(url));
+    }
+
+    /** Resets (disables) remote logging for a log type — its appender reverts to the local RollingFile. */
+    @When("I disable remote logging for log type {string}")
+    public void disableRemoteLogging(String logType) throws Exception {
+        sendConfigOp("resetRemoteServerConfig", "urn:resetRemoteServerConfig", logType, "");
+    }
+
+    private void sendConfigOp(String op, String soapAction, String logType, String url) throws Exception {
+        StringBuilder data = new StringBuilder()
+                .append("<ax2:connectTimeoutMillis>2000</ax2:connectTimeoutMillis>")
+                .append("<ax2:logType>").append(logType).append("</ax2:logType>")
+                .append("<ax2:url>").append(url == null ? "" : url).append("</ax2:url>")
+                .append("<ax2:verifyHostname>false</ax2:verifyHostname>");
+        String envelope = "<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\" "
+                + "xmlns:ns=\"" + OP_NS + "\" xmlns:ax2=\"" + DATA_NS + "\">"
+                + "<soapenv:Header/><soapenv:Body>"
+                + "<ns:" + op + "><ns:data>" + data + "</ns:data><ns:args1>false</ns:args1></ns:" + op + ">"
+                + "</soapenv:Body></soapenv:Envelope>";
+
+        User admin = Identity.resolveActor("admin");
+        HttpResponse response = SimpleHTTPClient.getInstance().sendSoapRequest(baseUrl() + SERVICE_PATH, envelope,
+                soapAction, admin.getUserName(), admin.getPassword());
+        TestContext.set("httpResponse", response);
+        // These are one-way (Robust In-Only) SOAP ops — Axis2 acknowledges with 202 Accepted (no response body),
+        // not 200. A SOAP fault would surface as 500, so 202 confirms the config was accepted.
+        Assert.assertEquals(response.getResponseCode(), 202, op + " SOAP call failed: " + response.getData());
+    }
+
+    /**
+     * Polls the running container's {@code log4j2.properties} until the named appender's {@code type} equals the
+     * expected value (the OSGi log reconfig after the SOAP call is asynchronous, so this waits, never sleeps blind).
+     */
+    @Then("the {string} log appender should become {string} within {int} seconds")
+    public void appenderShouldBecome(String appenderName, String expectedType, int timeoutSeconds) throws Exception {
+        Pattern p = Pattern.compile("(?m)^appender\\." + Pattern.quote(appenderName) + "\\.type\\s*=\\s*(\\S+)");
+        long end = System.currentTimeMillis() + Math.max(timeoutSeconds * 1000L, 10000L);
+        String actual = null;
+        while (System.currentTimeMillis() < end) {
+            Matcher m = p.matcher(container().readContainerFile(container().getContainerLog4j2Path()));
+            actual = m.find() ? m.group(1).trim() : null;
+            if (expectedType.equals(actual)) {
+                return;
+            }
+            Thread.sleep(2000);
+        }
+        Assert.assertEquals(actual, expectedType,
+                appenderName + " appender type did not become " + expectedType + " within the deadline");
+    }
+
+    /**
+     * Starts a host HTTP sink on an ephemeral port and stores the container-reachable URL under {@code ctxKey}
+     * (via {@code host.docker.internal}, which {@code DynamicApimContainer} maps to the host gateway).
+     */
+    @When("I start a mock log sink and store its container URL as {string}")
+    public void startMockSink(String ctxKey) throws Exception {
+        sinkPayloads.clear();
+        sinkServer = HttpServer.create(new InetSocketAddress(0), 0);
+        int port = sinkServer.getAddress().getPort();
+        sinkServer.createContext("/api/logs/consume", exchange -> {
+            try (InputStream body = exchange.getRequestBody()) {
+                sinkPayloads.add(new String(body.readAllBytes(), StandardCharsets.UTF_8));
+            }
+            exchange.sendResponseHeaders(200, -1);
+            exchange.close();
+        });
+        sinkServer.start();
+        TestContext.set(Utils.normalizeContextKey(ctxKey),
+                "http://host.docker.internal:" + port + "/api/logs/consume");
+    }
+
+    /** Triggers an action that emits an AUDIT_LOG entry — an authenticated admin GET of the key-managers. */
+    @When("I trigger an audit log entry")
+    public void triggerAuditLogEntry() throws Exception {
+        Map<String, String> headers = new HashMap<>();
+        headers.put(Constants.REQUEST_HEADERS.AUTHORIZATION, "Bearer " + Identity.adminToken());
+        HttpResponse response = SimpleHTTPClient.getInstance().doGet(Utils.getKeyManagersURL(baseUrl()), headers);
+        TestContext.set("httpResponse", response);
+    }
+
+    /** Asserts the mock sink receives at least one payload within the deadline, re-triggering audit actions. */
+    @Then("the mock log sink should receive a log payload within {int} seconds")
+    public void sinkShouldReceivePayload(int timeoutSeconds) throws Exception {
+        long end = System.currentTimeMillis() + Math.max(timeoutSeconds * 1000L, 10000L);
+        while (System.currentTimeMillis() < end) {
+            if (!sinkPayloads.isEmpty()) {
+                return;
+            }
+            triggerAuditLogEntry();
+            Thread.sleep(2000);
+        }
+        Assert.assertFalse(sinkPayloads.isEmpty(), "Mock log sink received no log payload within the deadline");
+    }
+
+    /**
+     * Asserts the remote stream STOPS after remote logging is disabled. The runtime OSGi reconfig lags the
+     * log4j2.properties file update, so audit logs already in flight keep arriving briefly after the disable
+     * call — this first waits for the stream to quiesce (count stable across a quiet window), then confirms a
+     * FRESH audit action produces no new payload (remote logging is genuinely off, not just draining).
+     */
+    @Then("the mock log sink should stop receiving payloads within {int} seconds")
+    public void sinkShouldStopReceiving(int timeoutSeconds) throws Exception {
+        long end = System.currentTimeMillis() + Math.max(timeoutSeconds * 1000L, 20000L);
+        int last = -1;
+        int stableRounds = 0;
+        while (System.currentTimeMillis() < end) {
+            int now = sinkPayloads.size();
+            if (now == last) {
+                if (++stableRounds >= 3) {
+                    break;   // count unchanged across ~6s → stream quiesced
+                }
+            } else {
+                stableRounds = 0;
+                last = now;
+            }
+            Thread.sleep(2000);
+        }
+        // The stream has quiesced — a fresh audit action must now NOT reach the sink (appender is local again).
+        int before = sinkPayloads.size();
+        triggerAuditLogEntry();
+        Thread.sleep(5000);
+        Assert.assertEquals(sinkPayloads.size(), before,
+                "Mock sink still received a payload after remote logging was disabled and the stream quiesced");
+    }
+
+    /** Stops the host mock sink after the remote-logging scenarios (idempotent). */
+    @After("@remote-logging")
+    public void stopMockSink() {
+        if (sinkServer != null) {
+            sinkServer.stop(0);
+            sinkServer = null;
+        }
+        sinkPayloads.clear();
+    }
+}

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/utils/Identity.java
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/utils/Identity.java
@@ -138,6 +138,10 @@ public final class Identity {
         return qualify("adminAccessToken", actor);
     }
 
+    public static String governanceTokenKey(User actor) {
+        return qualify("governanceAccessToken", actor);
+    }
+
     /** Reads the cached Publisher token for the default actor (super-tenant admin). */
     public static String publisherToken() {
         return publisherToken(defaultActor());
@@ -163,6 +167,15 @@ public final class Identity {
 
     public static String adminToken(User actor) {
         return require(adminTokenKey(actor), "Admin access token", actor);
+    }
+
+    /** Reads the cached Governance token for the acting actor. */
+    public static String governanceToken() {
+        return governanceToken(defaultActor());
+    }
+
+    public static String governanceToken(User actor) {
+        return require(governanceTokenKey(actor), "Governance access token", actor);
     }
 
     private static String qualify(String base, User actor) {

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/utils/Requests.java
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/utils/Requests.java
@@ -1,0 +1,105 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.wso2.am.integration.cucumbertests.utils;
+
+import org.wso2.am.integration.cucumbertests.utils.clients.SimpleHTTPClient;
+import org.wso2.carbon.automation.test.utils.http.client.HttpResponse;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Centralized funnel for management-plane HTTP requests whose response a following assertion step reads — the
+ * counterpart of {@code APIInvocationSteps#execute} (the gateway-invocation funnel). Every method CLEARS the
+ * shared {@code httpResponse} context key BEFORE the call, so if the call throws, the context is left WITHOUT a
+ * stale response — a later {@code The response status code should be N} then cannot be satisfied by a leftover
+ * value from an earlier step. On a real response it publishes it under {@code httpResponse} and returns it.
+ *
+ * <p>Use these instead of hand-writing {@code TestContext.remove("httpResponse")} /
+ * {@code SimpleHTTPClient.getInstance().doX(...)} / {@code TestContext.set("httpResponse", ...)} at each call
+ * site (that duplication is the stale-response trap this removes).
+ *
+ * <p>Use ONLY for the request whose response the step publishes for assertions. An intermediate call whose body
+ * is consumed locally (e.g. a GET-then-mutate-then-PUT round trip) must NOT publish {@code httpResponse}, so keep
+ * those on {@link SimpleHTTPClient} directly.
+ */
+public final class Requests {
+
+    private static final String HTTP_RESPONSE_KEY = "httpResponse";
+
+    private Requests() {
+    }
+
+    /** A deferred HTTP call, so the funnel can clear {@code httpResponse} BEFORE the call is made. */
+    @FunctionalInterface
+    private interface Call {
+        HttpResponse invoke() throws IOException;
+    }
+
+    /** The single clear -> call -> set primitive every method below funnels through. */
+    private static HttpResponse execute(Call call) throws IOException {
+        TestContext.remove(HTTP_RESPONSE_KEY);
+        HttpResponse response = call.invoke();
+        TestContext.set(HTTP_RESPONSE_KEY, response);
+        return response;
+    }
+
+    public static HttpResponse get(String url, Map<String, String> headers) throws IOException {
+        return execute(() -> SimpleHTTPClient.getInstance().doGet(url, headers));
+    }
+
+    public static HttpResponse delete(String url, Map<String, String> headers) throws IOException {
+        return execute(() -> SimpleHTTPClient.getInstance().doDelete(url, headers));
+    }
+
+    public static HttpResponse post(String url, Map<String, String> headers, String payload, String contentType)
+            throws IOException {
+        return execute(() -> SimpleHTTPClient.getInstance().doPost(url, headers, payload, contentType));
+    }
+
+    public static HttpResponse put(String url, Map<String, String> headers, String payload, String contentType)
+            throws IOException {
+        return execute(() -> SimpleHTTPClient.getInstance().doPut(url, headers, payload, contentType));
+    }
+
+    public static HttpResponse postMultipart(String url, Map<String, String> headers, Map<String, File> files,
+                                             Map<String, String> formFields) throws IOException {
+        return execute(() -> SimpleHTTPClient.getInstance().doPostMultipartWithFiles(url, headers, files, formFields));
+    }
+
+    public static HttpResponse putMultipart(String url, Map<String, String> headers, Map<String, File> files,
+                                            Map<String, String> formFields) throws IOException {
+        return execute(() -> SimpleHTTPClient.getInstance().doPutMultipartWithFiles(url, headers, files, formFields));
+    }
+
+    public static HttpResponse head(String url, Map<String, String> headers) throws IOException {
+        return execute(() -> SimpleHTTPClient.getInstance().doHead(url, headers));
+    }
+
+    public static HttpResponse patch(String url, Map<String, String> headers, String payload, String contentType)
+            throws IOException {
+        return execute(() -> SimpleHTTPClient.getInstance().doPatch(url, headers, payload, contentType));
+    }
+
+    public static HttpResponse soap(String url, String payload, String soapAction, String adminUsername,
+                                    String adminPassword) throws IOException {
+        return execute(() -> SimpleHTTPClient.getInstance()
+                .sendSoapRequest(url, payload, soapAction, adminUsername, adminPassword));
+    }
+}

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/utils/ResourceCleanup.java
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/utils/ResourceCleanup.java
@@ -55,6 +55,14 @@ public final class ResourceCleanup {
 
     private static final Log logger = LogFactory.getLog(ResourceCleanup.class);
 
+    /**
+     * Teardown list for custom AI service providers (LLM providers). Not in the shared {@link Constants}
+     * because it is specific to the AI-API glue. An AI provider cannot be deleted while an AIAPI-subtype API
+     * still references it (an {@code AM_API_AI_CONFIGURATION} foreign key), so it is swept AFTER the APIs — see
+     * the ordering in {@link #deleteRegisteredResources()}.
+     */
+    public static final String CREATED_AI_PROVIDER_IDS = "createdAiProviderIds";
+
     private ResourceCleanup() {
     }
 
@@ -92,7 +100,14 @@ public final class ResourceCleanup {
                 && TestContext.getList(Constants.CREATED_APPLICATION_POLICY_IDS).isEmpty()
                 && TestContext.getList(Constants.CREATED_SUBSCRIPTION_POLICY_IDS).isEmpty()
                 && TestContext.getList(Constants.CREATED_ADVANCED_POLICY_IDS).isEmpty()
-                && TestContext.getList(Constants.CREATED_CUSTOM_POLICY_IDS).isEmpty()) {
+                && TestContext.getList(Constants.CREATED_CUSTOM_POLICY_IDS).isEmpty()
+                && TestContext.getList(Constants.CREATED_API_PRODUCT_IDS).isEmpty()
+                && TestContext.getList(Constants.CREATED_ENVIRONMENT_IDS).isEmpty()
+                && TestContext.getList(Constants.CREATED_GOVERNANCE_POLICY_IDS).isEmpty()
+                && TestContext.getList(Constants.CREATED_GOVERNANCE_RULESET_IDS).isEmpty()
+                && TestContext.getList(Constants.CREATED_KEY_MANAGER_IDS).isEmpty()
+                && TestContext.getList(Constants.CREATED_DENY_POLICY_IDS).isEmpty()
+                && TestContext.getList(CREATED_AI_PROVIDER_IDS).isEmpty()) {
             return;
         }
         String baseUrl = baseUrlObj.toString();
@@ -100,8 +115,17 @@ public final class ResourceCleanup {
         try {
             deleteResources(Constants.CREATED_APPLICATION_IDS, Identity::devportalTokenKey,
                     id -> Utils.getApplicationEndpointURL(baseUrl, id));
+            // API Products BEFORE their underlying APIs — a product references APIs, so an API delete is
+            // rejected while a product still uses it. Deleted with the publisher token.
+            deleteResources(Constants.CREATED_API_PRODUCT_IDS, Identity::publisherTokenKey,
+                    id -> Utils.getResourceEndpointURL(baseUrl, "api-products", id));
             deleteResources(Constants.CREATED_API_IDS, Identity::publisherTokenKey,
                     id -> Utils.getResourceEndpointURL(baseUrl, "apis", id));
+            // Custom AI service providers AFTER the AIAPI-subtype APIs that reference them — an AI provider
+            // delete is rejected with a foreign-key violation (AM_API_AI_CONFIGURATION → AM_LLM_PROVIDER) while
+            // any API still binds it. Deleted with the admin token (the provider is an admin-plane resource).
+            deleteResources(CREATED_AI_PROVIDER_IDS, Identity::adminTokenKey,
+                    id -> Utils.getAIServiceProviderByIdURL(baseUrl, id));
             // Common (reusable) operation policies are tenant-global, so they outlive their API and must be
             // swept explicitly (API-specific policies are removed when their API is deleted above).
             deleteResources(Constants.CREATED_OPERATION_POLICY_IDS, Identity::publisherTokenKey,
@@ -125,7 +149,25 @@ public final class ResourceCleanup {
             // global rules that would keep matching traffic, so delete them explicitly.
             deleteResources(Constants.CREATED_CUSTOM_POLICY_IDS, Identity::adminTokenKey,
                     id -> Utils.getCustomThrottlingPolicyByIdURL(baseUrl, id));
+            // Gateway environments (admin). No revisions are deployed to test envs, so delete is unblocked.
+            deleteResources(Constants.CREATED_ENVIRONMENT_IDS, Identity::adminTokenKey,
+                    id -> Utils.getEnvironmentByIdURL(baseUrl, id));
+            // Governance policies BEFORE governance rulesets — a policy references rulesets, so a ruleset
+            // delete is rejected with 409 while a policy still attaches it. Both deleted with the governance
+            // token (apim:gov_*), not the admin token.
+            deleteResources(Constants.CREATED_GOVERNANCE_POLICY_IDS, Identity::governanceTokenKey,
+                    id -> Utils.getGovernancePolicyByIdURL(baseUrl, id));
+            deleteResources(Constants.CREATED_GOVERNANCE_RULESET_IDS, Identity::governanceTokenKey,
+                    id -> Utils.getGovernanceRulesetByIdURL(baseUrl, id));
+            // Key managers (admin, tenant-scoped config registry). No resource references them at test time, so
+            // delete is unblocked.
+            deleteResources(Constants.CREATED_KEY_MANAGER_IDS, Identity::adminTokenKey,
+                    id -> Utils.getKeyManagerByIdURL(baseUrl, id));
+            // Deny (blocking-condition) policies (admin, tenant-global). Deleted via the singular by-id path.
+            deleteResources(Constants.CREATED_DENY_POLICY_IDS, Identity::adminTokenKey,
+                    id -> Utils.getDenyPolicyByIdURL(baseUrl, id));
         } finally {
+            TestContext.remove(Constants.CREATED_API_PRODUCT_IDS);
             TestContext.remove(Constants.CREATED_API_IDS);
             TestContext.remove(Constants.CREATED_APPLICATION_IDS);
             TestContext.remove(Constants.CREATED_SHARED_SCOPE_IDS);
@@ -134,6 +176,12 @@ public final class ResourceCleanup {
             TestContext.remove(Constants.CREATED_SUBSCRIPTION_POLICY_IDS);
             TestContext.remove(Constants.CREATED_ADVANCED_POLICY_IDS);
             TestContext.remove(Constants.CREATED_CUSTOM_POLICY_IDS);
+            TestContext.remove(Constants.CREATED_ENVIRONMENT_IDS);
+            TestContext.remove(Constants.CREATED_GOVERNANCE_POLICY_IDS);
+            TestContext.remove(Constants.CREATED_GOVERNANCE_RULESET_IDS);
+            TestContext.remove(Constants.CREATED_KEY_MANAGER_IDS);
+            TestContext.remove(Constants.CREATED_DENY_POLICY_IDS);
+            TestContext.remove(CREATED_AI_PROVIDER_IDS);
         }
     }
 

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/utils/ResourceCleanup.java
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/utils/ResourceCleanup.java
@@ -63,6 +63,23 @@ public final class ResourceCleanup {
      */
     public static final String CREATED_AI_PROVIDER_IDS = "createdAiProviderIds";
 
+    /**
+     * Teardown list for publisher MCP servers. Not in the shared {@link Constants} because it is specific to the
+     * MCP glue. An MCP server built FROM an API references that API (its delete is rejected while the MCP server
+     * binds it), so it is swept BEFORE the APIs — see the ordering in {@link #deleteRegisteredResources()}. It is
+     * created with the publisher token and so deleted with it.
+     */
+    public static final String CREATED_MCP_SERVER_IDS = "createdMcpServerIds";
+
+    /**
+     * Teardown list for "bring your own" OAuth clients registered via DCR ({@code iRegisterOAuthClient}), holding
+     * each client's consumer key. A DCR client is a standalone OAuth service provider that deleting the DevPortal
+     * application does NOT remove, and the DCR REST endpoint exposes no delete — so it is deregistered explicitly
+     * via the Carbon {@code OAuthAdminService} SOAP admin service (as its owner) or it leaks. Swept by
+     * {@link #deleteDcrClients(String)}, not the generic bearer-token {@link #deleteResources}.
+     */
+    public static final String CREATED_DCR_CLIENT_IDS = "createdDcrClientIds";
+
     private ResourceCleanup() {
     }
 
@@ -107,7 +124,9 @@ public final class ResourceCleanup {
                 && TestContext.getList(Constants.CREATED_GOVERNANCE_RULESET_IDS).isEmpty()
                 && TestContext.getList(Constants.CREATED_KEY_MANAGER_IDS).isEmpty()
                 && TestContext.getList(Constants.CREATED_DENY_POLICY_IDS).isEmpty()
-                && TestContext.getList(CREATED_AI_PROVIDER_IDS).isEmpty()) {
+                && TestContext.getList(CREATED_AI_PROVIDER_IDS).isEmpty()
+                && TestContext.getList(CREATED_MCP_SERVER_IDS).isEmpty()
+                && TestContext.getList(CREATED_DCR_CLIENT_IDS).isEmpty()) {
             return;
         }
         String baseUrl = baseUrlObj.toString();
@@ -115,6 +134,11 @@ public final class ResourceCleanup {
         try {
             deleteResources(Constants.CREATED_APPLICATION_IDS, Identity::devportalTokenKey,
                     id -> Utils.getApplicationEndpointURL(baseUrl, id));
+            // MCP servers AFTER applications (whose removal clears any MCP subscriptions) but BEFORE the APIs they
+            // may be built from — a from-api MCP server references an API, whose delete is rejected while the MCP
+            // server still binds it. Created with the publisher token.
+            deleteResources(CREATED_MCP_SERVER_IDS, Identity::publisherTokenKey,
+                    id -> Utils.getMCPServerByIdURL(baseUrl, id));
             // API Products BEFORE their underlying APIs — a product references APIs, so an API delete is
             // rejected while a product still uses it. Deleted with the publisher token.
             deleteResources(Constants.CREATED_API_PRODUCT_IDS, Identity::publisherTokenKey,
@@ -166,6 +190,9 @@ public final class ResourceCleanup {
             // Deny (blocking-condition) policies (admin, tenant-global). Deleted via the singular by-id path.
             deleteResources(Constants.CREATED_DENY_POLICY_IDS, Identity::adminTokenKey,
                     id -> Utils.getDenyPolicyByIdURL(baseUrl, id));
+            // BYO OAuth clients registered via DCR: swept separately because they authenticate with the owner's
+            // Basic credentials (not a bearer token) and are not removed by the DevPortal application's deletion.
+            deleteDcrClients(baseUrl);
         } finally {
             TestContext.remove(Constants.CREATED_API_PRODUCT_IDS);
             TestContext.remove(Constants.CREATED_API_IDS);
@@ -182,7 +209,51 @@ public final class ResourceCleanup {
             TestContext.remove(Constants.CREATED_KEY_MANAGER_IDS);
             TestContext.remove(Constants.CREATED_DENY_POLICY_IDS);
             TestContext.remove(CREATED_AI_PROVIDER_IDS);
+            TestContext.remove(CREATED_MCP_SERVER_IDS);
+            TestContext.remove(CREATED_DCR_CLIENT_IDS);
         }
+    }
+
+    /**
+     * Deregisters DCR-registered ("bring your own") OAuth clients. These are NOT deleted with a bearer token:
+     * the DCR endpoint authenticates with the OWNER's Basic credentials (the same way {@code iRegisterOAuthClient}
+     * created them), and a DCR client is a standalone service provider that the DevPortal application's deletion
+     * does not remove — so it must be swept explicitly or it leaks. Best-effort: a 404 (already gone) is fine.
+     */
+    private static void deleteDcrClients(String baseUrl) {
+        String serviceUrl = baseUrl + "services/OAuthAdminService";
+        // Axis2 wraps operation elements in this namespace (same as other Carbon admin-service SOAP calls).
+        String ns = "http://org.apache.axis2/xsd";
+        for (Object o : TestContext.getList(CREATED_DCR_CLIENT_IDS)) {
+            if (!(o instanceof OwnedResource res) || res.id() == null) {
+                continue;
+            }
+            User owner = Identity.resolveActor(res.actorRef());
+            String removeEnvelope = "<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\" "
+                    + "xmlns:xsd=\"" + ns + "\"><soapenv:Header/><soapenv:Body>"
+                    + "<xsd:removeOAuthApplicationData><xsd:consumerKey>" + res.id() + "</xsd:consumerKey>"
+                    + "</xsd:removeOAuthApplicationData></soapenv:Body></soapenv:Envelope>";
+            try {
+                HttpResponse resp = SimpleHTTPClient.getInstance().sendSoapRequest(serviceUrl, removeEnvelope,
+                        "urn:removeOAuthApplicationData", owner.getUserName(), owner.getPassword());
+                int code = resp.getResponseCode();
+                if (code >= 200 && code < 300) {
+                    logger.info("Cleanup: deregistered DCR client " + res.id() + " (HTTP " + code + ").");
+                } else {
+                    logger.warn("Cleanup: deregister of DCR client " + res.id() + " returned HTTP " + code
+                            + " — it may leak: " + trunc(resp.getData()));
+                }
+            } catch (Exception e) {
+                logger.warn("Cleanup failed to deregister DCR client " + res.id() + ": " + e.getMessage());
+            }
+        }
+    }
+
+    private static String trunc(String s) {
+        if (s == null) {
+            return "";
+        }
+        return s.length() > 300 ? s.substring(0, 300) : s;
     }
 
     /**

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/utils/TestContext.java
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/utils/TestContext.java
@@ -122,6 +122,22 @@ public class TestContext {
         return getCurrentSharedContext().get(key);
     }
 
+    /**
+     * Resolves a REQUIRED value from context: strips an optional {@code <...>} reference wrapper, then reads the
+     * key. Throws {@link IllegalArgumentException} if the value is absent — use this for a caller-supplied key
+     * that must exist, so a missing/typo'd key fails fast with a clear message instead of a downstream NPE. For a
+     * key that may legitimately be absent (or a framework-managed key you null-check yourself), use
+     * {@link #get(String)} (nullable) or {@link #contains(String)}.
+     */
+    public static Object resolve(String key) {
+        String lookupKey = (key.startsWith("<") && key.endsWith(">")) ? key.substring(1, key.length() - 1) : key;
+        Object value = get(lookupKey);
+        if (value == null) {
+            throw new IllegalArgumentException("No value found in context for key: " + lookupKey);
+        }
+        return value;
+    }
+
     public static boolean contains(String key) {
         return getCurrentLocalContext().containsKey(key) || getCurrentSharedContext().containsKey(key);
     }

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/utils/Utils.java
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/utils/Utils.java
@@ -875,24 +875,6 @@ public class Utils {
     }
 
     /**
-     * Resolves a value from the {@link TestContext} using the given key.
-     *
-     * @param key the key
-     * @return the resolved value
-     * @throws IllegalArgumentException if the key is not found
-     */
-    public static Object resolveFromContext(String key) {
-
-        String lookupKey = (key.startsWith("<") && key.endsWith(">")) ? key.substring(1, key.length() - 1) : key;
-
-        Object value = TestContext.get(lookupKey);
-        if (value == null) {
-            throw new IllegalArgumentException("No value found in context for key: " + lookupKey);
-        }
-        return value;
-    }
-
-    /**
      * Resolves the value from context only if the input is a context key (e.g., "<sampleKey>").
      * If the input is not wrapped in brackets, it returns the input string as-is.
      *
@@ -901,7 +883,7 @@ public class Utils {
      */
     public static Object resolveIfContextKey(String input) {
         if (input != null && input.startsWith("<") && input.endsWith(">")) {
-            return resolveFromContext(input);
+            return TestContext.resolve(input);
         }
         return input;
     }

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/utils/Utils.java
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/utils/Utils.java
@@ -87,6 +87,26 @@ public class Utils {
         return baseUrl + Constants.DEFAULT_APIM_API_DEPLOYER + resourceType + "/" + resourceId;
     }
 
+    /** Publisher API endpoints sub-resource collection: {@code /apis/{apiId}/endpoints} (POST add, GET list). */
+    public static String getApiEndpointsURL(String baseUrl, String apiId) {
+        return baseUrl + Constants.DEFAULT_APIM_API_DEPLOYER + "apis/" + apiId + "/endpoints";
+    }
+
+    /** Publisher GraphQL per-field complexity config: {@code /apis/{apiId}/graphql-policies/complexity} (GET/PUT). */
+    public static String getGraphQLComplexityURL(String baseUrl, String apiId) {
+        return baseUrl + Constants.DEFAULT_APIM_API_DEPLOYER + "apis/" + apiId + "/graphql-policies/complexity";
+    }
+
+    /** Publisher API client-certificates (mutual SSL) collection: {@code /apis/{apiId}/client-certificates}. */
+    public static String getClientCertificatesURL(String baseUrl, String apiId) {
+        return baseUrl + Constants.DEFAULT_APIM_API_DEPLOYER + "apis/" + apiId + "/client-certificates";
+    }
+
+    /** Publisher single API endpoint: {@code /apis/{apiId}/endpoints/{endpointId}} (GET, PUT, DELETE). */
+    public static String getApiEndpointByIdURL(String baseUrl, String apiId, String endpointId) {
+        return baseUrl + Constants.DEFAULT_APIM_API_DEPLOYER + "apis/" + apiId + "/endpoints/" + endpointId;
+    }
+
     public static String getRevisionURL(String baseUrl, String resourceType, String resourceId) {
         return baseUrl + Constants.DEFAULT_APIM_API_DEPLOYER + resourceType + "/" + resourceId + "/revisions";
     }
@@ -157,7 +177,14 @@ public class Utils {
             throw new IllegalArgumentException("ID and Action must be provided.");
         }
 
-        String idParam = "apis".equals(resourceType) ? "apiId" : "apiProductId";
+        String idParam;
+        if ("apis".equals(resourceType)) {
+            idParam = "apiId";
+        } else if ("mcp-servers".equals(resourceType)) {
+            idParam = "mcpServerId";
+        } else {
+            idParam = "apiProductId";
+        }
 
         StringBuilder urlBuilder = new StringBuilder(baseUrl)
                 .append(Constants.DEFAULT_APIM_API_DEPLOYER)
@@ -214,6 +241,53 @@ public class Utils {
         return urlBuilder.toString();
     }
 
+    /** Admin — list applications owned by a given user (owner search). */
+    public static String getAdminApplicationsByOwnerURL(String baseUrl, String owner) {
+        return baseUrl + Constants.DEFAULT_APIM_ADMIN + "applications?user="
+                + URLEncoder.encode(owner, StandardCharsets.UTF_8);
+    }
+
+    /** Publisher — force-change a subscription's business plan (validates the plan; POST, query params). */
+    public static String getChangeSubscriptionBusinessPlanURL(String baseUrl, String subscriptionId, String plan) {
+        return baseUrl + Constants.DEFAULT_APIM_API_DEPLOYER + "subscriptions/change-business-plan?subscriptionId="
+                + URLEncoder.encode(subscriptionId, StandardCharsets.UTF_8) + "&throttlingPolicy="
+                + URLEncoder.encode(plan, StandardCharsets.UTF_8);
+    }
+
+    /** Admin — search applications by name (the admin /applications endpoint's {@code name} query param). */
+    public static String getAdminApplicationsByNameURL(String baseUrl, String name) {
+        return baseUrl + Constants.DEFAULT_APIM_ADMIN + "applications?name="
+                + URLEncoder.encode(name, StandardCharsets.UTF_8);
+    }
+
+    /** Publisher — upload (POST, multipart) / download (GET) an API's thumbnail image. */
+    public static String getThumbnailURL(String baseUrl, String apiId) {
+        return baseUrl + Constants.DEFAULT_APIM_API_DEPLOYER + "apis/" + apiId + "/thumbnail";
+    }
+
+    /** Publisher — import an API from an OpenAPI definition or archive (POST, multipart {@code file}). */
+    public static String getImportOpenAPIURL(String baseUrl) {
+        return baseUrl + Constants.DEFAULT_APIM_API_DEPLOYER + "apis/import-openapi";
+    }
+
+    /** Publisher — validate a system role by name. The path segment is URL-safe base64 WITHOUT padding:
+     *  a literal '=' pad in the path breaks the auth-filter's resource match (→ 401). */
+    public static String getValidateRoleURL(String baseUrl, String role) {
+        String encoded = java.util.Base64.getUrlEncoder().withoutPadding()
+                .encodeToString(role.getBytes(StandardCharsets.UTF_8));
+        return baseUrl + Constants.DEFAULT_APIM_API_DEPLOYER + "roles/" + encoded;
+    }
+
+    /** Publisher — generate the inline mock implementation script for an API (POST). */
+    public static String getGenerateMockScriptsURL(String baseUrl, String apiId) {
+        return baseUrl + Constants.DEFAULT_APIM_API_DEPLOYER + "apis/" + apiId + "/generate-mock-scripts";
+    }
+
+    /** Publisher — retrieve the generated inline mock implementation script for an API (GET). */
+    public static String getGeneratedMockScriptsURL(String baseUrl, String apiId) {
+        return baseUrl + Constants.DEFAULT_APIM_API_DEPLOYER + "apis/" + apiId + "/generated-mock-scripts";
+    }
+
     public static String getAPILifecycleStateURL(String baseUrl, String apiId) {
         return baseUrl + Constants.DEFAULT_APIM_API_DEPLOYER + "apis/" + apiId + "/lifecycle-state";
     }
@@ -246,8 +320,25 @@ public class Utils {
         return baseUrl + Constants.DEFAULT_DEVPORTAL + "applications/" + applicationId + "/generate-keys";
     }
 
+    /** DevPortal — regenerate (rotate) the consumer secret of an application's key mapping (by key-mapping id). */
+    public static String getRegenerateConsumerSecretURL(String baseUrl, String applicationId, String keyMappingId) {
+        return baseUrl + Constants.DEFAULT_DEVPORTAL + "applications/" + applicationId + "/oauth-keys/"
+                + keyMappingId + "/regenerate-secret";
+    }
+
     public static String getApplicationAllKeys(String baseUrl, String applicationId) {
         return baseUrl + Constants.DEFAULT_DEVPORTAL + "applications/" + applicationId + "/oauth-keys";
+    }
+
+    /** DevPortal — map a pre-existing (BYO) OAuth client's consumer key/secret to an application. */
+    public static String getMapKeysURL(String baseUrl, String applicationId) {
+        return baseUrl + Constants.DEFAULT_DEVPORTAL + "applications/" + applicationId + "/map-keys";
+    }
+
+    /** DevPortal — clean up an application's key registration for a key mapping (after a failed/partial key-gen). */
+    public static String getCleanupRegistrationURL(String baseUrl, String applicationId, String keyMappingId) {
+        return baseUrl + Constants.DEFAULT_DEVPORTAL + "applications/" + applicationId + "/oauth-keys/"
+                + keyMappingId + "/clean-up";
     }
 
     public static String getGenerateApplicationSecretURL(String baseUrl, String applicationId, String keyMappingId) {
@@ -272,6 +363,16 @@ public class Utils {
 
     public static String getGenerateAPIKeyURL(String baseUrl, String applicationId) {
         return baseUrl + Constants.DEFAULT_DEVPORTAL + "applications/" + applicationId + "/api-keys/PRODUCTION/generate";
+    }
+
+    /** DevPortal — revoke an application API key ({@code applications/{id}/api-keys/PRODUCTION/revoke}). */
+    public static String getRevokeAPIKeyURL(String baseUrl, String applicationId) {
+        return baseUrl + Constants.DEFAULT_DEVPORTAL + "applications/" + applicationId + "/api-keys/PRODUCTION/revoke";
+    }
+
+    /** DevPortal — list an application's API keys ({@code applications/{id}/api-keys/PRODUCTION}); carries keyUUID. */
+    public static String getListAPIKeysURL(String baseUrl, String applicationId) {
+        return baseUrl + Constants.DEFAULT_DEVPORTAL + "applications/" + applicationId + "/api-keys/PRODUCTION";
     }
 
     public static String getUpdateKey(String baseUrl, String applicationId, String keyMappingId) {
@@ -407,6 +508,51 @@ public class Utils {
         return baseUrl + Constants.DEFAULT_APIM_API_DEPLOYER + "gateway-policies/" + policyMappingId + "/deploy";
     }
 
+    /** Publisher REST API — create an MCP server by proxying a third-party MCP server (POST, JSON {@code url}). */
+    public static String getMCPServerProxyURL(String baseUrl) {
+        return baseUrl + Constants.DEFAULT_APIM_API_DEPLOYER + "mcp-servers/generate-from-mcp-server";
+    }
+
+    /** Publisher REST API — create an MCP server from an OpenAPI definition (POST, multipart file). */
+    public static String getMCPServerFromOpenAPIURL(String baseUrl) {
+        return baseUrl + Constants.DEFAULT_APIM_API_DEPLOYER + "mcp-servers/generate-from-openapi";
+    }
+
+    /** Publisher REST API — create an MCP server from an existing API (POST, JSON MCPServer body). */
+    public static String getMCPServerFromAPIURL(String baseUrl) {
+        return baseUrl + Constants.DEFAULT_APIM_API_DEPLOYER + "mcp-servers/generate-from-api";
+    }
+
+    /** Publisher REST API — a single MCP server by id (get/delete). */
+    public static String getMCPServerByIdURL(String baseUrl, String mcpServerId) {
+        return baseUrl + Constants.DEFAULT_APIM_API_DEPLOYER + "mcp-servers/" + mcpServerId;
+    }
+
+    /** Publisher REST API — an MCP server's backend endpoints collection {@code /mcp-servers/{id}/backends} (GET). */
+    public static String getMCPServerBackendsURL(String baseUrl, String mcpServerId) {
+        return baseUrl + Constants.DEFAULT_APIM_API_DEPLOYER + "mcp-servers/" + mcpServerId + "/backends";
+    }
+
+    /** Publisher REST API — a single MCP server backend endpoint by id (GET, PUT). */
+    public static String getMCPServerBackendByIdURL(String baseUrl, String mcpServerId, String backendId) {
+        return baseUrl + Constants.DEFAULT_APIM_API_DEPLOYER + "mcp-servers/" + mcpServerId + "/backends/" + backendId;
+    }
+
+    /** Admin REST API — AI service providers (list/create). */
+    public static String getAIServiceProvidersURL(String baseUrl) {
+        return baseUrl + Constants.DEFAULT_APIM_ADMIN + "ai-service-providers";
+    }
+
+    /** Admin REST API — a single AI service provider by id (get/update/delete). */
+    public static String getAIServiceProviderByIdURL(String baseUrl, String providerId) {
+        return baseUrl + Constants.DEFAULT_APIM_ADMIN + "ai-service-providers/" + providerId;
+    }
+
+    /** Publisher REST API — an AI service provider's model list ({@code /ai-service-providers/{id}/models}). */
+    public static String getAIServiceProviderModelsURL(String baseUrl, String providerId) {
+        return baseUrl + Constants.DEFAULT_APIM_API_DEPLOYER + "ai-service-providers/" + providerId + "/models";
+    }
+
     /** Admin REST API — application throttling policies (create/list). */
     public static String getApplicationThrottlingPoliciesURL(String baseUrl) {
         return baseUrl + Constants.DEFAULT_APIM_ADMIN + "throttling/policies/application";
@@ -437,6 +583,127 @@ public class Utils {
         return baseUrl + Constants.DEFAULT_APIM_ADMIN + "throttling/policies/advanced/" + policyId;
     }
 
+    /** Admin REST API — throttling policies of a given type (create/list): {@code application|subscription|advanced|custom}. */
+    public static String getThrottlingPoliciesByTypeURL(String baseUrl, String policyType) {
+        return baseUrl + Constants.DEFAULT_APIM_ADMIN + "throttling/policies/" + policyType;
+    }
+
+    /** Admin REST API — a single throttling policy of a given type by id (get/update/delete). */
+    public static String getThrottlingPolicyByTypeURL(String baseUrl, String policyType, String policyId) {
+        return baseUrl + Constants.DEFAULT_APIM_ADMIN + "throttling/policies/" + policyType + "/" + policyId;
+    }
+
+    /** Admin REST API — gateway environments (create/list). */
+    public static String getEnvironmentsURL(String baseUrl) {
+        return baseUrl + Constants.DEFAULT_APIM_ADMIN + "environments";
+    }
+
+    /** Admin REST API — a single gateway environment by id (get/update/delete). */
+    public static String getEnvironmentByIdURL(String baseUrl, String environmentId) {
+        return baseUrl + Constants.DEFAULT_APIM_ADMIN + "environments/" + environmentId;
+    }
+
+    /** Admin REST API — the gateway instances of an environment. */
+    public static String getEnvironmentGatewaysURL(String baseUrl, String environmentId) {
+        return baseUrl + Constants.DEFAULT_APIM_ADMIN + "environments/" + environmentId + "/gateways";
+    }
+
+    /** Admin REST API — organizations collection (list/create). */
+    public static String getOrganizationsURL(String baseUrl) {
+        return baseUrl + Constants.DEFAULT_APIM_ADMIN + "organizations";
+    }
+
+    /** Admin REST API — a single organization by id (get/update/delete). */
+    public static String getOrganizationByIdURL(String baseUrl, String organizationId) {
+        return baseUrl + Constants.DEFAULT_APIM_ADMIN + "organizations/" + organizationId;
+    }
+
+    /** SOAP admin service — claim-metadata management (register local claims). */
+    public static String getClaimMetadataMgtServiceURL(String baseUrl) {
+        return baseUrl + "services/ClaimMetadataManagementService";
+    }
+
+    /** DevPortal REST API — key managers visible to the calling user's organization. */
+    public static String getDevportalKeyManagersURL(String baseUrl) {
+        return baseUrl + Constants.DEFAULT_DEVPORTAL + "key-managers";
+    }
+
+    /** Admin REST API — tenant configuration (get/update). */
+    public static String getTenantConfigURL(String baseUrl) {
+        return baseUrl + Constants.DEFAULT_APIM_ADMIN + "tenant-config";
+    }
+
+    /** Admin REST API — tenant configuration JSON schema (get). */
+    public static String getTenantConfigSchemaURL(String baseUrl) {
+        return baseUrl + Constants.DEFAULT_APIM_ADMIN + "tenant-config-schema";
+    }
+
+    /** Admin REST API — system-scope role-alias mappings (get/put). */
+    public static String getRoleAliasesURL(String baseUrl) {
+        return baseUrl + Constants.DEFAULT_APIM_ADMIN + "system-scopes/role-aliases";
+    }
+
+    /** Admin REST API — export a throttling policy by name + type ({@code sub}/{@code app}/{@code api}/{@code global}). */
+    public static String getThrottlePolicyExportURL(String baseUrl, String name, String type) {
+        return baseUrl + Constants.DEFAULT_APIM_ADMIN + "throttling/policies/export?name="
+                + java.net.URLEncoder.encode(name, java.nio.charset.StandardCharsets.UTF_8) + "&type=" + type;
+    }
+
+    /** Admin REST API — import a throttling policy (multipart file); {@code overwrite} controls update vs conflict. */
+    public static String getThrottlePolicyImportURL(String baseUrl, String overwrite) {
+        return baseUrl + Constants.DEFAULT_APIM_ADMIN + "throttling/policies/import?overwrite=" + overwrite;
+    }
+
+    /** Admin REST API — deny (blocking-condition) policies collection (list/create). */
+    public static String getDenyPoliciesURL(String baseUrl) {
+        return baseUrl + Constants.DEFAULT_APIM_ADMIN + "throttling/deny-policies";
+    }
+
+    /** Admin REST API — a single deny policy by condition id (get/update-status/delete). NOTE: singular path. */
+    public static String getDenyPolicyByIdURL(String baseUrl, String conditionId) {
+        return baseUrl + Constants.DEFAULT_APIM_ADMIN + "throttling/deny-policy/" + conditionId;
+    }
+
+    /** Admin REST API — key managers collection (list/create). */
+    public static String getKeyManagersURL(String baseUrl) {
+        return baseUrl + Constants.DEFAULT_APIM_ADMIN + "key-managers";
+    }
+
+    /** Admin REST API — a single key manager by id (get/update/delete). */
+    public static String getKeyManagerByIdURL(String baseUrl, String keyManagerId) {
+        return baseUrl + Constants.DEFAULT_APIM_ADMIN + "key-managers/" + keyManagerId;
+    }
+
+    /** Governance REST API — rulesets collection (list/create). */
+    public static String getGovernanceRulesetsURL(String baseUrl) {
+        return baseUrl + Constants.DEFAULT_APIM_GOVERNANCE + "rulesets";
+    }
+
+    /** Governance REST API — a single ruleset by id (get/update/delete). */
+    public static String getGovernanceRulesetByIdURL(String baseUrl, String rulesetId) {
+        return baseUrl + Constants.DEFAULT_APIM_GOVERNANCE + "rulesets/" + rulesetId;
+    }
+
+    /** Governance REST API — the raw ruleset content by id. */
+    public static String getGovernanceRulesetContentURL(String baseUrl, String rulesetId) {
+        return baseUrl + Constants.DEFAULT_APIM_GOVERNANCE + "rulesets/" + rulesetId + "/content";
+    }
+
+    /** Governance REST API — policies collection (list/create). */
+    public static String getGovernancePoliciesURL(String baseUrl) {
+        return baseUrl + Constants.DEFAULT_APIM_GOVERNANCE + "policies";
+    }
+
+    /** Governance REST API — a single policy by id (get/update/delete). */
+    public static String getGovernancePolicyByIdURL(String baseUrl, String policyId) {
+        return baseUrl + Constants.DEFAULT_APIM_GOVERNANCE + "policies/" + policyId;
+    }
+
+    /** Governance REST API — artifact compliance for an API by id. */
+    public static String getGovernanceApiComplianceURL(String baseUrl, String apiId) {
+        return baseUrl + Constants.DEFAULT_APIM_GOVERNANCE + "artifact-compliance/api/" + apiId;
+    }
+
     /** Admin REST API — custom (Siddhi) throttling rules (create/list). */
     public static String getCustomThrottlingPoliciesURL(String baseUrl) {
         return baseUrl + Constants.DEFAULT_APIM_ADMIN + "throttling/policies/custom";
@@ -455,9 +722,36 @@ public class Utils {
         return baseUrl + Constants.DEFAULT_APIM_API_DEPLOYER + "apis/import-openapi";
     }
 
+    /** Publisher REST API — OpenAPI definition validation (multipart file / url). */
+    public static String getValidateOpenAPIURL(String baseUrl) {
+        return baseUrl + Constants.DEFAULT_APIM_API_DEPLOYER + "apis/validate-openapi";
+    }
+
+    /** Publisher REST API — linter custom rules. */
+    public static String getLinterCustomRulesURL(String baseUrl) {
+        return baseUrl + Constants.DEFAULT_APIM_API_DEPLOYER + "linter-custom-rules";
+    }
+
+    /** Publisher REST API — available throttling policies for a policy level (subscription / api / application). */
+    public static String getPublisherThrottlingPoliciesURL(String baseUrl, String policyLevel) {
+        return baseUrl + Constants.DEFAULT_APIM_API_DEPLOYER + "throttling-policies/" + policyLevel;
+    }
+
 
     public static String getInternalAPIKey(String baseUrl, String apiId) {
         return baseUrl + Constants.DEFAULT_APIM_API_DEPLOYER + "apis/" + apiId + "/generate-key";
+    }
+
+    /** Publisher REST API — an API Product's swagger/OpenAPI definition. */
+    public static String getAPIProductSwaggerURL(String baseUrl, String apiProductId) {
+        return baseUrl + Constants.DEFAULT_APIM_API_DEPLOYER + "api-products/" + apiProductId + "/swagger";
+    }
+
+    /** Publisher REST API — create a new version of an API Product (copy). */
+    public static String getAPIProductNewVersionURL(String baseUrl, String newVersion, boolean defaultVersion,
+                                                    String apiProductId) {
+        return baseUrl + Constants.DEFAULT_APIM_API_DEPLOYER + "api-products/copy-api-products?newVersion="
+                + newVersion + "&defaultVersion=" + defaultVersion + "&apiProductId=" + apiProductId;
     }
 
     // --- API-bound API Key endpoints (devportal) ---
@@ -532,6 +826,25 @@ public class Utils {
             return JsonPath.read(jsonPayload, jsonPath);
         } catch (Exception e) {
             throw new IOException("Path '" + jsonPath + "' not found or invalid in JSON payload.", e);
+        }
+    }
+
+    /**
+     * Finds an entry by {@code name} in a paginated list payload ({@code {"list":[{"id","name",...}]}}) and
+     * returns its {@code id}, or {@code null} if no entry matches. Used to reference a named resource (e.g. a
+     * built-in governance ruleset) whose id is not known ahead of time.
+     */
+    public static String extractIdByName(String jsonPayload, String name) throws IOException {
+
+        if (StringUtils.isBlank(jsonPayload)) {
+            throw new IOException("JSON payload is null or empty.");
+        }
+        try {
+            java.util.List<Object> ids = JsonPath.read(jsonPayload,
+                    "$.list[?(@.name == '" + name + "')].id");
+            return ids.isEmpty() ? null : String.valueOf(ids.get(0));
+        } catch (Exception e) {
+            throw new IOException("Failed to locate id for name '" + name + "' in list payload.", e);
         }
     }
 

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/utils/clients/SimpleHTTPClient.java
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/utils/clients/SimpleHTTPClient.java
@@ -25,6 +25,7 @@ import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpHead;
 import org.apache.http.client.methods.HttpPatch;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
@@ -136,6 +137,93 @@ public class SimpleHTTPClient {
         setHeaders(headers, request);
         try (CloseableHttpResponse response = client.execute(request)) {
             return constructResponse(response);
+        }
+    }
+
+    /**
+     * Send a HTTP HEAD request to the specified URL. Used for existence-check endpoints that respond with a
+     * status code and no body (e.g. publisher role validation {@code HEAD /roles/{roleId}}).
+     *
+     * @param url     Target endpoint URL
+     * @param headers Any HTTP headers that should be added to the request
+     * @return Returned HTTP response (status code; body is empty for HEAD)
+     * @throws IOException If an error occurs while making the invocation
+     */
+    public org.wso2.carbon.automation.test.utils.http.client.HttpResponse doHead(String url, Map<String, String> headers)
+            throws IOException {
+
+        HttpHead request = new HttpHead(url);
+        setHeaders(headers, request);
+        try (CloseableHttpResponse response = client.execute(request)) {
+            return constructResponse(response);
+        }
+    }
+
+    /**
+     * Send a HTTP GET request WITHOUT URI normalization, so a percent-encoded path (e.g. {@code %28}/{@code %29})
+     * is sent to the server verbatim rather than being decoded by the client. Needed to test how the gateway
+     * routes an encoded URI path segment — the default {@link #doGet} lets Apache HttpClient normalize/decode the
+     * path, changing what the gateway receives.
+     *
+     * @param url     Target endpoint URL (with any percent-encoding already applied)
+     * @param headers Any HTTP headers that should be added to the request
+     * @return Returned HTTP response
+     * @throws IOException If an error occurs while making the invocation
+     */
+    public org.wso2.carbon.automation.test.utils.http.client.HttpResponse doGetRaw(String url,
+            Map<String, String> headers) throws IOException {
+
+        HttpGet request = new HttpGet(url);
+        request.setConfig(RequestConfig.custom().setNormalizeUri(false).build());
+        setHeaders(headers, request);
+        try (CloseableHttpResponse response = client.execute(request)) {
+            return constructResponse(response);
+        }
+    }
+
+    /**
+     * Send a HTTPS GET presenting a CLIENT CERTIFICATE (mutual SSL). Builds a transient HttpClient whose
+     * SSLContext loads the given JKS keystore's KEY material (the client cert + private key) — so the client
+     * offers that cert during the TLS handshake — while still trusting the gateway's server cert (trust-all).
+     * Used to invoke an API whose securityScheme is {@code mutualssl}/{@code mutualssl_mandatory}. The singleton
+     * client can't do this (it loads no key material), so this is a per-call client keyed to the keystore.
+     *
+     * @param clientKeyStorePath filesystem path to the client JKS keystore
+     * @param keyStorePassword   the keystore (and key) password
+     * @param url                target gateway HTTPS URL
+     * @param headers            request headers
+     * @return the HTTP response
+     * @throws IOException on connectivity or keystore/SSL setup failure
+     */
+    public org.wso2.carbon.automation.test.utils.http.client.HttpResponse doMutualSSLGet(
+            String clientKeyStorePath, String keyStorePassword, String url, Map<String, String> headers)
+            throws IOException {
+        try {
+            KeyStore clientKeyStore = KeyStore.getInstance("JKS");
+            try (InputStream in = new FileInputStream(clientKeyStorePath)) {
+                clientKeyStore.load(in, keyStorePassword.toCharArray());
+            }
+            KeyStore emptyTrustStore = KeyStore.getInstance(KeyStore.getDefaultType());
+            emptyTrustStore.load(null, null);
+            SSLContext sslContext = SSLContexts.custom()
+                    .loadTrustMaterial(emptyTrustStore, new TrustAllStrategy())
+                    .loadKeyMaterial(clientKeyStore, keyStorePassword.toCharArray())
+                    .build();
+            SSLConnectionSocketFactory sslSocketFactory =
+                    new SSLConnectionSocketFactory(sslContext, NoopHostnameVerifier.INSTANCE);
+            try (CloseableHttpClient mtlsClient = HttpClients.custom()
+                    .setSSLSocketFactory(sslSocketFactory)
+                    .setDefaultRequestConfig(RequestConfig.custom().setRedirectsEnabled(false).build())
+                    .disableCookieManagement()
+                    .build()) {
+                HttpGet request = new HttpGet(url);
+                setHeaders(headers, request);
+                try (CloseableHttpResponse response = mtlsClient.execute(request)) {
+                    return constructResponse(response);
+                }
+            }
+        } catch (java.security.GeneralSecurityException e) {
+            throw new IOException("Failed to build mutual-SSL client for keystore " + clientKeyStorePath, e);
         }
     }
 

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/utils/listeners/BlockLifecycleListener.java
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/utils/listeners/BlockLifecycleListener.java
@@ -61,6 +61,9 @@ public class BlockLifecycleListener implements ITestListener {
     static final String CONTAINER_KEY = "blockApimContainer";
     static final String BASE_URL_KEY = "baseUrl";
     static final String BASE_GATEWAY_URL_KEY = "baseGatewayUrl";
+    static final String BASE_GATEWAY_WS_URL_KEY = "baseGatewayWsUrl";
+    static final String BASE_GATEWAY_WSS_URL_KEY = "baseGatewayWssUrl";
+    static final String GATEWAY_CLIENT_IP_KEY = "gatewayClientIp";
 
     /** Optional {@code <parameter>} names read from the block's {@code <test>}. */
     static final String PARAM_BLOCK_LABEL = "blockLabel";
@@ -127,6 +130,9 @@ public class BlockLifecycleListener implements ITestListener {
             TestContext.setShared(CONTAINER_KEY, container);
             TestContext.setShared(BASE_URL_KEY, baseUrl);
             TestContext.setShared(BASE_GATEWAY_URL_KEY, gatewayUrl);
+            TestContext.setShared(BASE_GATEWAY_WS_URL_KEY, container.getGatewayWsUrl());
+            TestContext.setShared(BASE_GATEWAY_WSS_URL_KEY, container.getGatewayWssUrl());
+            TestContext.setShared(GATEWAY_CLIENT_IP_KEY, container.getGatewayClientIp());
             logger.info("Block '" + label + "' booted and ready: baseUrl=" + baseUrl
                     + " baseGatewayUrl=" + gatewayUrl);
 

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/artifacts/configFiles/applicationAttributes/deployment.toml
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/artifacts/configFiles/applicationAttributes/deployment.toml
@@ -1,0 +1,25 @@
+# Feature-specific TOML overlay for the IntegrationV2-ApplicationAttributes block.
+#
+# Merged ON TOP of the shared `basic` overlay (which is itself merged onto the product distribution
+# deployment.toml) via the block's `tomlExtraOverlayPath` parameter — so only the extra keys this feature
+# needs live here; everything else (DB, ports, gateway wiring) is inherited.
+#
+# Ports the config of the legacy ApplicationAttributesTestCase:
+#   - [apim.jwt] enable = true : turns on backend JWT generation, so the gateway injects the
+#     X-JWT-Assertion header (carrying the application-attribute claims) towards the backend.
+#   - [[apim.devportal.application_attributes]] : declares a custom application attribute
+#     ("External Reference Id"). required=true means every Developer Portal application creation in this
+#     block must supply it (this is also what makes the "reject create without the attribute" negative real).
+
+[apim.jwt]
+enable = true
+encoding = "base64"
+claim_dialect = "http://wso2.org/claims"
+header = "X-JWT-Assertion"
+signing_algorithm = "SHA256withRSA"
+
+[[apim.devportal.application_attributes]]
+required = true
+hidden = false
+name = "External Reference Id"
+description = "External Reference Id"

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/artifacts/payloads/OAS/mcp_petstore_oas3.json
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/artifacts/payloads/OAS/mcp_petstore_oas3.json
@@ -1,0 +1,48 @@
+{
+  "openapi": "3.0.0",
+  "info": { "version": "1.0.0", "title": "Petstore MCP Backend", "license": { "name": "MIT" } },
+  "servers": [ { "url": "http://petstore.example/v1" } ],
+  "paths": {
+    "/pets": {
+      "get": {
+        "summary": "Get a list of pets",
+        "description": "Get a list of pets",
+        "operationId": "get_pets",
+        "responses": {
+          "200": {
+            "description": "A list of pets",
+            "content": { "application/json": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/Pet" } } } }
+          }
+        }
+      }
+    },
+    "/pets/{petId}": {
+      "get": {
+        "summary": "Get a pet by ID",
+        "description": "Get a pet by ID",
+        "operationId": "get_pets_by_petId",
+        "parameters": [
+          { "name": "petId", "in": "path", "required": true, "description": "The id of the pet to retrieve", "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": {
+            "description": "A pet",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Pet" } } }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Pet": {
+        "type": "object",
+        "required": ["id", "name"],
+        "properties": {
+          "id": { "type": "integer", "format": "int64" },
+          "name": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/artifacts/payloads/ai/ai-service-provider-config-no-auth.json
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/artifacts/payloads/ai/ai-service-provider-config-no-auth.json
@@ -1,0 +1,46 @@
+{
+  "connectorType": "mistralAi_1.0.0",
+  "authenticationConfiguration": {
+    "enabled": false,
+    "type": "none",
+    "parameters": {}
+  },
+  "metadata": [
+    {
+      "attributeName": "requestModel",
+      "inputSource": "payload",
+      "attributeIdentifier": "$.model",
+      "required": false
+    },
+    {
+      "attributeName": "responseModel",
+      "inputSource": "payload",
+      "attributeIdentifier": "$.model",
+      "required": true
+    },
+    {
+      "attributeName": "promptTokenCount",
+      "inputSource": "payload",
+      "attributeIdentifier": "$.usage.prompt_tokens",
+      "required": true
+    },
+    {
+      "attributeName": "completionTokenCount",
+      "inputSource": "payload",
+      "attributeIdentifier": "$.usage.completion_tokens",
+      "required": true
+    },
+    {
+      "attributeName": "totalTokenCount",
+      "inputSource": "payload",
+      "attributeIdentifier": "$.usage.total_tokens",
+      "required": true
+    },
+    {
+      "attributeName": "remainingTokenCount",
+      "inputSource": "header",
+      "attributeIdentifier": "x-ratelimit-remaining-tokens",
+      "required": false
+    }
+  ]
+}

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/artifacts/payloads/ai/ai-service-provider-config-with-auth.json
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/artifacts/payloads/ai/ai-service-provider-config-with-auth.json
@@ -1,0 +1,50 @@
+{
+  "connectorType": "mistralAi_1.0.0",
+  "authenticationConfiguration": {
+    "enabled": true,
+    "type": "apikey",
+    "parameters": {
+      "headerEnabled": true,
+      "queryParameterEnabled": false,
+      "headerName": "Authorization"
+    }
+  },
+  "metadata": [
+    {
+      "attributeName": "requestModel",
+      "inputSource": "payload",
+      "attributeIdentifier": "$.model",
+      "required": false
+    },
+    {
+      "attributeName": "responseModel",
+      "inputSource": "payload",
+      "attributeIdentifier": "$.model",
+      "required": true
+    },
+    {
+      "attributeName": "promptTokenCount",
+      "inputSource": "payload",
+      "attributeIdentifier": "$.usage.prompt_tokens",
+      "required": true
+    },
+    {
+      "attributeName": "completionTokenCount",
+      "inputSource": "payload",
+      "attributeIdentifier": "$.usage.completion_tokens",
+      "required": true
+    },
+    {
+      "attributeName": "totalTokenCount",
+      "inputSource": "payload",
+      "attributeIdentifier": "$.usage.total_tokens",
+      "required": true
+    },
+    {
+      "attributeName": "remainingTokenCount",
+      "inputSource": "header",
+      "attributeIdentifier": "x-ratelimit-remaining-tokens",
+      "required": false
+    }
+  ]
+}

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/artifacts/payloads/ai/mistral-def.json
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/artifacts/payloads/ai/mistral-def.json
@@ -1,0 +1,4055 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Mistral AI API",
+    "description": "Our Chat Completion and Embeddings APIs specification. Create your account on [La Plateforme](https://console.mistral.ai) to get access and read the [docs](https://docs.mistral.ai) to learn how to use it.",
+    "version": "0.0.2"
+  },
+  "paths": {
+    "/v1/models": {
+      "get": {
+        "summary": "List Models",
+        "description": "List all models available to the user.",
+        "operationId": "list_models_v1_models_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ModelList"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "models"
+        ]
+      }
+    },
+    "/v1/models/{model_id}": {
+      "get": {
+        "summary": "Retrieve Model",
+        "description": "Retrieve a model information.",
+        "operationId": "retrieve_model_v1_models__model_id__get",
+        "parameters": [
+          {
+            "name": "model_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Model Id"
+            },
+            "example": "ft:open-mistral-7b:587a6b29:20240514:7e773925",
+            "description": "The ID of the model to retrieve."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ModelCard"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "models"
+        ]
+      },
+      "delete": {
+        "summary": "Delete Model",
+        "description": "Delete a fine-tuned model.",
+        "operationId": "delete_model_v1_models__model_id__delete",
+        "parameters": [
+          {
+            "name": "model_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Model Id"
+            },
+            "example": "ft:open-mistral-7b:587a6b29:20240514:7e773925",
+            "description": "The ID of the model to delete."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteModelOut"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "models"
+        ]
+      }
+    },
+    "/v1/files": {
+      "post": {
+        "operationId": "files_api_routes_upload_file",
+        "summary": "Upload File",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UploadFileOut"
+                }
+              }
+            }
+          }
+        },
+        "description": "Upload a file that can be used across various endpoints.\n\nThe size of individual files can be a maximum of 512 MB. The Fine-tuning API only supports .jsonl files.\n\nPlease contact us if you need to increase these storage limits.",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "title": "MultiPartBodyParams",
+                "type": "object",
+                "properties": {
+                  "purpose": {
+                    "const": "fine-tune",
+                    "default": "fine-tune",
+                    "enum": [
+                      "fine-tune"
+                    ],
+                    "title": "Purpose",
+                    "type": "string"
+                  },
+                  "file": {
+                    "format": "binary",
+                    "title": "File",
+                    "type": "string",
+                    "description": "The File object (not file name) to be uploaded.\n To upload a file and specify a custom file name you should format your request as such:\n ```bash\n file=@path/to/your/file.jsonl;filename=custom_name.jsonl\n ```\n Otherwise, you can just keep the original file name:\n ```bash\n file=@path/to/your/file.jsonl\n ```"
+                  }
+                },
+                "required": [
+                  "file"
+                ]
+              }
+            }
+          },
+          "required": true
+        },
+        "tags": [
+          "files"
+        ]
+      },
+      "get": {
+        "operationId": "files_api_routes_list_files",
+        "summary": "List Files",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListFilesOut"
+                }
+              }
+            }
+          }
+        },
+        "description": "Returns a list of files that belong to the user's organization.",
+        "tags": [
+          "files"
+        ]
+      }
+    },
+    "/v1/files/{file_id}": {
+      "get": {
+        "operationId": "files_api_routes_retrieve_file",
+        "summary": "Retrieve File",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "file_id",
+            "schema": {
+              "title": "File Id",
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RetrieveFileOut"
+                }
+              }
+            }
+          }
+        },
+        "description": "Returns information about a specific file.",
+        "tags": [
+          "files"
+        ]
+      },
+      "delete": {
+        "operationId": "files_api_routes_delete_file",
+        "summary": "Delete File",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "file_id",
+            "schema": {
+              "title": "File Id",
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteFileOut"
+                }
+              }
+            }
+          }
+        },
+        "description": "Delete a file.",
+        "tags": [
+          "files"
+        ]
+      }
+    },
+    "/v1/fine_tuning/jobs": {
+      "get": {
+        "operationId": "jobs_api_routes_fine_tuning_get_fine_tuning_jobs",
+        "summary": "Get Fine Tuning Jobs",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "default": 0,
+              "title": "Page",
+              "type": "integer"
+            },
+            "required": false,
+            "description": "The page number of the results to be returned."
+          },
+          {
+            "in": "query",
+            "name": "page_size",
+            "schema": {
+              "default": 100,
+              "title": "Page Size",
+              "type": "integer"
+            },
+            "required": false,
+            "description": "The number of items to return per page."
+          },
+          {
+            "in": "query",
+            "name": "model",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Model"
+            },
+            "required": false,
+            "description": "The model name used for fine-tuning to filter on. When set, the other results are not displayed."
+          },
+          {
+            "in": "query",
+            "name": "created_after",
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Created After"
+            },
+            "required": false,
+            "description": "The date/time to filter on. When set, the results for previous creation times are not displayed."
+          },
+          {
+            "in": "query",
+            "name": "created_by_me",
+            "schema": {
+              "default": false,
+              "title": "Created By Me",
+              "type": "boolean"
+            },
+            "required": false,
+            "description": "When set, only return results for jobs created by the API caller. Other results are not displayed."
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "schema": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "QUEUED",
+                    "STARTED",
+                    "VALIDATING",
+                    "VALIDATED",
+                    "RUNNING",
+                    "FAILED_VALIDATION",
+                    "FAILED",
+                    "SUCCESS",
+                    "CANCELLED",
+                    "CANCELLATION_REQUESTED"
+                  ],
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Status"
+            },
+            "required": false,
+            "description": "The current job state to filter on. When set, the other results are not displayed."
+          },
+          {
+            "in": "query",
+            "name": "wandb_project",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Wandb Project"
+            },
+            "required": false,
+            "description": "The Weights and Biases project to filter on. When set, the other results are not displayed."
+          },
+          {
+            "in": "query",
+            "name": "wandb_name",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Wandb Name"
+            },
+            "required": false,
+            "description": "The Weight and Biases run name to filter on. When set, the other results are not displayed."
+          },
+          {
+            "in": "query",
+            "name": "suffix",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Suffix"
+            },
+            "required": false,
+            "description": "The model suffix to filter on. When set, the other results are not displayed."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JobsOut"
+                }
+              }
+            }
+          }
+        },
+        "description": "Get a list of fine-tuning jobs for your organization and user.",
+        "tags": [
+          "fine-tuning"
+        ]
+      },
+      "post": {
+        "operationId": "jobs_api_routes_fine_tuning_create_fine_tuning_job",
+        "summary": "Create Fine Tuning Job",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "dry_run",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Dry Run"
+            },
+            "required": false,
+            "description": "* If `true` the job is not spawned, instead the query returns a handful of useful metadata\n  for the user to perform sanity checks (see `LegacyJobMetadataOut` response).\n* Otherwise, the job is started and the query returns the job ID along with some of the\n  input parameters (see `JobOut` response).\n"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/JobOut"
+                    },
+                    {
+                      "$ref": "#/components/schemas/LegacyJobMetadataOut"
+                    }
+                  ],
+                  "title": "Response"
+                }
+              }
+            }
+          }
+        },
+        "description": "Create a new fine-tuning job, it will be queued for processing.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JobIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "tags": [
+          "fine-tuning"
+        ]
+      }
+    },
+    "/v1/fine_tuning/jobs/{job_id}": {
+      "get": {
+        "operationId": "jobs_api_routes_fine_tuning_get_fine_tuning_job",
+        "summary": "Get Fine Tuning Job",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "job_id",
+            "schema": {
+              "format": "uuid",
+              "title": "Job Id",
+              "type": "string"
+            },
+            "required": true,
+            "description": "The ID of the job to analyse."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DetailedJobOut"
+                }
+              }
+            }
+          }
+        },
+        "description": "Get a fine-tuned job details by its UUID.",
+        "tags": [
+          "fine-tuning"
+        ]
+      }
+    },
+    "/v1/fine_tuning/jobs/{job_id}/cancel": {
+      "post": {
+        "operationId": "jobs_api_routes_fine_tuning_cancel_fine_tuning_job",
+        "summary": "Cancel Fine Tuning Job",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "job_id",
+            "schema": {
+              "format": "uuid",
+              "title": "Job Id",
+              "type": "string"
+            },
+            "required": true,
+            "description": "The ID of the job to cancel."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DetailedJobOut"
+                }
+              }
+            }
+          }
+        },
+        "description": "Request the cancellation of a fine tuning job.",
+        "tags": [
+          "fine-tuning"
+        ]
+      }
+    },
+    "/v1/fine_tuning/jobs/{job_id}/start": {
+      "post": {
+        "operationId": "jobs_api_routes_fine_tuning_start_fine_tuning_job",
+        "summary": "Start Fine Tuning Job",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "job_id",
+            "schema": {
+              "format": "uuid",
+              "title": "Job Id",
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DetailedJobOut"
+                }
+              }
+            }
+          }
+        },
+        "description": "Request the start of a validated fine tuning job.",
+        "tags": [
+          "fine-tuning"
+        ]
+      }
+    },
+    "/v1/fine_tuning/models/{model_id}": {
+      "patch": {
+        "operationId": "jobs_api_routes_fine_tuning_update_fine_tuned_model",
+        "summary": "Update Fine Tuned Model",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "model_id",
+            "schema": {
+              "title": "Model Id",
+              "type": "string"
+            },
+            "required": true,
+            "example": "ft:open-mistral-7b:587a6b29:20240514:7e773925",
+            "description": "The ID of the model to update."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FTModelOut"
+                }
+              }
+            }
+          }
+        },
+        "description": "Update a model name or description.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateFTModelIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "tags": [
+          "models"
+        ]
+      }
+    },
+    "/v1/fine_tuning/models/{model_id}/archive": {
+      "post": {
+        "operationId": "jobs_api_routes_fine_tuning_archive_fine_tuned_model",
+        "summary": "Archive Fine Tuned Model",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "model_id",
+            "schema": {
+              "title": "Model Id",
+              "type": "string"
+            },
+            "required": true,
+            "example": "ft:open-mistral-7b:587a6b29:20240514:7e773925",
+            "description": "The ID of the model to archive."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ArchiveFTModelOut"
+                }
+              }
+            }
+          }
+        },
+        "description": "Archive a fine-tuned model.",
+        "tags": [
+          "models"
+        ]
+      },
+      "delete": {
+        "operationId": "jobs_api_routes_fine_tuning_unarchive_fine_tuned_model",
+        "summary": "Unarchive Fine Tuned Model",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "model_id",
+            "schema": {
+              "title": "Model Id",
+              "type": "string"
+            },
+            "required": true,
+            "example": "ft:open-mistral-7b:587a6b29:20240514:7e773925",
+            "description": "The ID of the model to unarchive."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnarchiveFTModelOut"
+                }
+              }
+            }
+          }
+        },
+        "description": "Un-archive a fine-tuned model.",
+        "tags": [
+          "models"
+        ]
+      }
+    },
+    "/v1/chat/completions": {
+      "post": {
+        "summary": "Chat Completion",
+        "operationId": "chat_completion_v1_chat_completions_post",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChatCompletionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChatCompletionResponse"
+                }
+              },
+              "text/event-stream": {
+                "schema": {
+                  "$ref": "#/components/schemas/CompletionEvent"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "chat"
+        ]
+      }
+    },
+    "/v1/fim/completions": {
+      "post": {
+        "summary": "Fim Completion",
+        "description": "FIM completion.",
+        "operationId": "fim_completion_v1_fim_completions_post",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FIMCompletionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FIMCompletionResponse"
+                }
+              },
+              "text/event-stream": {
+                "schema": {
+                  "$ref": "#/components/schemas/CompletionEvent"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "fim"
+        ]
+      }
+    },
+    "/v1/agents/completions": {
+      "post": {
+        "summary": "Agents Completion",
+        "operationId": "agents_completion_v1_agents_completions_post",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentsCompletionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChatCompletionResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "agents"
+        ]
+      }
+    },
+    "/v1/embeddings": {
+      "post": {
+        "summary": "Embeddings",
+        "description": "Embeddings",
+        "operationId": "embeddings_v1_embeddings_post",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EmbeddingRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EmbeddingResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "embeddings"
+        ]
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "DeleteModelOut": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id",
+            "description": "The ID of the deleted model.",
+            "examples": [
+              "ft:open-mistral-7b:587a6b29:20240514:7e773925"
+            ]
+          },
+          "object": {
+            "type": "string",
+            "title": "Object",
+            "default": "model",
+            "description": "The object type that was deleted"
+          },
+          "deleted": {
+            "type": "boolean",
+            "title": "Deleted",
+            "default": true,
+            "description": "The deletion status",
+            "examples": [
+              true
+            ]
+          }
+        },
+        "type": "object",
+        "required": [
+          "id"
+        ],
+        "title": "DeleteModelOut"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "ModelCapabilities": {
+        "properties": {
+          "completion_chat": {
+            "type": "boolean",
+            "title": "Completion Chat",
+            "default": true
+          },
+          "completion_fim": {
+            "type": "boolean",
+            "title": "Completion Fim",
+            "default": false
+          },
+          "function_calling": {
+            "type": "boolean",
+            "title": "Function Calling",
+            "default": true
+          },
+          "fine_tuning": {
+            "type": "boolean",
+            "title": "Fine Tuning",
+            "default": false
+          }
+        },
+        "type": "object",
+        "title": "ModelCapabilities"
+      },
+      "ModelCard": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "object": {
+            "type": "string",
+            "title": "Object",
+            "default": "model"
+          },
+          "created": {
+            "type": "integer",
+            "title": "Created"
+          },
+          "owned_by": {
+            "type": "string",
+            "title": "Owned By",
+            "default": "mistralai"
+          },
+          "root": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Root"
+          },
+          "archived": {
+            "type": "boolean",
+            "title": "Archived",
+            "default": false
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "capabilities": {
+            "$ref": "#/components/schemas/ModelCapabilities"
+          },
+          "max_context_length": {
+            "type": "integer",
+            "title": "Max Context Length",
+            "default": 32768
+          },
+          "aliases": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Aliases",
+            "default": []
+          },
+          "deprecation": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Deprecation"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "capabilities"
+        ],
+        "title": "ModelCard"
+      },
+      "ModelList": {
+        "properties": {
+          "object": {
+            "type": "string",
+            "title": "Object",
+            "default": "list"
+          },
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/ModelCard"
+            },
+            "type": "array",
+            "title": "Data"
+          }
+        },
+        "type": "object",
+        "title": "ModelList"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      },
+      "SampleType": {
+        "enum": [
+          "pretrain",
+          "instruct"
+        ],
+        "title": "SampleType",
+        "type": "string"
+      },
+      "Source": {
+        "enum": [
+          "upload",
+          "repository"
+        ],
+        "title": "Source",
+        "type": "string"
+      },
+      "UploadFileOut": {
+        "properties": {
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string",
+            "description": "The unique identifier of the file.",
+            "examples": [
+              "497f6eca-6276-4993-bfeb-53cbbbba6f09"
+            ]
+          },
+          "object": {
+            "title": "Object",
+            "type": "string",
+            "description": "The object type, which is always \"file\".",
+            "examples": [
+              "file"
+            ]
+          },
+          "bytes": {
+            "title": "Bytes",
+            "type": "integer",
+            "description": "The size of the file, in bytes.",
+            "examples": [
+              13000
+            ]
+          },
+          "created_at": {
+            "title": "Created At",
+            "type": "integer",
+            "description": "The UNIX timestamp (in seconds) of the event.",
+            "examples": [
+              1716963433
+            ]
+          },
+          "filename": {
+            "title": "Filename",
+            "type": "string",
+            "description": "The name of the uploaded file.",
+            "examples": [
+              "files_upload.jsonl"
+            ]
+          },
+          "purpose": {
+            "const": "fine-tune",
+            "enum": [
+              "fine-tune"
+            ],
+            "title": "Purpose",
+            "type": "string",
+            "description": "The intended purpose of the uploaded file. Only accepts fine-tuning (`fine-tune`) for now.",
+            "examples": [
+              "fine-tune"
+            ]
+          },
+          "sample_type": {
+            "$ref": "#/components/schemas/SampleType"
+          },
+          "num_lines": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Num Lines"
+          },
+          "source": {
+            "$ref": "#/components/schemas/Source"
+          }
+        },
+        "required": [
+          "id",
+          "object",
+          "bytes",
+          "created_at",
+          "filename",
+          "purpose",
+          "sample_type",
+          "source"
+        ],
+        "title": "UploadFileOut",
+        "type": "object"
+      },
+      "FileSchema": {
+        "properties": {
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string",
+            "description": "The unique identifier of the file.",
+            "examples": [
+              "497f6eca-6276-4993-bfeb-53cbbbba6f09"
+            ]
+          },
+          "object": {
+            "title": "Object",
+            "type": "string",
+            "description": "The object type, which is always \"file\".",
+            "examples": [
+              "file"
+            ]
+          },
+          "bytes": {
+            "title": "Bytes",
+            "type": "integer",
+            "description": "The size of the file, in bytes.",
+            "examples": [
+              13000
+            ]
+          },
+          "created_at": {
+            "title": "Created At",
+            "type": "integer",
+            "description": "The UNIX timestamp (in seconds) of the event.",
+            "examples": [
+              1716963433
+            ]
+          },
+          "filename": {
+            "title": "Filename",
+            "type": "string",
+            "description": "The name of the uploaded file.",
+            "examples": [
+              "files_upload.jsonl"
+            ]
+          },
+          "purpose": {
+            "const": "fine-tune",
+            "enum": [
+              "fine-tune"
+            ],
+            "title": "Purpose",
+            "type": "string",
+            "description": "The intended purpose of the uploaded file. Only accepts fine-tuning (`fine-tune`) for now.",
+            "examples": [
+              "fine-tune"
+            ]
+          },
+          "sample_type": {
+            "$ref": "#/components/schemas/SampleType"
+          },
+          "num_lines": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Num Lines"
+          },
+          "source": {
+            "$ref": "#/components/schemas/Source"
+          }
+        },
+        "required": [
+          "id",
+          "object",
+          "bytes",
+          "created_at",
+          "filename",
+          "purpose",
+          "sample_type",
+          "source"
+        ],
+        "title": "FileSchema",
+        "type": "object"
+      },
+      "ListFilesOut": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/FileSchema"
+            },
+            "title": "Data",
+            "type": "array"
+          },
+          "object": {
+            "title": "Object",
+            "type": "string"
+          }
+        },
+        "required": [
+          "data",
+          "object"
+        ],
+        "title": "ListFilesOut",
+        "type": "object"
+      },
+      "RetrieveFileOut": {
+        "properties": {
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string",
+            "description": "The unique identifier of the file.",
+            "examples": [
+              "497f6eca-6276-4993-bfeb-53cbbbba6f09"
+            ]
+          },
+          "object": {
+            "title": "Object",
+            "type": "string",
+            "description": "The object type, which is always \"file\".",
+            "examples": [
+              "file"
+            ]
+          },
+          "bytes": {
+            "title": "Bytes",
+            "type": "integer",
+            "description": "The size of the file, in bytes.",
+            "examples": [
+              13000
+            ]
+          },
+          "created_at": {
+            "title": "Created At",
+            "type": "integer",
+            "description": "The UNIX timestamp (in seconds) of the event.",
+            "examples": [
+              1716963433
+            ]
+          },
+          "filename": {
+            "title": "Filename",
+            "type": "string",
+            "description": "The name of the uploaded file.",
+            "examples": [
+              "files_upload.jsonl"
+            ]
+          },
+          "purpose": {
+            "const": "fine-tune",
+            "enum": [
+              "fine-tune"
+            ],
+            "title": "Purpose",
+            "type": "string",
+            "description": "The intended purpose of the uploaded file. Only accepts fine-tuning (`fine-tune`) for now.",
+            "examples": [
+              "fine-tune"
+            ]
+          },
+          "sample_type": {
+            "$ref": "#/components/schemas/SampleType"
+          },
+          "num_lines": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Num Lines"
+          },
+          "source": {
+            "$ref": "#/components/schemas/Source"
+          }
+        },
+        "required": [
+          "id",
+          "object",
+          "bytes",
+          "created_at",
+          "filename",
+          "purpose",
+          "sample_type",
+          "source"
+        ],
+        "title": "RetrieveFileOut",
+        "type": "object"
+      },
+      "DeleteFileOut": {
+        "properties": {
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string",
+            "description": "The ID of the deleted file.",
+            "examples": [
+              "497f6eca-6276-4993-bfeb-53cbbbba6f09"
+            ]
+          },
+          "object": {
+            "title": "Object",
+            "type": "string",
+            "description": "The object type that was deleted",
+            "examples": [
+              "file"
+            ]
+          },
+          "deleted": {
+            "title": "Deleted",
+            "type": "boolean",
+            "description": "The deletion status.",
+            "examples": [
+              false
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "object",
+          "deleted"
+        ],
+        "title": "DeleteFileOut",
+        "type": "object"
+      },
+      "FineTuneableModel": {
+        "enum": [
+          "open-mistral-7b",
+          "mistral-small-latest",
+          "codestral-latest",
+          "mistral-large-latest",
+          "open-mistral-nemo"
+        ],
+        "title": "FineTuneableModel",
+        "type": "string",
+        "description": "The name of the model to fine-tune."
+      },
+      "GithubRepositoryOut": {
+        "properties": {
+          "type": {
+            "const": "github",
+            "default": "github",
+            "enum": [
+              "github"
+            ],
+            "title": "Type",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "owner": {
+            "title": "Owner",
+            "type": "string"
+          },
+          "ref": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ref"
+          },
+          "weight": {
+            "default": 1,
+            "exclusiveMinimum": 0,
+            "title": "Weight",
+            "type": "number"
+          },
+          "commit_id": {
+            "maxLength": 40,
+            "minLength": 40,
+            "title": "Commit Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "owner",
+          "commit_id"
+        ],
+        "title": "GithubRepositoryOut",
+        "type": "object"
+      },
+      "JobMetadataOut": {
+        "properties": {
+          "expected_duration_seconds": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expected Duration Seconds"
+          },
+          "cost": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cost"
+          },
+          "cost_currency": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cost Currency"
+          },
+          "train_tokens_per_step": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Train Tokens Per Step"
+          },
+          "train_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Train Tokens"
+          },
+          "data_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Data Tokens"
+          },
+          "estimated_start_time": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Estimated Start Time"
+          }
+        },
+        "title": "JobMetadataOut",
+        "type": "object"
+      },
+      "JobOut": {
+        "properties": {
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string",
+            "description": "The ID of the job."
+          },
+          "auto_start": {
+            "title": "Auto Start",
+            "type": "boolean"
+          },
+          "hyperparameters": {
+            "$ref": "#/components/schemas/TrainingParameters"
+          },
+          "model": {
+            "$ref": "#/components/schemas/FineTuneableModel"
+          },
+          "status": {
+            "enum": [
+              "QUEUED",
+              "STARTED",
+              "VALIDATING",
+              "VALIDATED",
+              "RUNNING",
+              "FAILED_VALIDATION",
+              "FAILED",
+              "SUCCESS",
+              "CANCELLED",
+              "CANCELLATION_REQUESTED"
+            ],
+            "title": "Status",
+            "type": "string",
+            "description": "The current status of the fine-tuning job."
+          },
+          "job_type": {
+            "title": "Job Type",
+            "type": "string",
+            "description": "The type of job (`FT` for fine-tuning)."
+          },
+          "created_at": {
+            "title": "Created At",
+            "type": "integer",
+            "description": "The UNIX timestamp (in seconds) for when the fine-tuning job was created."
+          },
+          "modified_at": {
+            "title": "Modified At",
+            "type": "integer",
+            "description": "The UNIX timestamp (in seconds) for when the fine-tuning job was last modified."
+          },
+          "training_files": {
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "title": "Training Files",
+            "type": "array",
+            "description": "A list containing the IDs of uploaded files that contain training data."
+          },
+          "validation_files": {
+            "anyOf": [
+              {
+                "items": {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": [],
+            "title": "Validation Files",
+            "description": "A list containing the IDs of uploaded files that contain validation data."
+          },
+          "object": {
+            "const": "job",
+            "default": "job",
+            "enum": [
+              "job"
+            ],
+            "title": "Object",
+            "type": "string",
+            "description": "The object type of the fine-tuning job."
+          },
+          "fine_tuned_model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fine Tuned Model",
+            "description": "The name of the fine-tuned model that is being created. The value will be `null` if the fine-tuning job is still running."
+          },
+          "suffix": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Suffix",
+            "description": "Optional text/code that adds more context for the model. When given a `prompt` and a `suffix` the model will fill what is between them. When `suffix` is not provided, the model will simply execute completion starting with `prompt`."
+          },
+          "integrations": {
+            "anyOf": [
+              {
+                "items": {
+                  "discriminator": {
+                    "mapping": {
+                      "wandb": "#/components/schemas/WandbIntegrationOut"
+                    },
+                    "propertyName": "type"
+                  },
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/WandbIntegrationOut"
+                    }
+                  ]
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Integrations",
+            "description": "A list of integrations enabled for your fine-tuning job."
+          },
+          "trained_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Trained Tokens",
+            "description": "Total number of tokens trained."
+          },
+          "repositories": {
+            "default": [],
+            "items": {
+              "discriminator": {
+                "mapping": {
+                  "github": "#/components/schemas/GithubRepositoryOut"
+                },
+                "propertyName": "type"
+              },
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/GithubRepositoryOut"
+                }
+              ]
+            },
+            "maxItems": 20,
+            "title": "Repositories",
+            "type": "array"
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/JobMetadataOut"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "auto_start",
+          "hyperparameters",
+          "model",
+          "status",
+          "job_type",
+          "created_at",
+          "modified_at",
+          "training_files"
+        ],
+        "title": "JobOut",
+        "type": "object"
+      },
+      "JobsOut": {
+        "properties": {
+          "data": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/JobOut"
+            },
+            "title": "Data",
+            "type": "array"
+          },
+          "object": {
+            "const": "list",
+            "default": "list",
+            "enum": [
+              "list"
+            ],
+            "title": "Object",
+            "type": "string"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "total"
+        ],
+        "title": "JobsOut",
+        "type": "object"
+      },
+      "TrainingParameters": {
+        "properties": {
+          "training_steps": {
+            "anyOf": [
+              {
+                "minimum": 1,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Training Steps"
+          },
+          "learning_rate": {
+            "default": 0.0001,
+            "maximum": 1,
+            "minimum": 1e-8,
+            "title": "Learning Rate",
+            "type": "number"
+          },
+          "weight_decay": {
+            "anyOf": [
+              {
+                "maximum": 1,
+                "minimum": 0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": 0.1,
+            "title": "Weight Decay"
+          },
+          "warmup_fraction": {
+            "anyOf": [
+              {
+                "maximum": 1,
+                "minimum": 0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": 0.05,
+            "title": "Warmup Fraction"
+          },
+          "epochs": {
+            "anyOf": [
+              {
+                "minimum": 0.01,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Epochs"
+          },
+          "fim_ratio": {
+            "anyOf": [
+              {
+                "maximum": 1,
+                "minimum": 0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": 0.9,
+            "title": "Fim Ratio"
+          }
+        },
+        "title": "TrainingParameters",
+        "type": "object"
+      },
+      "WandbIntegrationOut": {
+        "properties": {
+          "type": {
+            "const": "wandb",
+            "default": "wandb",
+            "enum": [
+              "wandb"
+            ],
+            "title": "Type",
+            "type": "string"
+          },
+          "project": {
+            "title": "Project",
+            "type": "string",
+            "description": "The name of the project that the new run will be created under."
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name",
+            "description": "A display name to set for the run. If not set, will use the job ID as the name."
+          },
+          "run_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Run Name"
+          }
+        },
+        "required": [
+          "project"
+        ],
+        "title": "WandbIntegrationOut",
+        "type": "object"
+      },
+      "LegacyJobMetadataOut": {
+        "properties": {
+          "expected_duration_seconds": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expected Duration Seconds",
+            "description": "The approximated time (in seconds) for the fine-tuning process to complete.",
+            "examples": [
+              220
+            ]
+          },
+          "cost": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cost",
+            "description": "The cost of the fine-tuning job.",
+            "examples": [
+              10
+            ]
+          },
+          "cost_currency": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cost Currency",
+            "description": "The currency used for the fine-tuning job cost.",
+            "examples": [
+              "EUR"
+            ]
+          },
+          "train_tokens_per_step": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Train Tokens Per Step",
+            "description": "The number of tokens consumed by one training step.",
+            "examples": [
+              131072
+            ]
+          },
+          "train_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Train Tokens",
+            "description": "The total number of tokens used during the fine-tuning process.",
+            "examples": [
+              1310720
+            ]
+          },
+          "data_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Data Tokens",
+            "description": "The total number of tokens in the training dataset.",
+            "examples": [
+              305375
+            ]
+          },
+          "estimated_start_time": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Estimated Start Time"
+          },
+          "deprecated": {
+            "default": true,
+            "title": "Deprecated",
+            "type": "boolean"
+          },
+          "details": {
+            "title": "Details",
+            "type": "string"
+          },
+          "epochs": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Epochs",
+            "description": "The number of complete passes through the entire training dataset.",
+            "examples": [
+              4.2922
+            ]
+          },
+          "training_steps": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Training Steps",
+            "description": "The number of training steps to perform. A training step refers to a single update of the model weights during the fine-tuning process. This update is typically calculated using a batch of samples from the training dataset.",
+            "examples": [
+              10
+            ]
+          },
+          "object": {
+            "const": "job.metadata",
+            "default": "job.metadata",
+            "enum": [
+              "job.metadata"
+            ],
+            "title": "Object",
+            "type": "string"
+          }
+        },
+        "required": [
+          "details"
+        ],
+        "title": "LegacyJobMetadataOut",
+        "type": "object"
+      },
+      "GithubRepositoryIn": {
+        "properties": {
+          "type": {
+            "const": "github",
+            "default": "github",
+            "enum": [
+              "github"
+            ],
+            "title": "Type",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "owner": {
+            "title": "Owner",
+            "type": "string"
+          },
+          "ref": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ref"
+          },
+          "weight": {
+            "default": 1,
+            "exclusiveMinimum": 0,
+            "title": "Weight",
+            "type": "number"
+          },
+          "token": {
+            "title": "Token",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "owner",
+          "token"
+        ],
+        "title": "GithubRepositoryIn",
+        "type": "object"
+      },
+      "JobIn": {
+        "properties": {
+          "model": {
+            "$ref": "#/components/schemas/FineTuneableModel"
+          },
+          "training_files": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/TrainingFile"
+            },
+            "title": "Training Files",
+            "type": "array"
+          },
+          "validation_files": {
+            "anyOf": [
+              {
+                "items": {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Validation Files",
+            "description": "A list containing the IDs of uploaded files that contain validation data. If you provide these files, the data is used to generate validation metrics periodically during fine-tuning. These metrics can be viewed in `checkpoints` when getting the status of a running fine-tuning job. The same data should not be present in both train and validation files."
+          },
+          "hyperparameters": {
+            "$ref": "#/components/schemas/TrainingParametersIn"
+          },
+          "suffix": {
+            "anyOf": [
+              {
+                "maxLength": 18,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Suffix",
+            "description": "A string that will be added to your fine-tuning model name. For example, a suffix of \"my-great-model\" would produce a model name like `ft:open-mistral-7b:my-great-model:xxx...`"
+          },
+          "integrations": {
+            "anyOf": [
+              {
+                "items": {
+                  "discriminator": {
+                    "mapping": {
+                      "wandb": "#/components/schemas/WandbIntegration"
+                    },
+                    "propertyName": "type"
+                  },
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/WandbIntegration"
+                    }
+                  ]
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Integrations",
+            "description": "A list of integrations to enable for your fine-tuning job."
+          },
+          "repositories": {
+            "default": [],
+            "items": {
+              "discriminator": {
+                "mapping": {
+                  "github": "#/components/schemas/GithubRepositoryIn"
+                },
+                "propertyName": "type"
+              },
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/GithubRepositoryIn"
+                }
+              ]
+            },
+            "title": "Repositories",
+            "type": "array"
+          },
+          "auto_start": {
+            "description": "This field will be required in a future release.",
+            "title": "Auto Start",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "model",
+          "hyperparameters"
+        ],
+        "title": "JobIn",
+        "type": "object"
+      },
+      "TrainingFile": {
+        "properties": {
+          "file_id": {
+            "format": "uuid",
+            "title": "File Id",
+            "type": "string"
+          },
+          "weight": {
+            "default": 1,
+            "exclusiveMinimum": 0,
+            "title": "Weight",
+            "type": "number"
+          }
+        },
+        "required": [
+          "file_id"
+        ],
+        "title": "TrainingFile",
+        "type": "object"
+      },
+      "TrainingParametersIn": {
+        "properties": {
+          "training_steps": {
+            "anyOf": [
+              {
+                "minimum": 1,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Training Steps",
+            "description": "The number of training steps to perform. A training step refers to a single update of the model weights during the fine-tuning process. This update is typically calculated using a batch of samples from the training dataset."
+          },
+          "learning_rate": {
+            "default": 0.0001,
+            "maximum": 1,
+            "minimum": 1e-8,
+            "title": "Learning Rate",
+            "type": "number",
+            "description": "A parameter describing how much to adjust the pre-trained model's weights in response to the estimated error each time the weights are updated during the fine-tuning process."
+          },
+          "weight_decay": {
+            "anyOf": [
+              {
+                "maximum": 1,
+                "minimum": 0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": 0.1,
+            "title": "Weight Decay",
+            "description": "(Advanced Usage) Weight decay adds a term to the loss function that is proportional to the sum of the squared weights. This term reduces the magnitude of the weights and prevents them from growing too large."
+          },
+          "warmup_fraction": {
+            "anyOf": [
+              {
+                "maximum": 1,
+                "minimum": 0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": 0.05,
+            "title": "Warmup Fraction",
+            "description": "(Advanced Usage) A parameter that specifies the percentage of the total training steps at which the learning rate warm-up phase ends. During this phase, the learning rate gradually increases from a small value to the initial learning rate, helping to stabilize the training process and improve convergence. Similar to `pct_start` in [mistral-finetune](https://github.com/mistralai/mistral-finetune)"
+          },
+          "epochs": {
+            "anyOf": [
+              {
+                "minimum": 0.01,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Epochs"
+          },
+          "fim_ratio": {
+            "anyOf": [
+              {
+                "maximum": 1,
+                "minimum": 0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": 0.9,
+            "title": "Fim Ratio"
+          }
+        },
+        "title": "TrainingParametersIn",
+        "type": "object",
+        "description": "The fine-tuning hyperparameter settings used in a fine-tune job."
+      },
+      "WandbIntegration": {
+        "properties": {
+          "type": {
+            "const": "wandb",
+            "default": "wandb",
+            "enum": [
+              "wandb"
+            ],
+            "title": "Type",
+            "type": "string"
+          },
+          "project": {
+            "title": "Project",
+            "type": "string",
+            "description": "The name of the project that the new run will be created under."
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name",
+            "description": "A display name to set for the run. If not set, will use the job ID as the name."
+          },
+          "api_key": {
+            "maxLength": 40,
+            "minLength": 40,
+            "title": "Api Key",
+            "type": "string",
+            "description": "The WandB API key to use for authentication."
+          },
+          "run_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Run Name"
+          }
+        },
+        "required": [
+          "project",
+          "api_key"
+        ],
+        "title": "WandbIntegration",
+        "type": "object"
+      },
+      "CheckpointOut": {
+        "properties": {
+          "metrics": {
+            "$ref": "#/components/schemas/MetricOut"
+          },
+          "step_number": {
+            "title": "Step Number",
+            "type": "integer",
+            "description": "The step number that the checkpoint was created at."
+          },
+          "created_at": {
+            "title": "Created At",
+            "type": "integer",
+            "description": "The UNIX timestamp (in seconds) for when the checkpoint was created.",
+            "examples": [
+              1716963433
+            ]
+          }
+        },
+        "required": [
+          "metrics",
+          "step_number",
+          "created_at"
+        ],
+        "title": "CheckpointOut",
+        "type": "object"
+      },
+      "DetailedJobOut": {
+        "properties": {
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "auto_start": {
+            "title": "Auto Start",
+            "type": "boolean"
+          },
+          "hyperparameters": {
+            "$ref": "#/components/schemas/TrainingParameters"
+          },
+          "model": {
+            "$ref": "#/components/schemas/FineTuneableModel"
+          },
+          "status": {
+            "enum": [
+              "QUEUED",
+              "STARTED",
+              "VALIDATING",
+              "VALIDATED",
+              "RUNNING",
+              "FAILED_VALIDATION",
+              "FAILED",
+              "SUCCESS",
+              "CANCELLED",
+              "CANCELLATION_REQUESTED"
+            ],
+            "title": "Status",
+            "type": "string"
+          },
+          "job_type": {
+            "title": "Job Type",
+            "type": "string"
+          },
+          "created_at": {
+            "title": "Created At",
+            "type": "integer"
+          },
+          "modified_at": {
+            "title": "Modified At",
+            "type": "integer"
+          },
+          "training_files": {
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "title": "Training Files",
+            "type": "array"
+          },
+          "validation_files": {
+            "anyOf": [
+              {
+                "items": {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": [],
+            "title": "Validation Files"
+          },
+          "object": {
+            "const": "job",
+            "default": "job",
+            "enum": [
+              "job"
+            ],
+            "title": "Object",
+            "type": "string"
+          },
+          "fine_tuned_model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fine Tuned Model"
+          },
+          "suffix": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Suffix"
+          },
+          "integrations": {
+            "anyOf": [
+              {
+                "items": {
+                  "discriminator": {
+                    "mapping": {
+                      "wandb": "#/components/schemas/WandbIntegrationOut"
+                    },
+                    "propertyName": "type"
+                  },
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/WandbIntegrationOut"
+                    }
+                  ]
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Integrations"
+          },
+          "trained_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Trained Tokens"
+          },
+          "repositories": {
+            "default": [],
+            "items": {
+              "discriminator": {
+                "mapping": {
+                  "github": "#/components/schemas/GithubRepositoryOut"
+                },
+                "propertyName": "type"
+              },
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/GithubRepositoryOut"
+                }
+              ]
+            },
+            "maxItems": 20,
+            "title": "Repositories",
+            "type": "array"
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/JobMetadataOut"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "events": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/EventOut"
+            },
+            "title": "Events",
+            "type": "array",
+            "description": "Event items are created every time the status of a fine-tuning job changes. The timestamped list of all events is accessible here."
+          },
+          "checkpoints": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/CheckpointOut"
+            },
+            "title": "Checkpoints",
+            "type": "array"
+          }
+        },
+        "required": [
+          "id",
+          "auto_start",
+          "hyperparameters",
+          "model",
+          "status",
+          "job_type",
+          "created_at",
+          "modified_at",
+          "training_files"
+        ],
+        "title": "DetailedJobOut",
+        "type": "object"
+      },
+      "EventOut": {
+        "properties": {
+          "name": {
+            "title": "Name",
+            "type": "string",
+            "description": "The name of the event."
+          },
+          "data": {
+            "anyOf": [
+              {
+                "type": "object",
+                "additionalProperties": true
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Data"
+          },
+          "created_at": {
+            "title": "Created At",
+            "type": "integer",
+            "description": "The UNIX timestamp (in seconds) of the event."
+          }
+        },
+        "required": [
+          "name",
+          "created_at"
+        ],
+        "title": "EventOut",
+        "type": "object"
+      },
+      "MetricOut": {
+        "properties": {
+          "train_loss": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Train Loss"
+          },
+          "valid_loss": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Valid Loss"
+          },
+          "valid_mean_token_accuracy": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Valid Mean Token Accuracy"
+          }
+        },
+        "title": "MetricOut",
+        "type": "object",
+        "description": "Metrics at the step number during the fine-tuning job. Use these metrics to assess if the training is going smoothly (loss should decrease, token accuracy should increase)."
+      },
+      "FTModelCapabilitiesOut": {
+        "properties": {
+          "completion_chat": {
+            "default": true,
+            "title": "Completion Chat",
+            "type": "boolean"
+          },
+          "completion_fim": {
+            "default": false,
+            "title": "Completion Fim",
+            "type": "boolean"
+          },
+          "function_calling": {
+            "default": false,
+            "title": "Function Calling",
+            "type": "boolean"
+          },
+          "fine_tuning": {
+            "default": false,
+            "title": "Fine Tuning",
+            "type": "boolean"
+          }
+        },
+        "title": "FTModelCapabilitiesOut",
+        "type": "object"
+      },
+      "FTModelOut": {
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "object": {
+            "const": "model",
+            "default": "model",
+            "enum": [
+              "model"
+            ],
+            "title": "Object",
+            "type": "string"
+          },
+          "created": {
+            "title": "Created",
+            "type": "integer"
+          },
+          "owned_by": {
+            "title": "Owned By",
+            "type": "string"
+          },
+          "root": {
+            "title": "Root",
+            "type": "string"
+          },
+          "archived": {
+            "title": "Archived",
+            "type": "boolean"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "capabilities": {
+            "$ref": "#/components/schemas/FTModelCapabilitiesOut"
+          },
+          "max_context_length": {
+            "default": 32768,
+            "title": "Max Context Length",
+            "type": "integer"
+          },
+          "aliases": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Aliases",
+            "type": "array"
+          },
+          "job": {
+            "format": "uuid",
+            "title": "Job",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "created",
+          "owned_by",
+          "root",
+          "archived",
+          "capabilities",
+          "job"
+        ],
+        "title": "FTModelOut",
+        "type": "object"
+      },
+      "UpdateFTModelIn": {
+        "properties": {
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          }
+        },
+        "title": "UpdateFTModelIn",
+        "type": "object"
+      },
+      "ArchiveFTModelOut": {
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "object": {
+            "const": "model",
+            "default": "model",
+            "enum": [
+              "model"
+            ],
+            "title": "Object",
+            "type": "string"
+          },
+          "archived": {
+            "default": true,
+            "title": "Archived",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "title": "ArchiveFTModelOut",
+        "type": "object"
+      },
+      "UnarchiveFTModelOut": {
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "object": {
+            "const": "model",
+            "default": "model",
+            "enum": [
+              "model"
+            ],
+            "title": "Object",
+            "type": "string"
+          },
+          "archived": {
+            "default": false,
+            "title": "Archived",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "title": "UnarchiveFTModelOut",
+        "type": "object"
+      },
+      "AssistantMessage": {
+        "properties": {
+          "content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Content"
+          },
+          "tool_calls": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/ToolCall"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tool Calls"
+          },
+          "prefix": {
+            "type": "boolean",
+            "title": "Prefix",
+            "default": false,
+            "description": "Set this to `true` when adding an assistant message as prefix to condition the model response. The role of the prefix message is to force the model to start its answer by the content of the message."
+          },
+          "role": {
+            "type": "string",
+            "default": "assistant",
+            "title": "Role",
+            "enum": [
+              "assistant"
+            ]
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "title": "AssistantMessage"
+      },
+      "ChatCompletionRequest": {
+        "properties": {
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model",
+            "description": "ID of the model to use. You can use the [List Available Models](/api/#tag/models/operation/list_models_v1_models_get) API to see all of your available models, or see our [Model overview](/models) for model descriptions.",
+            "examples": [
+              "mistral-small-latest"
+            ]
+          },
+          "temperature": {
+            "type": "number",
+            "maximum": 1.5,
+            "minimum": 0,
+            "title": "Temperature",
+            "default": 0.7,
+            "description": "What sampling temperature to use, between 0.0 and 1.0. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic. We generally recommend altering this or `top_p` but not both."
+          },
+          "top_p": {
+            "type": "number",
+            "maximum": 1,
+            "minimum": 0,
+            "title": "Top P",
+            "default": 1,
+            "description": "Nucleus sampling, where the model considers the results of the tokens with `top_p` probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered. We generally recommend altering this or `temperature` but not both."
+          },
+          "max_tokens": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Tokens",
+            "description": "The maximum number of tokens to generate in the completion. The token count of your prompt plus `max_tokens` cannot exceed the model's context length."
+          },
+          "min_tokens": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Min Tokens",
+            "description": "The minimum number of tokens to generate in the completion."
+          },
+          "stream": {
+            "type": "boolean",
+            "title": "Stream",
+            "default": false,
+            "description": "Whether to stream back partial progress. If set, tokens will be sent as data-only server-side events as they become available, with the stream terminated by a data: [DONE] message. Otherwise, the server will hold the request open until the timeout or until completion, with the response containing the full result as JSON."
+          },
+          "stop": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            ],
+            "title": "Stop",
+            "description": "Stop generation if this token is detected. Or if one of these tokens is detected when providing an array"
+          },
+          "random_seed": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Random Seed",
+            "description": "The seed to use for random sampling. If set, different calls will generate deterministic results."
+          },
+          "messages": {
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/SystemMessage"
+                },
+                {
+                  "$ref": "#/components/schemas/UserMessage"
+                },
+                {
+                  "$ref": "#/components/schemas/AssistantMessage"
+                },
+                {
+                  "$ref": "#/components/schemas/ToolMessage"
+                }
+              ],
+              "discriminator": {
+                "propertyName": "role",
+                "mapping": {
+                  "assistant": "#/components/schemas/AssistantMessage",
+                  "system": "#/components/schemas/SystemMessage",
+                  "tool": "#/components/schemas/ToolMessage",
+                  "user": "#/components/schemas/UserMessage"
+                }
+              }
+            },
+            "type": "array",
+            "title": "Messages",
+            "description": "The prompt(s) to generate completions for, encoded as a list of dict with role and content.",
+            "examples": [
+              [
+                {
+                  "role": "user",
+                  "content": "Who is the best French painter? Answer in one short sentence."
+                }
+              ]
+            ]
+          },
+          "response_format": {
+            "$ref": "#/components/schemas/ResponseFormat"
+          },
+          "tools": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/Tool"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tools"
+          },
+          "tool_choice": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToolChoice"
+              }
+            ],
+            "default": "auto"
+          },
+          "safe_prompt": {
+            "type": "boolean",
+            "description": "Whether to inject a safety prompt before all conversations.",
+            "default": false
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "messages",
+          "model"
+        ],
+        "title": "ChatCompletionRequest"
+      },
+      "ChunkTypes": {
+        "type": "string",
+        "const": "text",
+        "title": "ChunkTypes"
+      },
+      "ContentChunk": {
+        "properties": {
+          "type": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ChunkTypes"
+              }
+            ],
+            "default": "text"
+          },
+          "text": {
+            "type": "string",
+            "title": "Text"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "text"
+        ],
+        "title": "ContentChunk"
+      },
+      "FIMCompletionRequest": {
+        "properties": {
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model",
+            "default": "codestral-2405",
+            "description": "ID of the model to use. Only compatible for now with:\n  - `codestral-2405`\n  - `codestral-latest`",
+            "examples": [
+              "codestral-2405"
+            ]
+          },
+          "temperature": {
+            "type": "number",
+            "maximum": 1.5,
+            "minimum": 0,
+            "title": "Temperature",
+            "default": 0.7,
+            "description": "What sampling temperature to use, between 0.0 and 1.0. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic. We generally recommend altering this or `top_p` but not both."
+          },
+          "top_p": {
+            "type": "number",
+            "maximum": 1,
+            "minimum": 0,
+            "title": "Top P",
+            "default": 1,
+            "description": "Nucleus sampling, where the model considers the results of the tokens with `top_p` probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered. We generally recommend altering this or `temperature` but not both."
+          },
+          "max_tokens": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Tokens",
+            "description": "The maximum number of tokens to generate in the completion. The token count of your prompt plus `max_tokens` cannot exceed the model's context length."
+          },
+          "min_tokens": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Min Tokens",
+            "description": "The minimum number of tokens to generate in the completion."
+          },
+          "stream": {
+            "type": "boolean",
+            "title": "Stream",
+            "default": false,
+            "description": "Whether to stream back partial progress. If set, tokens will be sent as data-only server-side events as they become available, with the stream terminated by a data: [DONE] message. Otherwise, the server will hold the request open until the timeout or until completion, with the response containing the full result as JSON."
+          },
+          "stop": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            ],
+            "title": "Stop",
+            "description": "Stop generation if this token is detected. Or if one of these tokens is detected when providing an array"
+          },
+          "random_seed": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Random Seed",
+            "description": "The seed to use for random sampling. If set, different calls will generate deterministic results."
+          },
+          "prompt": {
+            "type": "string",
+            "title": "Prompt",
+            "description": "The text/code to complete.",
+            "examples": [
+              "def"
+            ]
+          },
+          "suffix": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Suffix",
+            "default": "",
+            "description": "Optional text/code that adds more context for the model. When given a `prompt` and a `suffix` the model will fill what is between them. When `suffix` is not provided, the model will simply execute completion starting with `prompt`.",
+            "examples": [
+              "return a+b"
+            ]
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "prompt",
+          "model"
+        ],
+        "title": "FIMCompletionRequest"
+      },
+      "Function": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description",
+            "default": ""
+          },
+          "parameters": {
+            "type": "object",
+            "title": "Parameters",
+            "additionalProperties": true
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "name",
+          "parameters"
+        ],
+        "title": "Function"
+      },
+      "FunctionCall": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "arguments": {
+            "title": "Arguments",
+            "anyOf": [
+              {
+                "type": "object",
+                "additionalProperties": true
+              },
+              {
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "name",
+          "arguments"
+        ],
+        "title": "FunctionCall"
+      },
+      "ResponseFormat": {
+        "properties": {
+          "type": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResponseFormats"
+              }
+            ],
+            "default": "text"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "title": "ResponseFormat"
+      },
+      "ResponseFormats": {
+        "type": "string",
+        "enum": [
+          "text",
+          "json_object"
+        ],
+        "title": "ResponseFormats",
+        "description": "An object specifying the format that the model must output. Setting to `{ \"type\": \"json_object\" }` enables JSON mode, which guarantees the message the model generates is in JSON. When using JSON mode you MUST also instruct the model to produce JSON yourself with a system or a user message."
+      },
+      "SystemMessage": {
+        "properties": {
+          "content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "$ref": "#/components/schemas/ContentChunk"
+                },
+                "type": "array"
+              }
+            ],
+            "title": "Content"
+          },
+          "role": {
+            "type": "string",
+            "default": "system",
+            "enum": [
+              "system"
+            ]
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "content"
+        ],
+        "title": "SystemMessage"
+      },
+      "TextChunk": {
+        "properties": {
+          "type": {
+            "const": "text",
+            "title": "Type",
+            "default": "text"
+          },
+          "text": {
+            "type": "string",
+            "title": "Text"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "text"
+        ],
+        "title": "TextChunk"
+      },
+      "Tool": {
+        "properties": {
+          "type": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToolTypes"
+              }
+            ],
+            "default": "function"
+          },
+          "function": {
+            "$ref": "#/components/schemas/Function"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "function"
+        ],
+        "title": "Tool"
+      },
+      "ToolCall": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id",
+            "default": "null"
+          },
+          "type": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToolTypes"
+              }
+            ],
+            "default": "function"
+          },
+          "function": {
+            "$ref": "#/components/schemas/FunctionCall"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "function"
+        ],
+        "title": "ToolCall"
+      },
+      "ToolChoice": {
+        "type": "string",
+        "enum": [
+          "auto",
+          "none",
+          "any"
+        ],
+        "title": "ToolChoice"
+      },
+      "ToolMessage": {
+        "properties": {
+          "content": {
+            "type": "string",
+            "title": "Content"
+          },
+          "tool_call_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tool Call Id"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "role": {
+            "type": "string",
+            "default": "tool",
+            "enum": [
+              "tool"
+            ]
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "content"
+        ],
+        "title": "ToolMessage"
+      },
+      "ToolTypes": {
+        "type": "string",
+        "const": "function",
+        "title": "ToolTypes"
+      },
+      "UserMessage": {
+        "properties": {
+          "content": {
+            "title": "Content",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "$ref": "#/components/schemas/TextChunk"
+                },
+                "type": "array"
+              }
+            ]
+          },
+          "role": {
+            "type": "string",
+            "default": "user",
+            "enum": [
+              "user"
+            ]
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "content"
+        ],
+        "title": "UserMessage"
+      },
+      "AgentsCompletionRequest": {
+        "properties": {
+          "max_tokens": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Tokens",
+            "description": "The maximum number of tokens to generate in the completion. The token count of your prompt plus `max_tokens` cannot exceed the model's context length."
+          },
+          "min_tokens": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Min Tokens",
+            "description": "The minimum number of tokens to generate in the completion."
+          },
+          "stream": {
+            "type": "boolean",
+            "title": "Stream",
+            "default": false,
+            "description": "Whether to stream back partial progress. If set, tokens will be sent as data-only server-side events as they become available, with the stream terminated by a data: [DONE] message. Otherwise, the server will hold the request open until the timeout or until completion, with the response containing the full result as JSON."
+          },
+          "stop": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            ],
+            "title": "Stop",
+            "description": "Stop generation if this token is detected. Or if one of these tokens is detected when providing an array"
+          },
+          "random_seed": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Random Seed",
+            "description": "The seed to use for random sampling. If set, different calls will generate deterministic results."
+          },
+          "messages": {
+            "type": "array",
+            "title": "Messages",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/UserMessage"
+                },
+                {
+                  "$ref": "#/components/schemas/AssistantMessage"
+                },
+                {
+                  "$ref": "#/components/schemas/ToolMessage"
+                }
+              ],
+              "discriminator": {
+                "propertyName": "role",
+                "mapping": {
+                  "assistant": "#/components/schemas/AssistantMessage",
+                  "tool": "#/components/schemas/ToolMessage",
+                  "user": "#/components/schemas/UserMessage"
+                }
+              }
+            },
+            "description": "The prompt(s) to generate completions for, encoded as a list of dict with role and content.",
+            "examples": [
+              [
+                {
+                  "role": "user",
+                  "content": "Who is the best French painter? Answer in one short sentence."
+                }
+              ]
+            ]
+          },
+          "response_format": {
+            "$ref": "#/components/schemas/ResponseFormat"
+          },
+          "tools": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/Tool"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tools"
+          },
+          "tool_choice": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ToolChoice"
+              }
+            ],
+            "default": "auto"
+          },
+          "agent_id": {
+            "type": "string",
+            "description": "The ID of the agent to use for this completion."
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "messages",
+          "agent_id"
+        ],
+        "title": "AgentsCompletionRequest"
+      },
+      "EmbeddingRequest": {
+        "properties": {
+          "input": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            ],
+            "title": "Input",
+            "description": "Text to embed."
+          },
+          "model": {
+            "type": "string",
+            "title": "Model",
+            "description": "ID of the model to use."
+          },
+          "encoding_format": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Encoding Format",
+            "description": "The format to return the embeddings in.",
+            "default": "float"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "input",
+          "model"
+        ],
+        "title": "EmbeddingRequest"
+      },
+      "UsageInfo": {
+        "title": "UsageInfo",
+        "type": "object",
+        "properties": {
+          "prompt_tokens": {
+            "type": "integer",
+            "example": 16
+          },
+          "completion_tokens": {
+            "type": "integer",
+            "example": 34
+          },
+          "total_tokens": {
+            "type": "integer",
+            "example": 50
+          }
+        },
+        "required": [
+          "prompt_tokens",
+          "completion_tokens",
+          "total_tokens"
+        ]
+      },
+      "ResponseBase": {
+        "type": "object",
+        "title": "ResponseBase",
+        "properties": {
+          "id": {
+            "type": "string",
+            "example": "cmpl-e5cc70bb28c444948073e77776eb30ef"
+          },
+          "object": {
+            "type": "string",
+            "example": "chat.completion"
+          },
+          "model": {
+            "type": "string",
+            "example": "mistral-small-latest"
+          },
+          "usage": {
+            "$ref": "#/components/schemas/UsageInfo"
+          }
+        }
+      },
+      "ChatCompletionChoice": {
+        "title": "ChatCompletionChoice",
+        "type": "object",
+        "required": [
+          "index",
+          "finish_reason",
+          "message"
+        ],
+        "properties": {
+          "index": {
+            "type": "integer",
+            "example": 0
+          },
+          "message": {
+            "$ref": "#/components/schemas/AssistantMessage"
+          },
+          "finish_reason": {
+            "type": "string",
+            "enum": [
+              "stop",
+              "length",
+              "model_length",
+              "error",
+              "tool_calls"
+            ],
+            "example": "stop"
+          }
+        }
+      },
+      "ChatCompletionResponseBase": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ResponseBase"
+          },
+          {
+            "type": "object",
+            "title": "ChatCompletionResponseBase",
+            "properties": {
+              "created": {
+                "type": "integer",
+                "example": 1702256327
+              }
+            }
+          }
+        ]
+      },
+      "ChatCompletionResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ChatCompletionResponseBase"
+          },
+          {
+            "type": "object",
+            "title": "ChatCompletionResponse",
+            "properties": {
+              "choices": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ChatCompletionChoice"
+                }
+              }
+            },
+            "required": [
+              "id",
+              "object",
+              "data",
+              "model",
+              "usage"
+            ]
+          }
+        ]
+      },
+      "FIMCompletionResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ChatCompletionResponse"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "model": {
+                "type": "string",
+                "example": "codestral-latest"
+              }
+            }
+          }
+        ]
+      },
+      "EmbeddingResponseData": {
+        "title": "EmbeddingResponseData",
+        "type": "object",
+        "properties": {
+          "object": {
+            "type": "string",
+            "example": "embedding"
+          },
+          "embedding": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            },
+            "examples": [
+              0.1,
+              0.2,
+              0.3
+            ]
+          },
+          "index": {
+            "type": "integer",
+            "example": 0
+          }
+        },
+        "examples": [
+          {
+            "object": "embedding",
+            "embedding": [
+              0.1,
+              0.2,
+              0.3
+            ],
+            "index": 0
+          },
+          {
+            "object": "embedding",
+            "embedding": [
+              0.4,
+              0.5,
+              0.6
+            ],
+            "index": 1
+          }
+        ]
+      },
+      "EmbeddingResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ResponseBase"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "data": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/EmbeddingResponseData"
+                }
+              }
+            },
+            "required": [
+              "id",
+              "object",
+              "data",
+              "model",
+              "usage"
+            ]
+          }
+        ]
+      },
+      "CompletionEvent": {
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/CompletionChunk"
+          }
+        }
+      },
+      "CompletionChunk": {
+        "type": "object",
+        "required": [
+          "id",
+          "model",
+          "choices"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "object": {
+            "type": "string"
+          },
+          "created": {
+            "type": "integer"
+          },
+          "model": {
+            "type": "string"
+          },
+          "usage": {
+            "$ref": "#/components/schemas/UsageInfo"
+          },
+          "choices": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CompletionResponseStreamChoice"
+            }
+          }
+        }
+      },
+      "CompletionResponseStreamChoice": {
+        "type": "object",
+        "required": [
+          "index",
+          "delta",
+          "finish_reason"
+        ],
+        "properties": {
+          "index": {
+            "type": "integer"
+          },
+          "delta": {
+            "$ref": "#/components/schemas/DeltaMessage"
+          },
+          "finish_reason": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "enum": [
+              "stop",
+              "length",
+              "error",
+              "tool_calls",
+              null
+            ]
+          }
+        }
+      },
+      "DeltaMessage": {
+        "type": "object",
+        "properties": {
+          "role": {
+            "type": "string"
+          },
+          "content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "tool_calls": {
+            "anyOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ToolCall"
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "ApiKey": {
+        "type": "http",
+        "scheme": "bearer"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "chat",
+      "x-displayName": "Chat",
+      "description": "Chat Completion API."
+    },
+    {
+      "name": "fim",
+      "x-displayName": "FIM",
+      "description": "Fill-in-the-middle API."
+    },
+    {
+      "name": "agents",
+      "x-displayName": "Agents",
+      "description": "Agents API."
+    },
+    {
+      "name": "embeddings",
+      "x-displayName": "Embeddings",
+      "description": "Embeddings API."
+    },
+    {
+      "name": "files",
+      "x-displayName": "Files",
+      "description": "Files API"
+    },
+    {
+      "name": "fine-tuning",
+      "x-displayName": "Fine Tuning",
+      "description": "Fine-tuning API"
+    },
+    {
+      "name": "models",
+      "x-displayName": "Models",
+      "description": "Model Management API"
+    }
+  ],
+  "security": [
+    {
+      "ApiKey": []
+    }
+  ],
+  "servers": [
+    {
+      "url": "https://api.mistral.ai",
+      "description": "Production server"
+    }
+  ]
+}

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/artifacts/payloads/ai/mistral-payload.json
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/artifacts/payloads/ai/mistral-payload.json
@@ -1,0 +1,4 @@
+{
+  "model": "mistral-small-latest",
+  "messages": [{"role": "user", "content": "Who is the most renowned French painter?"}]
+}

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/artifacts/payloads/ai/mistral_auth_add_props.json
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/artifacts/payloads/ai/mistral_auth_add_props.json
@@ -1,0 +1,70 @@
+{
+  "name": "${UNIQUE:mistralAuthAPI}",
+  "version": "1.0.0",
+  "context": "${UNIQUE:mistralAuthContext}",
+  "gatewayType": "wso2/synapse",
+  "policies": ["Unlimited"],
+  "endpointConfig": {
+    "endpoint_type": "http",
+    "production_endpoints": {
+      "url": "http://nodebackend:3001/jaxrs_basic/services/customers/customerservice/with-auth"
+    },
+    "sandbox_endpoints": {
+      "url": "http://nodebackend:3001/jaxrs_basic/services/customers/customerservice/with-auth"
+    },
+    "endpoint_security": {
+      "production": {
+        "enabled": true,
+        "type": "apikey",
+        "apiKeyIdentifier": "Authorization",
+        "apiKeyValue": "Bearer 123",
+        "apiKeyIdentifierType": "HEADER",
+        "username": "",
+        "password": "",
+        "grantType": "",
+        "tokenUrl": "",
+        "clientId": null,
+        "clientSecret": null,
+        "customParameters": "{}"
+      },
+      "sandbox": {
+        "enabled": true,
+        "type": "apikey",
+        "apiKeyIdentifier": "Authorization",
+        "apiKeyValue": "Bearer 123",
+        "apiKeyIdentifierType": "HEADER",
+        "username": "",
+        "password": "",
+        "grantType": "",
+        "tokenUrl": "",
+        "clientId": null,
+        "clientSecret": null,
+        "customParameters": "{}"
+      }
+    }
+  },
+  "subtypeConfiguration": {
+    "subtype": "AIAPI",
+    "configuration": {
+      "llmProviderName": "TestAIService",
+      "llmProviderApiVersion": "1.0.0"
+    }
+  },
+  "maxTps": {
+    "production": 1000,
+    "sandbox": 1000,
+    "productionTimeUnit": "MINUTE",
+    "sandboxTimeUnit": "MINUTE",
+    "tokenBasedThrottlingConfiguration": {
+      "productionMaxPromptTokenCount": 1234,
+      "productionMaxCompletionTokenCount": 2345,
+      "productionMaxTotalTokenCount": 3456,
+      "sandboxMaxPromptTokenCount": 4567,
+      "sandboxMaxCompletionTokenCount": 5678,
+      "sandboxMaxTotalTokenCount": 6789,
+      "isTokenBasedThrottlingEnabled": true
+    }
+  },
+  "securityScheme": ["oauth2"],
+  "egress": true
+}

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/artifacts/payloads/ai/mistral_no_auth_add_props.json
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/artifacts/payloads/ai/mistral_no_auth_add_props.json
@@ -1,0 +1,40 @@
+{
+  "name": "${UNIQUE:mistralNoAuthAPI}",
+  "version": "1.0.0",
+  "context": "${UNIQUE:mistralNoAuthContext}",
+  "gatewayType": "wso2/synapse",
+  "policies": ["Unlimited"],
+  "endpointConfig": {
+    "endpoint_type": "http",
+    "production_endpoints": {
+      "url": "http://nodebackend:3001/jaxrs_basic/services/customers/customerservice/no-auth"
+    },
+    "sandbox_endpoints": {
+      "url": "http://nodebackend:3001/jaxrs_basic/services/customers/customerservice/no-auth"
+    }
+  },
+  "subtypeConfiguration": {
+    "subtype": "AIAPI",
+    "configuration": {
+      "llmProviderName": "TestAIService",
+      "llmProviderApiVersion": "1.0.0"
+    }
+  },
+  "maxTps": {
+    "production": 1000,
+    "sandbox": 1000,
+    "productionTimeUnit": "MINUTE",
+    "sandboxTimeUnit": "MINUTE",
+    "tokenBasedThrottlingConfiguration": {
+      "productionMaxPromptTokenCount": 1234,
+      "productionMaxCompletionTokenCount": 2345,
+      "productionMaxTotalTokenCount": 3456,
+      "sandboxMaxPromptTokenCount": 4567,
+      "sandboxMaxCompletionTokenCount": 5678,
+      "sandboxMaxTotalTokenCount": 6789,
+      "isTokenBasedThrottlingEnabled": true
+    }
+  },
+  "securityScheme": ["oauth2", "api_key"],
+  "egress": true
+}

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/artifacts/payloads/create_apim_advertise_api.json
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/artifacts/payloads/create_apim_advertise_api.json
@@ -1,0 +1,25 @@
+{
+  "name": "${UNIQUE:APIMAdvertise}",
+  "context": "${UNIQUE:apiAdvertiseCtx}",
+  "version": "1.0.0",
+  "advertiseInfo": {
+    "advertised": true,
+    "apiExternalProductionEndpoint": "http://nodebackend:3001/jaxrs_basic/services/customers/customerservice/",
+    "apiExternalSandboxEndpoint": "http://nodebackend:3001/jaxrs_basic/services/customers/customerservice/",
+    "originalDevPortalUrl": "https://test.com",
+    "vendor": "WSO2"
+  },
+  "description": "Advertise-only API, aggregated into a product",
+  "tags": ["advertise"],
+  "policies": ["Gold", "Bronze", "Unlimited"],
+  "operations": [
+    {
+      "verb": "GET",
+      "target": "/customers/{id}",
+      "scopes": []
+    }
+  ],
+  "isDefaultVersion": true,
+  "additionalProperties": [],
+  "additionalPropertiesMap": {}
+}

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/artifacts/payloads/create_apim_app_with_attribute.json
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/artifacts/payloads/create_apim_app_with_attribute.json
@@ -1,0 +1,8 @@
+{
+  "name": "${UNIQUE:APIMAttrApp}",
+  "throttlingPolicy": "Unlimited",
+  "description": "Application carrying a custom application attribute",
+  "attributes": {
+    "External Reference Id": "c1237890"
+  }
+}

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/artifacts/payloads/create_apim_graphql_secured_api.json
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/artifacts/payloads/create_apim_graphql_secured_api.json
@@ -1,0 +1,173 @@
+{
+  "name": "${UNIQUE:APIMSecuredGraphQL}",
+  "description": null,
+  "context": "${UNIQUE:apiSecuredGraphQLContext}",
+  "version": "1.0.0",
+  "lifeCycleStatus": "CREATED",
+  "wsdlInfo": null,
+  "wsdlUrl": null,
+  "responseCachingEnabled": false,
+  "cacheTimeout": 300,
+  "hasThumbnail": false,
+  "isDefaultVersion": false,
+  "isRevision": false,
+  "revisionedApiId": null,
+  "revisionId": 0,
+  "enableSchemaValidation": false,
+  "enableSubscriberVerification": false,
+  "type": "GRAPHQL",
+  "audience": null,
+  "audiences": [
+    "all"
+  ],
+  "transport": [
+    "http",
+    "https"
+  ],
+  "tags": [],
+  "policies": [
+    "Unlimited",
+    "Bronze"
+  ],
+  "organizationPolicies": [],
+  "apiThrottlingPolicy": null,
+  "authorizationHeader": "Authorization",
+  "apiKeyHeader": "ApiKey",
+  "securityScheme": [
+    "oauth_basic_auth_api_key_mandatory",
+    "oauth2"
+  ],
+  "maxTps": null,
+  "visibility": "PUBLIC",
+  "visibleRoles": [
+    ""
+  ],
+  "visibleTenants": [],
+  "visibleOrganizations": [
+    "none"
+  ],
+  "mediationPolicies": [],
+  "apiPolicies": null,
+  "subscriptionAvailability": "CURRENT_TENANT",
+  "subscriptionAvailableTenants": [
+    ""
+  ],
+  "additionalProperties": [],
+  "additionalPropertiesMap": {},
+  "monetization": null,
+  "accessControl": "NONE",
+  "accessControlRoles": [],
+  "businessInformation": {
+    "businessOwner": null,
+    "businessOwnerEmail": null,
+    "technicalOwner": null,
+    "technicalOwnerEmail": null
+  },
+  "corsConfiguration": {
+    "corsConfigurationEnabled": false,
+    "accessControlAllowOrigins": [
+      "*"
+    ],
+    "accessControlAllowCredentials": false,
+    "accessControlAllowHeaders": [
+      "authorization",
+      "Access-Control-Allow-Origin",
+      "Content-Type",
+      "SOAPAction",
+      "apikey",
+      "Internal-Key"
+    ],
+    "accessControlAllowMethods": [
+      "GET",
+      "PUT",
+      "POST",
+      "DELETE",
+      "PATCH",
+      "OPTIONS"
+    ]
+  },
+  "websubSubscriptionConfiguration": {
+    "enable": false,
+    "secret": "",
+    "signingAlgorithm": "SHA1",
+    "signatureHeader": "x-hub-signature"
+  },
+  "workflowStatus": null,
+  "endpointConfig": {
+    "endpoint_type": "http",
+    "sandbox_endpoints": {
+      "url": "http://nodebackend:3003/graphql-secured"
+    },
+    "production_endpoints": {
+      "url": "http://nodebackend:3003/graphql-secured"
+    }
+  },
+  "primaryProductionEndpointId": null,
+  "primarySandboxEndpointId": null,
+  "endpointImplementationType": "ENDPOINT",
+  "subtypeConfiguration": {
+    "subtype": "DEFAULT",
+    "configuration": null
+  },
+  "scopes": [],
+  "operations": [
+    {
+      "id": "",
+      "target": "languages",
+      "verb": "QUERY",
+      "authType": "Application & Application User",
+      "throttlingPolicy": "Unlimited",
+      "scopes": [],
+      "usedProductIds": [],
+      "amznResourceName": null,
+      "amznResourceTimeout": null,
+      "amznResourceContentEncode": null,
+      "payloadSchema": null,
+      "uriMapping": null,
+      "operationPolicies": {
+        "request": [],
+        "response": [],
+        "fault": []
+      }
+    },
+    {
+      "id": "",
+      "target": "language",
+      "verb": "QUERY",
+      "authType": "Application & Application User",
+      "throttlingPolicy": "Unlimited",
+      "scopes": [],
+      "usedProductIds": [],
+      "amznResourceName": null,
+      "amznResourceTimeout": null,
+      "amznResourceContentEncode": null,
+      "payloadSchema": null,
+      "uriMapping": null,
+      "operationPolicies": {
+        "request": [],
+        "response": [],
+        "fault": []
+      }
+    }
+  ],
+  "threatProtectionPolicies": null,
+  "categories": [],
+  "keyManagers": [
+    "all"
+  ],
+  "serviceInfo": null,
+  "advertiseInfo": {
+    "advertised": false,
+    "apiExternalProductionEndpoint": null,
+    "apiExternalSandboxEndpoint": null,
+    "originalDevPortalUrl": null,
+    "apiOwner": "admin",
+    "vendor": "WSO2"
+  },
+  "gatewayVendor": "wso2",
+  "gatewayType": "wso2/synapse",
+  "asyncTransportProtocols": [
+    ""
+  ],
+  "egress": false
+}

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/artifacts/payloads/create_apim_optransform_api.json
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/artifacts/payloads/create_apim_optransform_api.json
@@ -1,0 +1,50 @@
+{
+  "name": "${UNIQUE:APIMOpPolicy}",
+  "context": "${UNIQUE:apiOpPolicyContext}",
+  "version": "1.0.0",
+  "endpointConfig": {
+    "endpoint_type": "http",
+    "production_endpoints": {
+      "template_not_supported": false,
+      "config": null,
+      "url": "http://nodebackend:3001/jaxrs_basic/services/customers/customerservice/"
+    },
+    "sandbox_endpoints": {
+      "url": "http://nodebackend:3001/jaxrs_basic/services/customers/customerservice/",
+      "config": null,
+      "template_not_supported": false
+    }
+  },
+  "description": "API with a jsonToXML request operation policy, aggregated into a product",
+  "tags": ["op-policy"],
+  "policies": ["Gold", "Bronze", "Unlimited"],
+  "operations": [
+    {
+      "verb": "POST",
+      "target": "/reflect-body",
+      "authType": "Application & Application User",
+      "throttlingPolicy": "Unlimited",
+      "scopes": [],
+      "operationPolicies": {
+        "request": [
+          {
+            "policyName": "jsonToXML",
+            "policyVersion": "v1",
+            "parameters": {}
+          }
+        ],
+        "response": [],
+        "fault": [
+          {
+            "policyName": "jsonFault",
+            "policyVersion": "v1",
+            "parameters": {}
+          }
+        ]
+      }
+    }
+  ],
+  "isDefaultVersion": true,
+  "additionalProperties": [],
+  "additionalPropertiesMap": {}
+}

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/artifacts/payloads/create_apim_reflect_api.json
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/artifacts/payloads/create_apim_reflect_api.json
@@ -1,0 +1,39 @@
+{
+  "name": "${UNIQUE:APIMReflect}",
+  "context": "${UNIQUE:apiReflectContext}",
+  "version": "1.0.0",
+  "endpointConfig": {
+    "endpoint_type": "http",
+    "production_endpoints": {
+      "template_not_supported": false,
+      "config": null,
+      "url": "http://nodebackend:3001/jaxrs_basic/services/customers/customerservice/"
+    },
+    "sandbox_endpoints": {
+      "url": "http://nodebackend:3001/jaxrs_basic/services/customers/customerservice/",
+      "config": null,
+      "template_not_supported": false
+    }
+  },
+  "description": "API routing to a header-reflecting backend, for application-attribute JWT-claim verification",
+  "tags": [
+    "attributes"
+  ],
+  "policies": [
+    "Gold",
+    "Bronze",
+    "Unlimited"
+  ],
+  "operations": [
+    {
+      "verb": "GET",
+      "target": "/reflect-headers",
+      "scopes": [
+
+      ]
+    }
+  ],
+  "isDefaultVersion": true,
+  "additionalProperties": [],
+  "additionalPropertiesMap": {}
+}

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/artifacts/payloads/create_apim_restricted_visibility_api.json
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/artifacts/payloads/create_apim_restricted_visibility_api.json
@@ -1,0 +1,33 @@
+{
+  "name": "${UNIQUE:APIMRestricted}",
+  "context": "${UNIQUE:apiRestrictedContext}",
+  "version": "1.0.0",
+  "visibility": "RESTRICTED",
+  "visibleRoles": ["admin"],
+  "endpointConfig": {
+    "endpoint_type": "http",
+    "production_endpoints": {
+      "template_not_supported": false,
+      "config": null,
+      "url": "http://nodebackend:3001/jaxrs_basic/services/customers/customerservice/"
+    },
+    "sandbox_endpoints": {
+      "url": "http://nodebackend:3001/jaxrs_basic/services/customers/customerservice/",
+      "config": null,
+      "template_not_supported": false
+    }
+  },
+  "description": "Restricted-visibility API, aggregated into a product",
+  "tags": ["restricted"],
+  "policies": ["Gold", "Bronze", "Unlimited"],
+  "operations": [
+    {
+      "verb": "GET",
+      "target": "/customers/{id}",
+      "scopes": []
+    }
+  ],
+  "isDefaultVersion": true,
+  "additionalProperties": [],
+  "additionalPropertiesMap": {}
+}

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/artifacts/payloads/graphql_query_complexity.json
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/artifacts/payloads/graphql_query_complexity.json
@@ -1,0 +1,8 @@
+{
+  "list": [
+    {"type": "Query", "field": "languages", "complexityValue": 1},
+    {"type": "Query", "field": "language", "complexityValue": 1},
+    {"type": "Language", "field": "code", "complexityValue": 1},
+    {"type": "Language", "field": "name", "complexityValue": 1}
+  ]
+}

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/artifacts/payloads/mcp_petstore_api_props.json
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/artifacts/payloads/mcp_petstore_api_props.json
@@ -1,0 +1,19 @@
+{
+  "name": "${UNIQUE:MCPPetstoreBackingAPI}",
+  "context": "${UNIQUE:mcpPetstoreApiContext}",
+  "version": "1.0.0",
+  "type": "HTTP",
+  "transport": ["http", "https"],
+  "policies": ["Unlimited"],
+  "apiThrottlingPolicy": "Unlimited",
+  "securityScheme": ["oauth2", "oauth_basic_auth_mandatory"],
+  "endpointConfig": {
+    "endpoint_type": "http",
+    "production_endpoints": {
+      "url": "http://nodebackend:3001/jaxrs_basic/services/customers/customerservice"
+    },
+    "sandbox_endpoints": {
+      "url": "http://nodebackend:3001/jaxrs_basic/services/customers/customerservice"
+    }
+  }
+}

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/features/analytics/remote_logging.feature
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/features/analytics/remote_logging.feature
@@ -1,0 +1,29 @@
+@remote-logging
+Feature: Remote Server Logging
+
+  Server-global remote logging (RemoteLoggingAppenderTest): the Carbon RemoteLoggingConfig admin service
+  redirects a log type's appender to a remote HTTP endpoint. Enabling it flips the AUDIT_LOGFILE appender in
+  the running server's log4j2.properties from a local RollingFile to a SecuredHttp appender AND streams audit
+  log entries to the remote endpoint; disabling it reverts the appender and stops the stream. Remote logging is
+  a super-tenant, server-wide setting, so this runs once as the super-tenant admin in a dedicated
+  thread-count=1 block (it mutates the shared server's log configuration).
+
+  @cap:analytics @feat:remote-logging @rule:end-to-end @type:regression @legacy:RemoteLoggingAppenderTest
+  Scenario: Audit logs stream to a remote endpoint when enabled and stop when disabled
+    Given The system is ready
+    And I have valid access tokens as "admin"
+    # Stand up a host sink the container reaches via host.docker.internal
+    When I start a mock log sink and store its container URL as "sinkUrl"
+    # Enable remote logging for the AUDIT log type, pointing at the sink
+    When I enable remote logging for log type "AUDIT" pointing at URL "{{sinkUrl}}"
+    Then The response status code should be 202
+    # The AUDIT_LOGFILE appender is rewritten to the HTTP (SecuredHttp) type in log4j2.properties
+    And the "AUDIT_LOGFILE" log appender should become "SecuredHttp" within 30 seconds
+    # An audit-producing admin action's log entry reaches the remote sink
+    When I trigger an audit log entry
+    Then the mock log sink should receive a log payload within 30 seconds
+    # Disabling reverts the appender to the local RollingFile and stops the remote stream
+    When I disable remote logging for log type "AUDIT"
+    Then The response status code should be 202
+    And the "AUDIT_LOGFILE" log appender should become "RollingFile" within 30 seconds
+    And the mock log sink should stop receiving payloads within 30 seconds

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/features/devportal/application_attributes.feature
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/features/devportal/application_attributes.feature
@@ -1,0 +1,101 @@
+@cleanup
+Feature: DevPortal Custom Application Attributes
+
+  Ports the legacy ApplicationAttributesTestCase: a custom application attribute ("External Reference Id")
+  declared server-side via [[apim.devportal.application_attributes]] is stored on the application and, when
+  the application invokes a subscribed API, surfaced to the backend in the X-JWT-Assertion backend JWT under
+  the http://wso2.org/claims/applicationAttributes claim. The block enables backend JWT generation
+  ([apim.jwt] enable=true) so the gateway injects the assertion towards the backend, and the API routes to a
+  header-reflecting backend route (/reflect-headers) so the test can read the header the backend received —
+  the v2 analogue of the legacy jwt_backend echo. The attribute is declared required=true, so creating an
+  application without it is rejected (the negative). Legacy verified both a JWT-type and an OAuth-type
+  application; both are covered via the token-type column, and x2 tenant (super + tenant) though legacy was
+  super-only. Teardown via the per-scenario cleanup hook removes the application and API.
+
+  @cap:devportal @feat:application-attributes @type:regression @dep:gateway @dep:key-manager @legacy:ApplicationAttributesTestCase
+  Scenario Outline: A custom application attribute is stored and surfaced in the backend JWT for a <tokenType> application as <actor>
+    Given The system is ready
+    And I have valid access tokens as "<actor>"
+    And I have created an api from "artifacts/payloads/create_apim_reflect_api.json" as "createdApiId" and deployed it
+    When I publish the "apis" resource with id "createdApiId"
+    Then The lifecycle status of API "createdApiId" should be "Published"
+    When I retrieve the "apis" resource with id "createdApiId"
+    And I extract response field "context" and store it as "apiContext"
+
+    When I put JSON payload from file "artifacts/payloads/create_apim_app_with_attribute.json" in context as "createAppPayload"
+    And I set the field "tokenType" to "<tokenType>" in the payload "createAppPayload"
+    And I create an application with payload "createAppPayload"
+    Then The response status code should be 201
+    # Attribute is stored on the application.
+    When I retrieve the application with id "createdAppId"
+    Then The response status code should be 200
+    And The response should contain "External Reference Id"
+    And The response should contain "c1237890"
+
+    When I put the following JSON payload in context as "generateApplicationKeysPayload"
+    """
+    {"keyType": "PRODUCTION", "grantTypesToBeSupported": ["client_credentials", "password"]}
+    """
+    And I generate client credentials for application id "createdAppId" with payload "generateApplicationKeysPayload"
+    Then The response status code should be 200
+
+    When I put the following JSON payload in context as "apiSubscriptionPayload"
+    """
+    {"applicationId": "{{applicationId}}", "apiId": "{{apiId}}", "throttlingPolicy": "Gold"}
+    """
+    And I subscribe to API "createdApiId" using application "createdAppId" with payload "apiSubscriptionPayload" as "subscriptionId"
+    Then The response status code should be 201
+
+    When I put the following JSON payload in context as "createApplicationAccessTokenPayload"
+    """
+    {"consumerSecret": "{{appConsumerSecret}}", "validityPeriod": 3600}
+    """
+    And I request an access token for application id "createdAppId" using payload "createApplicationAccessTokenPayload"
+    Then The response status code should be 200
+
+    # Invoke through the gateway; the reflecting backend returns the headers it received, including the
+    # gateway-injected X-JWT-Assertion carrying the applicationAttributes claim.
+    When I invoke the API at gateway context "{{apiContext}}/1.0.0/reflect-headers" with method "GET" using access token "generatedAccessToken" and payload "" until response status code becomes 200 within 60 seconds
+    Then The response status code should be 200
+    And The reflected backend JWT should contain application attribute "External Reference Id" with value "c1237890"
+
+    Examples:
+      | tokenType | actor             |
+      | JWT       | admin             |
+      | OAUTH     | admin             |
+      | JWT       | admin@tenant1.com |
+      | OAUTH     | admin@tenant1.com |
+
+  # NOTE: a "create without the required attribute is rejected" negative is intentionally NOT included.
+  # Legacy (ApplicationAttributesTestCase) never tested it, and probing 4.7.0 live shows the product mishandles
+  # the case: the server recognises it ("GlobalThrowableMapper: Bad Request. Required application attribute not
+  # provided") but the exception mapper returns 500 (900967 General Error) instead of a clean 400. Per the
+  # no-500-enshrinement principle this server bug is documented (increment-2 backlog), not asserted.
+
+  # L3: a custom application attribute can be UPDATED (create → change value → verify). Salvages the delta of
+  # the (legacy-disabled, otherwise-duplicate) ApplicationWithCustomAttributesTestCase — the create+enforce+JWT
+  # -claim coverage is already above; this adds the update-mutation path.
+  @cap:devportal @feat:application-attributes @type:regression @legacy:ApplicationWithCustomAttributesTestCase
+  Scenario Outline: A custom application attribute can be updated as <actor>
+    Given The system is ready
+    And I have valid access tokens as "<actor>"
+    When I put JSON payload from file "artifacts/payloads/create_apim_app_with_attribute.json" in context as "attrCreatePayload"
+    And I create an application with payload "attrCreatePayload"
+    Then The response status code should be 201
+    And I extract response field "name" and store it as "attrAppName"
+    When I retrieve the application with id "createdAppId"
+    Then The response should contain "c1237890"
+    When I put the following JSON payload in context as "attrUpdatePayload"
+    """
+    {"name":"{{attrAppName}}","throttlingPolicy":"Unlimited","description":"updated attributes","attributes":{"External Reference Id":"c1237890_updated"}}
+    """
+    And I update the application "createdAppId" with payload "attrUpdatePayload"
+    Then The response status code should be 200
+    When I retrieve the application with id "createdAppId"
+    Then The response status code should be 200
+    And The response should contain "c1237890_updated"
+
+    Examples:
+      | actor             |
+      | admin             |
+      | admin@tenant1.com |

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/features/devportal/search.feature
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/features/devportal/search.feature
@@ -7,7 +7,7 @@ Feature: DevPortal Search & Discovery
   asynchronous index, so the search step polls until the result appears (no fixed sleep). Self-contained
   scenario, torn down by the per-scenario cleanup hook.
 
-  @cap:devportal @feat:search @type:smoke @legacy:DevPortalSearchVisibilityTestCase
+  @cap:devportal @feat:discovery @rule:search @type:smoke @legacy:DevPortalSearchVisibilityTestCase
   Scenario Outline: Search a newly published API by name and context as <actor>
     Given The system is ready and I have valid publisher access tokens as "<actor>"
     And I have created an api from "artifacts/payloads/create_apim_test_api.json" as "createdApiId" and deployed it

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/features/devportal/subscription_management.feature
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/features/devportal/subscription_management.feature
@@ -76,3 +76,31 @@ Feature: DevPortal Subscription Management
       | tenantSuffix |
       |              |
       | @tenant1.com |
+
+  # Wave B-3: force-changing a subscription's business plan to an invalid plan is rejected (400). Ports the 400
+  # negatives of ChangeSubscriptionBusinessPlanForcefullyTestCase via the PUBLISHER change-business-plan endpoint
+  # (which validates the plan). verify-first FINDING: the devportal subscription PUT does NOT validate — it
+  # silently keeps the current plan and returns 200 — so this uses the publisher force-change endpoint instead.
+  @cap:devportal @feat:subscription-management @rule:invalid-plan @type:negative @legacy:ChangeSubscriptionBusinessPlanForcefullyTestCase
+  Scenario Outline: Force-changing a subscription to an invalid business plan is rejected as <actor>
+    Given The system is ready
+    And I have valid access tokens as "<actor>"
+    And I have created an api from "artifacts/payloads/create_apim_test_api.json" as "createdApiId" and deployed it
+    When I publish the "apis" resource with id "createdApiId"
+    Then The lifecycle status of API "createdApiId" should be "Published"
+    When I have set up application with keys, subscribed to API "createdApiId", and obtained access token for "subscriptionId"
+    Then The response status code should be 200
+    # An empty business plan is rejected.
+    When I change the subscription business plan of "subscriptionId" to ""
+    Then The response status code should be 400
+    # A nonexistent business plan is rejected.
+    When I change the subscription business plan of "subscriptionId" to "INVALID_BUSINESS_PLAN"
+    Then The response status code should be 400
+    # A plan not among the API's allowed tiers (the API offers Gold/Bronze/Unlimited; Silver is a global default it does not offer).
+    When I change the subscription business plan of "subscriptionId" to "Silver"
+    Then The response status code should be 400
+
+    Examples:
+      | actor             |
+      | admin             |
+      | admin@tenant1.com |

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/features/gateway/ai_api_invocation.feature
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/features/gateway/ai_api_invocation.feature
@@ -1,0 +1,334 @@
+@cleanup
+Feature: Gateway AI API Invocation
+
+  AI-API capability: the admin registers a custom (no-auth) AI service provider — a copy of MistralAI whose
+  backend authentication is disabled so it can front a mock LLM — then an AIAPI-subtype API is imported from the
+  Mistral OpenAPI (backend = the mock LLM chat-completions endpoint on the node backend), published, subscribed
+  to, and invoked through the gateway; the LLM response flows back. Also asserts the predefined AI service
+  providers are listed. Ports AIAPITestCase (core provider-list + unsecured-AI-API create/publish/invoke).
+  NOTE: two invocation variants cover both AI auth schemes — the oauth2 scheme (reusing the standard
+  subscribe+token+invoke harness) and the api_key scheme (mint an application API key, invoke with the ApiKey
+  header) — the AI data-plane (LLM response through the gateway) is the subject in both. The AIAPI's
+  securityScheme lists both oauth2 and api_key. Teardown is fully hook-managed (@cleanup): ResourceCleanup
+  deletes the AI service provider AFTER its API, since a provider delete is blocked by a foreign key while any
+  AIAPI-subtype API still references it.
+
+  @cap:gateway @feat:ai-invocation @rule:providers @type:smoke @dep:admin @legacy:AIAPITestCase
+  Scenario Outline: The predefined AI service providers are listed as <actor>
+    Given The system is ready
+    And I have valid access tokens as "<actor>"
+    When I retrieve the AI service providers
+    Then The response status code should be 200
+    And The response should contain "MistralAI"
+
+    Examples:
+      | actor             |
+      | admin             |
+      | admin@tenant1.com |
+
+  @cap:gateway @feat:ai-invocation @rule:invocation @type:regression @dep:admin @legacy:AIAPITestCase
+  Scenario Outline: Invoke a published AI API through the gateway to a mock LLM backend as <actor>
+    Given The system is ready
+    And I have valid access tokens as "<actor>"
+    # Register a no-auth AI service provider (prerequisite for the AIAPI-subtype create); isolated per tenant org
+    When I create an AI service provider "TestAIService" version "1.0.0" with config "artifacts/payloads/ai/ai-service-provider-config-no-auth.json" and definition "artifacts/payloads/ai/mistral-def.json" as "aiProviderId"
+    Then The response status code should be 201
+    # Import the AIAPI-subtype API from the Mistral OpenAPI (backend → the mock LLM)
+    When I import openapi definition from "artifacts/payloads/ai/mistral-def.json" with additional properties "artifacts/payloads/ai/mistral_no_auth_add_props.json" as "aiApiId"
+    Then The response status code should be 201
+    When I deploy the API with id "aiApiId"
+    When I publish the "apis" resource with id "aiApiId"
+    Then The lifecycle status of API "aiApiId" should be "Published"
+    When I retrieve the "apis" resource with id "aiApiId"
+    And I extract response field "context" and store it as "aiContext"
+    When I have set up application with keys, subscribed to API "aiApiId" with plan "Unlimited", and obtained access token for "aiSubId"
+    Then The response status code should be 200
+    And I put JSON payload from file "artifacts/payloads/ai/mistral-payload.json" in context as "mistralPayload"
+    # Invoke the AI API's chat-completions resource; the gateway proxies to the mock LLM and returns its response
+    When I invoke the API at gateway context "{{aiContext}}/1.0.0/v1/chat/completions" with method "POST" using access token "generatedAccessToken" and payload "mistralPayload" until response status code becomes 200 within 60 seconds
+    Then The response should contain "chat.completion"
+    # Provider + API teardown is hook-managed (@cleanup): the AI provider is swept after its API (FK order)
+
+    Examples:
+      | actor             |
+      | admin             |
+      | admin@tenant1.com |
+
+  @cap:publisher @feat:api-config @rule:endpoints @type:regression @dep:admin @legacy:AIAPITestCase
+  Scenario Outline: Manage the endpoints of an AI API through the endpoints resource as <actor>
+    Given The system is ready
+    And I have valid access tokens as "<actor>"
+    # An AI provider + AIAPI-subtype API is the subject whose endpoints are managed
+    When I create an AI service provider "TestAIService" version "1.0.0" with config "artifacts/payloads/ai/ai-service-provider-config-no-auth.json" and definition "artifacts/payloads/ai/mistral-def.json" as "aiProviderId"
+    Then The response status code should be 201
+    When I import openapi definition from "artifacts/payloads/ai/mistral-def.json" with additional properties "artifacts/payloads/ai/mistral_no_auth_add_props.json" as "aiApiId"
+    Then The response status code should be 201
+    # Add a production endpoint
+    When I put the following JSON payload in context as "prodEndpointPayload"
+    """
+    {"name": "Prod Endpoint", "deploymentStage": "PRODUCTION", "endpointConfig": {"endpoint_type": "http", "production_endpoints": {"url": "http://nodebackend:3001/jaxrs_basic/services/customers/customerservice/no-auth"}, "endpoint_security": {"production": {"enabled": true, "type": "apikey", "apiKeyIdentifier": "Authorization", "apiKeyValue": "Bearer 123", "apiKeyIdentifierType": "HEADER"}}}}
+    """
+    And I add an endpoint to API "aiApiId" with payload "prodEndpointPayload" as "prodEndpointId"
+    Then The response status code should be 201
+    # Add a sandbox endpoint
+    When I put the following JSON payload in context as "sandboxEndpointPayload"
+    """
+    {"name": "Sandbox Endpoint", "deploymentStage": "SANDBOX", "endpointConfig": {"endpoint_type": "http", "sandbox_endpoints": {"url": "http://nodebackend:3001/jaxrs_basic/services/customers/customerservice/no-auth/sandbox"}, "endpoint_security": {"sandbox": {"enabled": true, "type": "apikey", "apiKeyIdentifier": "Authorization", "apiKeyValue": "Bearer 456", "apiKeyIdentifierType": "HEADER"}}}}
+    """
+    And I add an endpoint to API "aiApiId" with payload "sandboxEndpointPayload" as "sandboxEndpointId"
+    Then The response status code should be 201
+    # List endpoints — both must be present
+    When I retrieve the endpoints of API "aiApiId"
+    Then The response status code should be 200
+    And The response should contain "Prod Endpoint"
+    And The response should contain "Sandbox Endpoint"
+    # Get the production endpoint by id and verify its stage
+    When I retrieve endpoint "prodEndpointId" of API "aiApiId"
+    Then The response status code should be 200
+    And The response should contain "PRODUCTION"
+    # Update the production endpoint's URL and verify it persisted
+    When I put the following JSON payload in context as "prodEndpointUpdatePayload"
+    """
+    {"name": "Prod Endpoint", "deploymentStage": "PRODUCTION", "endpointConfig": {"endpoint_type": "http", "production_endpoints": {"url": "http://nodebackend:3001/jaxrs_basic/services/customers/customerservice/no-auth-updated"}, "endpoint_security": {"production": {"enabled": true, "type": "apikey", "apiKeyIdentifier": "Authorization", "apiKeyValue": "Bearer 456", "apiKeyIdentifierType": "HEADER"}}}}
+    """
+    And I update endpoint "prodEndpointId" of API "aiApiId" with payload "prodEndpointUpdatePayload"
+    Then The response status code should be 200
+    When I retrieve endpoint "prodEndpointId" of API "aiApiId"
+    Then The response status code should be 200
+    And The response should contain "no-auth-updated"
+    # Delete the sandbox endpoint — the production endpoint survives, the sandbox id is gone from the list
+    When I delete endpoint "sandboxEndpointId" of API "aiApiId"
+    Then The response status code should be 200
+    When I retrieve the endpoints of API "aiApiId"
+    Then The response status code should be 200
+    And The response should contain "Prod Endpoint"
+    And The response should not contain "{{sandboxEndpointId}}"
+
+    Examples:
+      | actor             |
+      | admin             |
+      | admin@tenant1.com |
+
+  @cap:gateway @feat:ai-invocation @rule:invocation @type:regression @dep:admin @legacy:AIAPITestCase
+  Scenario Outline: Invoke a published AI API through the gateway using an API key as <actor>
+    Given The system is ready
+    And I have valid access tokens as "<actor>"
+    # Register a no-auth AI service provider (prerequisite for the AIAPI-subtype create); isolated per tenant org
+    When I create an AI service provider "TestAIService" version "1.0.0" with config "artifacts/payloads/ai/ai-service-provider-config-no-auth.json" and definition "artifacts/payloads/ai/mistral-def.json" as "aiProviderId"
+    Then The response status code should be 201
+    # Import the AIAPI-subtype API (its securityScheme includes api_key alongside oauth2)
+    When I import openapi definition from "artifacts/payloads/ai/mistral-def.json" with additional properties "artifacts/payloads/ai/mistral_no_auth_add_props.json" as "aiApiId"
+    Then The response status code should be 201
+    When I deploy the API with id "aiApiId"
+    When I publish the "apis" resource with id "aiApiId"
+    Then The lifecycle status of API "aiApiId" should be "Published"
+    When I retrieve the "apis" resource with id "aiApiId"
+    And I extract response field "context" and store it as "aiContext"
+    # Set up an application subscribed to the AI API, then mint an API key for that application
+    When I have set up application with keys, subscribed to API "aiApiId" with plan "Unlimited", and obtained access token for "aiSubId"
+    Then The response status code should be 200
+    When I put the following JSON payload in context as "apiKeyGenerationPayload"
+    """
+    {"keyName": "AITestAPIKey", "validityPeriod": 3600, "additionalProperties": {"permittedIP": "", "permittedReferer": ""}}
+    """
+    And I request an api key for application id "createdAppId" using payload "apiKeyGenerationPayload"
+    Then The response status code should be 200
+    And I put JSON payload from file "artifacts/payloads/ai/mistral-payload.json" in context as "mistralPayload"
+    # Invoke the AI API's chat-completions resource with the API key; the gateway proxies to the mock LLM
+    When I invoke the API at gateway context "{{aiContext}}/1.0.0/v1/chat/completions" with method "POST" using api key "apiKey" and payload "mistralPayload" until response status code becomes 200 within 60 seconds
+    Then The response should contain "chat.completion"
+    # Provider + API teardown is hook-managed (@cleanup): the AI provider is swept after its API (FK order)
+
+    Examples:
+      | actor             |
+      | admin             |
+      | admin@tenant1.com |
+
+  @cap:gateway @feat:ai-invocation @rule:invocation @type:regression @dep:admin @legacy:AIAPITestCase
+  Scenario Outline: Invoke an AI API whose provider authenticates to a secured backend as <actor>
+    Given The system is ready
+    And I have valid access tokens as "<actor>"
+    # Register an AUTH-ENABLED AI service provider — its authenticationConfiguration injects the API's configured
+    # backend credential into the Authorization header on the backend leg
+    When I create an AI service provider "TestAIService" version "1.0.0" with config "artifacts/payloads/ai/ai-service-provider-config-with-auth.json" and definition "artifacts/payloads/ai/mistral-def.json" as "aiProviderId"
+    Then The response status code should be 201
+    # Import the secured AIAPI — its endpoint_security carries the credential "Bearer 123" and its backend points
+    # at the /with-auth mock LLM route, which returns 401 unless that exact Authorization header is injected
+    When I import openapi definition from "artifacts/payloads/ai/mistral-def.json" with additional properties "artifacts/payloads/ai/mistral_auth_add_props.json" as "aiApiId"
+    Then The response status code should be 201
+    When I deploy the API with id "aiApiId"
+    When I publish the "apis" resource with id "aiApiId"
+    Then The lifecycle status of API "aiApiId" should be "Published"
+    When I retrieve the "apis" resource with id "aiApiId"
+    And I extract response field "context" and store it as "aiContext"
+    When I have set up application with keys, subscribed to API "aiApiId" with plan "Unlimited", and obtained access token for "aiSubId"
+    Then The response status code should be 200
+    And I put JSON payload from file "artifacts/payloads/ai/mistral-payload.json" in context as "mistralPayload"
+    # A 200 here PROVES the gateway injected the backend credential — the /with-auth route rejects with 401 otherwise
+    When I invoke the API at gateway context "{{aiContext}}/1.0.0/v1/chat/completions" with method "POST" using access token "generatedAccessToken" and payload "mistralPayload" until response status code becomes 200 within 60 seconds
+    Then The response should contain "chat.completion"
+
+    Examples:
+      | actor             |
+      | admin             |
+      | admin@tenant1.com |
+
+  @cap:gateway @feat:throttling-enforcement @rule:ai-token-quota @type:regression @dep:admin @legacy:AIAPITestCase
+  Scenario Outline: Enforce an AI token quota — the gateway returns 429 once the token count is exceeded as <actor>
+    Given The system is ready
+    And I have valid access tokens as "<actor>"
+    # An AI-token-quota subscription policy: 300 total tokens/min. The mock LLM reports 358 total tokens per
+    # response, so the accumulated token count exceeds the quota within the first couple of calls → 429.
+    When I create a subscription throttling policy "aiTokenQuota" allowing 300 total tokens per minute
+    Then The response status code should be 201
+    When I create an AI service provider "TestAIService" version "1.0.0" with config "artifacts/payloads/ai/ai-service-provider-config-no-auth.json" and definition "artifacts/payloads/ai/mistral-def.json" as "aiProviderId"
+    Then The response status code should be 201
+    When I import openapi definition from "artifacts/payloads/ai/mistral-def.json" with additional properties "artifacts/payloads/ai/mistral_no_auth_add_props.json" as "aiApiId"
+    Then The response status code should be 201
+    # An app can only subscribe on a tier the API OFFERS — add the AI-token-quota tier to the API's business plans
+    When I retrieve the "apis" resource with id "aiApiId"
+    And I put the response payload in context as "aiApiPayload"
+    When I update the "apis" resource "aiApiId" and "aiApiPayload" with configuration type "policies" and value:
+    """
+    ["Unlimited","{{subThrottlePolicyName}}"]
+    """
+    Then The response status code should be 200
+    When I deploy the API with id "aiApiId"
+    When I publish the "apis" resource with id "aiApiId"
+    Then The lifecycle status of API "aiApiId" should be "Published"
+    When I retrieve the "apis" resource with id "aiApiId"
+    And I extract response field "context" and store it as "aiContext"
+    # Subscribe the application with the AI-token-quota policy (resolved from context), not Unlimited
+    When I have set up application with keys, subscribed to API "aiApiId" with plan "{{subThrottlePolicyName}}", and obtained access token for "aiSubId"
+    Then The response status code should be 200
+    And I put JSON payload from file "artifacts/payloads/ai/mistral-payload.json" in context as "mistralPayload"
+    # Invoke repeatedly; the accumulated token usage trips the quota and the gateway throttles with 429
+    When I invoke the API at gateway context "{{aiContext}}/1.0.0/v1/chat/completions" with method "POST" using access token "generatedAccessToken" and payload "mistralPayload" until response status code becomes 429 within 60 seconds
+    Then The response status code should be 429
+
+    Examples:
+      | actor             |
+      | admin             |
+      | admin@tenant1.com |
+
+  @cap:gateway @feat:failover @rule:model-round-robin @type:regression @dep:admin @legacy:AIAPITestCase
+  Scenario Outline: Route an AI API across models with a weighted round-robin policy as <actor>
+    Given The system is ready
+    And I have valid access tokens as "<actor>"
+    When I create an AI service provider "TestAIService" version "1.0.0" with config "artifacts/payloads/ai/ai-service-provider-config-no-auth.json" and definition "artifacts/payloads/ai/mistral-def.json" as "aiProviderId"
+    Then The response status code should be 201
+    When I import openapi definition from "artifacts/payloads/ai/mistral-def.json" with additional properties "artifacts/payloads/ai/mistral_no_auth_add_props.json" as "aiApiId"
+    Then The response status code should be 201
+    # Attach the modelWeightedRoundRobin AI mediation policy: the request model (mistral-small-latest) is
+    # REWRITTEN to a configured model per weight before the gateway forwards to the backend. Weight 100/0 makes
+    # it deterministic → always mistral-medium-latest (the mock echoes the rewritten model in its response).
+    When I put the following JSON payload in context as "roundRobinConfig"
+    """
+    {"production":[{"vendor":"","model":"mistral-medium-latest","endpointId":"default_production_endpoint","endpointName":"Default Production Endpoint","weight":100},{"vendor":"","model":"mistral-large-latest","endpointId":"default_production_endpoint","endpointName":"Default Production Endpoint","weight":0}],"sandbox":[],"suspendDuration":"5"}
+    """
+    And I apply the AI mediation policy "modelWeightedRoundRobin" with parameter "weightedRoundRobinConfigs" value "roundRobinConfig" to API "aiApiId"
+    Then The response status code should be 200
+    When I deploy the API with id "aiApiId"
+    When I publish the "apis" resource with id "aiApiId"
+    Then The lifecycle status of API "aiApiId" should be "Published"
+    When I retrieve the "apis" resource with id "aiApiId"
+    And I extract response field "context" and store it as "aiContext"
+    When I have set up application with keys, subscribed to API "aiApiId" with plan "Unlimited", and obtained access token for "aiSubId"
+    Then The response status code should be 200
+    And I put JSON payload from file "artifacts/payloads/ai/mistral-payload.json" in context as "mistralPayload"
+    # The response echoes the model the policy selected — proving the round-robin rewrote the request model
+    When I invoke the API at gateway context "{{aiContext}}/1.0.0/v1/chat/completions" with method "POST" using access token "generatedAccessToken" and payload "mistralPayload" until response status code becomes 200 within 60 seconds
+    Then The response should contain "mistral-medium-latest"
+    And The response should not contain "mistral-small-latest"
+
+    Examples:
+      | actor             |
+      | admin             |
+      | admin@tenant1.com |
+
+  # Failover: the target model's endpoint fails (429) and the gateway falls back to the fallback model's endpoint.
+  # (Legacy tested this on a copied API version; version-copy itself is covered by publisher/versioning.feature, so
+  # here failover is the sole subject and runs on a fresh API.)
+  @cap:gateway @feat:failover @rule:model-failover @type:regression @dep:admin @legacy:AIAPITestCase
+  Scenario Outline: Fail an AI API over to a fallback model when the target model endpoint fails as <actor>
+    Given The system is ready
+    And I have valid access tokens as "<actor>"
+    When I create an AI service provider "TestAIService" version "1.0.0" with config "artifacts/payloads/ai/ai-service-provider-config-no-auth.json" and definition "artifacts/payloads/ai/mistral-def.json" as "aiProviderId"
+    Then The response status code should be 201
+    When I import openapi definition from "artifacts/payloads/ai/mistral-def.json" with additional properties "artifacts/payloads/ai/mistral_no_auth_add_props.json" as "aiApiId"
+    Then The response status code should be 201
+    # Add a FAILOVER-TARGET endpoint that returns 429 (the /failover-target mock route)
+    When I put the following JSON payload in context as "failoverEndpointPayload"
+    """
+    {"name": "Failover Endpoint", "deploymentStage": "PRODUCTION", "endpointConfig": {"endpoint_type": "http", "production_endpoints": {"url": "http://nodebackend:3001/jaxrs_basic/services/customers/customerservice/failover-target"}}}
+    """
+    And I add an endpoint to API "aiApiId" with payload "failoverEndpointPayload" as "failoverEndpointId"
+    Then The response status code should be 201
+    # Make the failover endpoint the PRIMARY production endpoint so the gateway hits it first (429) → failover
+    When I set the primary production endpoint of API "aiApiId" to "failoverEndpointId"
+    Then The response status code should be 200
+    # modelFailover: try mistral-small-latest on the failover endpoint (429) → fall back to mistral-large-latest on
+    # the default (echoing) endpoint. A large-model response therefore PROVES failover triggered.
+    When I put the following JSON payload in context as "failoverConfig"
+    """
+    {"production":{"targetModel":{"model":"mistral-small-latest","endpointId":"{{failoverEndpointId}}","endpointName":"Failover Endpoint"},"fallbackModels":[{"model":"mistral-large-latest","endpointId":"default_production_endpoint","endpointName":"Default Production Endpoint"}]},"sandbox":{"targetModel":{},"fallbackModels":[]},"requestTimeout":"120","suspendDuration":"0"}
+    """
+    And I apply the AI mediation policy "modelFailover" with parameter "failoverConfigs" value "failoverConfig" to API "aiApiId"
+    Then The response status code should be 200
+    When I deploy the API with id "aiApiId"
+    When I publish the "apis" resource with id "aiApiId"
+    Then The lifecycle status of API "aiApiId" should be "Published"
+    When I retrieve the "apis" resource with id "aiApiId"
+    And I extract response field "context" and store it as "aiContext"
+    When I have set up application with keys, subscribed to API "aiApiId" with plan "Unlimited", and obtained access token for "aiSubId"
+    Then The response status code should be 200
+    And I put JSON payload from file "artifacts/payloads/ai/mistral-payload.json" in context as "mistralPayload"
+    # The response echoes the FALLBACK model — proving the target's 429 triggered failover to the fallback endpoint
+    When I invoke the API at gateway context "{{aiContext}}/1.0.0/v1/chat/completions" with method "POST" using access token "generatedAccessToken" and payload "mistralPayload" until response status code becomes 200 within 60 seconds
+    Then The response should contain "mistral-large-latest"
+
+    Examples:
+      | actor             |
+      | admin             |
+      | admin@tenant1.com |
+
+  # Admin provider CRUD — UPDATE: register a no-auth provider, then update its configurations (no-auth →
+  # auth-enabled) and description via the multipart PUT, and confirm the change persisted on a GET. Ports
+  # AIAPITestCase#updateCustomAiServiceProvider.
+  @cap:gateway @feat:ai-invocation @rule:provider-update @type:regression @dep:admin @legacy:AIAPITestCase
+  Scenario Outline: Update an AI service provider and verify the change persisted as <actor>
+    Given The system is ready
+    And I have valid access tokens as "<actor>"
+    When I create an AI service provider "TestAIService" version "1.0.0" with config "artifacts/payloads/ai/ai-service-provider-config-no-auth.json" and definition "artifacts/payloads/ai/mistral-def.json" as "aiProviderId"
+    Then The response status code should be 201
+    # Update the provider's configurations (no-auth → auth-enabled) and description
+    When I update the AI service provider "aiProviderId" named "TestAIService" version "1.0.0" to config "artifacts/payloads/ai/ai-service-provider-config-with-auth.json" with definition "artifacts/payloads/ai/mistral-def.json" and description "Updated AI service provider config"
+    Then The response status code should be 200
+    # GET the provider and confirm the update persisted
+    When I retrieve the AI service provider "aiProviderId"
+    Then The response status code should be 200
+    And The response should contain "Updated AI service provider config"
+
+    Examples:
+      | actor             |
+      | admin             |
+      | admin@tenant1.com |
+
+  # Provider models: register a provider with an explicit model list, then retrieve it via the publisher
+  # models endpoint and assert all three models are present. Ports AIAPITestCase#testGetServiceProviderModels.
+  @cap:gateway @feat:ai-invocation @rule:provider-models @type:regression @dep:admin @legacy:AIAPITestCase
+  Scenario Outline: Retrieve an AI service provider's registered model list as <actor>
+    Given The system is ready
+    And I have valid access tokens as "<actor>"
+    When I create an AI service provider "TestAIService" version "1.0.0" with config "artifacts/payloads/ai/ai-service-provider-config-no-auth.json" definition "artifacts/payloads/ai/mistral-def.json" and models "mistral-small-latest,mistral-medium-latest,mistral-large-latest" as "aiProviderId"
+    Then The response status code should be 201
+    When I retrieve the models of AI service provider "aiProviderId"
+    Then The response status code should be 200
+    And The response should contain "mistral-small-latest"
+    And The response should contain "mistral-medium-latest"
+    And The response should contain "mistral-large-latest"
+
+    Examples:
+      | actor             |
+      | admin             |
+      | admin@tenant1.com |

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/features/gateway/api_product_invocation.feature
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/features/gateway/api_product_invocation.feature
@@ -1,0 +1,282 @@
+@cleanup
+Feature: Gateway API Product Invocation
+
+  Ports the invocation + lifecycle-stage behaviour of the legacy APIProductCreationTestCase / APIProductLifecycleTest:
+  an API Product, once deployed + published + subscribed, is invocable at the gateway through its own context
+  (routing to the aggregated API's backend), and the gateway response tracks the product's lifecycle state
+  (PUBLISHED → 200, BLOCKED → 503, DEPRECATED → 200, RETIRED → 404) — the product analogue of
+  gateway/lifecycle_stage_invocation. Single-tenant (super) for the lifecycle arc; the create/invoke smoke runs
+  ×2. Runs in the concurrent IntegrationV2-Gateway block (backend started). Teardown via @cleanup.
+
+  @cap:gateway @feat:rest-invocation @type:smoke @dep:publisher @legacy:APIProductCreationTestCase
+  Scenario Outline: Invoke a published API product through the gateway as <actor>
+    Given The system is ready
+    And I have valid access tokens as "<actor>"
+    And I have created an api from "artifacts/payloads/create_apim_test_api.json" as "prodApiId" and deployed it
+    When I create an API product "${UNIQUE:InvokeProduct}" with context "${UNIQUE:invokeProductCtx}" from API "prodApiId" as "productId"
+    Then The response status code should be 201
+    # Deploy a product revision, publish, and capture the product's gateway context.
+    When I put the following JSON payload in context as "prodRev"
+    """
+    {"description":"initial product revision"}
+    """
+    And I make a request to create a revision for "api-products" resource "productId" with payload "prodRev"
+    When I put the following JSON payload in context as "prodDeploy"
+    """
+    [{"name":"{{gatewayEnvironment}}","vhost":"localhost","displayOnDevportal":true}]
+    """
+    And I make a request to deploy revision "revisionId" of "api-products" resource "productId" with payload "prodDeploy"
+    Then The response status code should be 201
+    When I publish the "api-products" resource with id "productId"
+    Then The response status code should be 200
+    When I retrieve the "api-products" resource with id "productId"
+    And I extract response field "context" and store it as "productContext"
+    # Subscribe an application and invoke the product's aggregated resource.
+    When I have set up application with keys, subscribed to API "productId", and obtained access token for "prodSubId"
+    Then The response status code should be 200
+    When I invoke the API at gateway context "{{productContext}}/1.0.0/customers/123/" with method "GET" using access token "generatedAccessToken" and payload "" until response status code becomes 200 within 60 seconds
+    Then The response status code should be 200
+
+    Examples:
+      | actor             |
+      | admin             |
+      | admin@tenant1.com |
+
+  @cap:gateway @feat:rest-invocation @type:regression @dep:publisher @legacy:APIProductLifecycleTest
+  Scenario Outline: The gateway response to an API product invocation tracks its lifecycle state as <actor>
+    Given The system is ready
+    And I have valid access tokens as "<actor>"
+    And I have created an api from "artifacts/payloads/create_apim_test_api.json" as "lcApiId" and deployed it
+    When I create an API product "${UNIQUE:LcProduct}" with context "${UNIQUE:lcProductCtx}" from API "lcApiId" as "lcProductId"
+    Then The response status code should be 201
+    When I put the following JSON payload in context as "lcRev"
+    """
+    {"description":"initial product revision"}
+    """
+    And I make a request to create a revision for "api-products" resource "lcProductId" with payload "lcRev"
+    When I put the following JSON payload in context as "lcDeploy"
+    """
+    [{"name":"{{gatewayEnvironment}}","vhost":"localhost","displayOnDevportal":true}]
+    """
+    And I make a request to deploy revision "revisionId" of "api-products" resource "lcProductId" with payload "lcDeploy"
+    Then The response status code should be 201
+    When I publish the "api-products" resource with id "lcProductId"
+    Then The response status code should be 200
+    When I retrieve the "api-products" resource with id "lcProductId"
+    And I extract response field "context" and store it as "lcProductContext"
+    When I have set up application with keys, subscribed to API "lcProductId", and obtained access token for "lcSubId"
+    Then The response status code should be 200
+
+    # PUBLISHED → invocable.
+    When I invoke the API at gateway context "{{lcProductContext}}/1.0.0/customers/123/" with method "GET" using access token "generatedAccessToken" and payload "" until response status code becomes 200 within 60 seconds
+    Then The response status code should be 200
+
+    # BLOCKED → gateway refuses (503).
+    When I change the lifecycle of "api-products" resource "lcProductId" with action "Block"
+    Then The response status code should be 200
+    When I invoke the API at gateway context "{{lcProductContext}}/1.0.0/customers/123/" with method "GET" using access token "generatedAccessToken" and payload "" until response status code becomes 503 within 60 seconds
+    Then The response status code should be 503
+
+    # DEPRECATED → still invocable (200).
+    When I change the lifecycle of "api-products" resource "lcProductId" with action "Deprecate"
+    Then The response status code should be 200
+    When I invoke the API at gateway context "{{lcProductContext}}/1.0.0/customers/123/" with method "GET" using access token "generatedAccessToken" and payload "" until response status code becomes 200 within 60 seconds
+    Then The response status code should be 200
+    # (RETIRED is a publisher/delete concern for products — see publisher/api_products "lifecycle … deleted when
+    #  retired". Unlike a retired API (404), a retired product's key validation fails with 900900/500, which the
+    #  legacy never asserted, so it is deliberately not asserted at the gateway here.)
+
+    Examples:
+      | actor             |
+      | admin             |
+      | admin@tenant1.com |
+
+  # D2: a scope gated on the source API's operation is enforced when the operation is invoked through a product
+  # — a token WITH the scope succeeds (200), one WITHOUT it is refused (403). Ports
+  # APIProductCreationTestCase#testCreateAndInvokeApiProductWithScopes.
+  @cap:gateway @feat:security-enforcement @rule:product @type:regression @dep:publisher @legacy:APIProductCreationTestCase
+  Scenario Outline: A scope-gated operation is enforced when invoked through an API product as <actor>
+    Given The system is ready
+    And I have valid access tokens as "<actor>"
+    And I have created an api from "artifacts/payloads/create_apim_test_api.json" as "scopedApiId" and deployed it
+    When I create a new shared scope as "prodScopeEnf"
+    Then The response status code should be 201
+    # Register the scope on the API and gate the GET /customers/{id} operation with it.
+    When I retrieve the "apis" resource with id "scopedApiId"
+    And I put the response payload in context as "scopedApiPayload"
+    When I update the "apis" resource "scopedApiId" and "scopedApiPayload" with configuration type "scopes" and value:
+      """
+      [{"shared":true,"scope":{"name":"prodScopeEnf","displayName":"prodScopeEnf","description":"product scope enforcement","bindings":["admin"]}}]
+      """
+    Then The response status code should be 200
+    When I retrieve the "apis" resource with id "scopedApiId"
+    And I put the response payload in context as "scopedApiPayload"
+    When I update the "apis" resource "scopedApiId" and "scopedApiPayload" with configuration type "operations" and value:
+      """
+      [{"target":"/customers/{id}","verb":"GET","authType":"Application & Application User","throttlingPolicy":"Unlimited","scopes":["prodScopeEnf"],"operationPolicies":{"request":[],"response":[],"fault":[]}},{"target":"/customers/{id}","verb":"DELETE","authType":"Application & Application User","throttlingPolicy":"Unlimited","scopes":[],"operationPolicies":{"request":[],"response":[],"fault":[]}}]
+      """
+    Then The response status code should be 200
+    # Aggregate the scoped API into a product (the product inherits the gated operation), deploy and publish.
+    When I create an API product "${UNIQUE:ScopeProduct}" with context "${UNIQUE:scopeProductCtx}" from API "scopedApiId" as "scopeProductId"
+    Then The response status code should be 201
+    When I put the following JSON payload in context as "scopeRev"
+    """
+    {"description":"scoped product revision"}
+    """
+    And I make a request to create a revision for "api-products" resource "scopeProductId" with payload "scopeRev"
+    When I put the following JSON payload in context as "scopeDeploy"
+    """
+    [{"name":"{{gatewayEnvironment}}","vhost":"localhost","displayOnDevportal":true}]
+    """
+    And I make a request to deploy revision "revisionId" of "api-products" resource "scopeProductId" with payload "scopeDeploy"
+    Then The response status code should be 201
+    When I publish the "api-products" resource with id "scopeProductId"
+    Then The response status code should be 200
+    When I retrieve the "api-products" resource with id "scopeProductId"
+    And I extract response field "context" and store it as "scopeProductContext"
+    # Subscribe an application and key it.
+    When I put JSON payload from file "artifacts/payloads/create_apim_test_app.json" in context as "createAppPayload"
+    And I create an application with payload "createAppPayload"
+    Then The response status code should be 201
+    When I put the following JSON payload in context as "generateApplicationKeysPayload"
+    """
+    {"keyType": "PRODUCTION", "grantTypesToBeSupported": ["client_credentials", "password"]}
+    """
+    And I generate client credentials for application id "createdAppId" with payload "generateApplicationKeysPayload"
+    Then The response status code should be 200
+    When I put the following JSON payload in context as "apiSubscriptionPayload"
+    """
+    {"applicationId": "{{applicationId}}", "apiId": "{{apiId}}", "throttlingPolicy": "Unlimited"}
+    """
+    And I subscribe to API "scopeProductId" using application "createdAppId" with payload "apiSubscriptionPayload" as "scopeSubId"
+    Then The response status code should be 201
+    # A token WITH the scope invokes the gated operation (200); one WITHOUT it (a different scope) is refused (403).
+    When I request an OAuth access token for the current user using password grant with scope "prodScopeEnf"
+    Then The response status code should be 200
+    When I invoke the API at gateway context "{{scopeProductContext}}/1.0.0/customers/123/" with method "GET" using access token "generatedAccessToken" and payload "" until response status code becomes 200 within 60 seconds
+    Then The response status code should be 200
+    When I request an OAuth access token for the current user using password grant with scope "openid"
+    Then The response status code should be 200
+    And I invoke the API at gateway context "{{scopeProductContext}}/1.0.0/customers/123/" with method "GET" using access token "generatedAccessToken" and payload "" until response status code becomes 403 within 60 seconds
+    Then The response status code should be 403
+
+    Examples:
+      | actor             |
+      | admin             |
+      | admin@tenant1.com |
+
+  # D1: a product that aggregates an API whose devportal visibility is RESTRICTED (visibleRoles) is still
+  # invocable through the product (the source API's visibility restriction does not block product invocation).
+  # Ports APIProductCreationTestCase#testCreateAndInvokeApiProductWithVisibilityRestrictedApi (whose
+  # invocationStatusCodes is empty — i.e. all operations expected to return 200, no 403).
+  @cap:gateway @feat:rest-invocation @rule:product @type:regression @dep:publisher @legacy:APIProductCreationTestCase
+  Scenario Outline: A product aggregating a visibility-restricted API is invocable as <actor>
+    Given The system is ready
+    And I have valid access tokens as "<actor>"
+    And I have created an api from "artifacts/payloads/create_apim_restricted_visibility_api.json" as "restrictedApiId" and deployed it
+    When I create an API product "${UNIQUE:RestrictedProduct}" with context "${UNIQUE:restrictedProductCtx}" from API "restrictedApiId" as "restrictedProductId"
+    Then The response status code should be 201
+    When I put the following JSON payload in context as "restrictedRev"
+    """
+    {"description":"restricted-visibility product revision"}
+    """
+    And I make a request to create a revision for "api-products" resource "restrictedProductId" with payload "restrictedRev"
+    When I put the following JSON payload in context as "restrictedDeploy"
+    """
+    [{"name":"{{gatewayEnvironment}}","vhost":"localhost","displayOnDevportal":true}]
+    """
+    And I make a request to deploy revision "revisionId" of "api-products" resource "restrictedProductId" with payload "restrictedDeploy"
+    Then The response status code should be 201
+    When I publish the "api-products" resource with id "restrictedProductId"
+    Then The response status code should be 200
+    When I retrieve the "api-products" resource with id "restrictedProductId"
+    And I extract response field "context" and store it as "restrictedProductContext"
+    When I have set up application with keys, subscribed to API "restrictedProductId", and obtained access token for "restrictedSubId"
+    Then The response status code should be 200
+    When I invoke the API at gateway context "{{restrictedProductContext}}/1.0.0/customers/123/" with method "GET" using access token "generatedAccessToken" and payload "" until response status code becomes 200 within 60 seconds
+    Then The response status code should be 200
+
+    Examples:
+      | actor             |
+      | admin             |
+      | admin@tenant1.com |
+
+  # D4: a product that aggregates an advertise-only API is invocable through the product — the product provides
+  # the gateway routing (to the advertised API's external endpoint, here the node backend), even though an
+  # advertise-only API is not itself gateway-deployed. Ports
+  # APIProductCreationTestCase#testCreateApiProductWithAdvertiseOnlyApi. The advertised API is only CREATED
+  # (not deployed); only the product is deployed.
+  @cap:gateway @feat:rest-invocation @rule:product @type:regression @dep:publisher @legacy:APIProductCreationTestCase
+  Scenario Outline: A product aggregating an advertise-only API is invocable as <actor>
+    Given The system is ready
+    And I have valid access tokens as "<actor>"
+    When I put JSON payload from file "artifacts/payloads/create_apim_advertise_api.json" in context as "advertisePayload"
+    And I create an "apis" resource with payload "advertisePayload" as "advertiseApiId"
+    Then The response status code should be 201
+    When I create an API product "${UNIQUE:AdvertiseProduct}" with context "${UNIQUE:advertiseProductCtx}" from API "advertiseApiId" as "advertiseProductId"
+    Then The response status code should be 201
+    When I put the following JSON payload in context as "advertiseRev"
+    """
+    {"description":"advertise product revision"}
+    """
+    And I make a request to create a revision for "api-products" resource "advertiseProductId" with payload "advertiseRev"
+    When I put the following JSON payload in context as "advertiseDeploy"
+    """
+    [{"name":"{{gatewayEnvironment}}","vhost":"localhost","displayOnDevportal":true}]
+    """
+    And I make a request to deploy revision "revisionId" of "api-products" resource "advertiseProductId" with payload "advertiseDeploy"
+    Then The response status code should be 201
+    When I publish the "api-products" resource with id "advertiseProductId"
+    Then The response status code should be 200
+    When I retrieve the "api-products" resource with id "advertiseProductId"
+    And I extract response field "context" and store it as "advertiseProductContext"
+    When I have set up application with keys, subscribed to API "advertiseProductId", and obtained access token for "advertiseSubId"
+    Then The response status code should be 200
+    When I invoke the API at gateway context "{{advertiseProductContext}}/1.0.0/customers/123/" with method "GET" using access token "generatedAccessToken" and payload "" until response status code becomes 200 within 60 seconds
+    Then The response status code should be 200
+
+    Examples:
+      | actor             |
+      | admin             |
+      | admin@tenant1.com |
+
+  # D3: a request-flow operation policy (jsonToXML) on the source API's operation is applied when the operation
+  # is invoked through a product — a JSON request body is transformed to XML before reaching the backend (which
+  # echoes the body it received). Ports
+  # APIProductCreationTestCase#testCreateAndInvokeApiProductWithOperationPoliciesInRequestApi.
+  @cap:gateway @feat:mediation-policies @rule:product @type:regression @dep:publisher @legacy:APIProductCreationTestCase
+  Scenario Outline: A request-transformation operation policy is applied when invoked through an API product as <actor>
+    Given The system is ready
+    And I have valid access tokens as "<actor>"
+    And I have created an api from "artifacts/payloads/create_apim_optransform_api.json" as "opPolicyApiId" and deployed it
+    When I create an API product "${UNIQUE:OpPolicyProduct}" with context "${UNIQUE:opPolicyProductCtx}" from API "opPolicyApiId" as "opPolicyProductId"
+    Then The response status code should be 201
+    When I put the following JSON payload in context as "opPolicyRev"
+    """
+    {"description":"operation-policy product revision"}
+    """
+    And I make a request to create a revision for "api-products" resource "opPolicyProductId" with payload "opPolicyRev"
+    When I put the following JSON payload in context as "opPolicyDeploy"
+    """
+    [{"name":"{{gatewayEnvironment}}","vhost":"localhost","displayOnDevportal":true}]
+    """
+    And I make a request to deploy revision "revisionId" of "api-products" resource "opPolicyProductId" with payload "opPolicyDeploy"
+    Then The response status code should be 201
+    When I publish the "api-products" resource with id "opPolicyProductId"
+    Then The response status code should be 200
+    When I retrieve the "api-products" resource with id "opPolicyProductId"
+    And I extract response field "context" and store it as "opPolicyProductContext"
+    When I have set up application with keys, subscribed to API "opPolicyProductId", and obtained access token for "opPolicySubId"
+    Then The response status code should be 200
+    # A JSON request body is converted to XML by the jsonToXML request policy before reaching the reflecting backend.
+    When I put the following JSON payload in context as "opPolicyBody"
+    """
+    {"foo":"bar"}
+    """
+    And I invoke the API at gateway context "{{opPolicyProductContext}}/1.0.0/reflect-body" with method "POST" using access token "generatedAccessToken" and payload "opPolicyBody" until response body contains "<jsonObject>" within 60 seconds
+    Then The response should contain "<foo>bar</foo>"
+
+    Examples:
+      | actor             |
+      | admin             |
+      | admin@tenant1.com |

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/features/gateway/graphql_endpoint_security.feature
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/features/gateway/graphql_endpoint_security.feature
@@ -1,0 +1,42 @@
+@cleanup
+Feature: Gateway GraphQL Endpoint Security
+
+  The gateway injects the backend credential (endpoint_security) when invoking a GraphQL API whose backend
+  requires authentication. The node /graphql-secured endpoint returns 401 without `Authorization: Bearer
+  graphql-secret`; the API's endpoint_security.production carries that credential and the gateway injects it, so
+  the query returns 200. Documented endpoint security applied to GraphQL (the analogue of the AI secured-provider
+  flow). Ports the backend-auth dimension of GraphqlTestCase. Single-tenant (super).
+
+  @cap:gateway @feat:graphql-invocation @rule:endpoint-security @type:regression @dep:publisher @legacy:GraphqlTestCase
+  Scenario: A GraphQL API's required backend credential is injected by the gateway
+    Given The system is ready
+    And I have valid access tokens as "admin"
+    And I put JSON payload from file "artifacts/payloads/create_apim_graphql_secured_api.json" in context as "gqlSecPayload"
+    And I create a GraphQL API with schema file "artifacts/payloads/graphql_schema.graphql" and additional properties "gqlSecPayload" as "gqlSecApiId"
+    Then The response status code should be 201
+    When I retrieve the "apis" resource with id "gqlSecApiId"
+    And I put the response payload in context as "gqlSecFullPayload"
+    And I extract response field "context" and store it as "gqlSecContext"
+    # import-graphql-schema silently drops endpointConfig when endpoint_security is present, so the backend
+    # credential cannot be set at create time — it must be applied via the endpoint-config UPDATE path.
+    And I put the following JSON payload in context as "gqlSecEndpointConfig"
+    """
+    {"endpoint_type":"http","sandbox_endpoints":{"url":"http://nodebackend:3003/graphql-secured"},"production_endpoints":{"url":"http://nodebackend:3003/graphql-secured"},"endpoint_security":{"production":{"enabled":true,"type":"apikey","apiKeyIdentifier":"Authorization","apiKeyValue":"Bearer graphql-secret","apiKeyIdentifierType":"HEADER"},"sandbox":{"enabled":true,"type":"apikey","apiKeyIdentifier":"Authorization","apiKeyValue":"Bearer graphql-secret","apiKeyIdentifierType":"HEADER"}}}
+    """
+    And I update the "apis" resource "gqlSecApiId" and "gqlSecFullPayload" with configuration type "endpointConfig" and value:
+    """
+    gqlSecEndpointConfig
+    """
+    Then The response status code should be 200
+    And I deploy the API with id "gqlSecApiId"
+    When I publish the "apis" resource with id "gqlSecApiId"
+    Then The lifecycle status of API "gqlSecApiId" should be "Published"
+    When I have set up application with keys, subscribed to API "gqlSecApiId", and obtained access token for "gqlSecSubId"
+    Then The response status code should be 200
+    When I put the following JSON payload in context as "gqlSecQuery"
+    """
+    {"query": "{languages{code name}}"}
+    """
+    # Reaching 200 PROVES injection: /graphql-secured returns 401 without the Bearer credential the gateway injects
+    And I invoke the API at gateway context "{{gqlSecContext}}/1.0.0" with method "POST" using access token "generatedAccessToken" and payload "gqlSecQuery" until response status code becomes 200 within 60 seconds
+    Then The response status code should be 200

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/features/gateway/graphql_invocation.feature
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/features/gateway/graphql_invocation.feature
@@ -45,3 +45,41 @@ Feature: Gateway GraphQL API Invocation
       | actor             |
       | admin             |
       | admin@tenant1.com |
+
+  # Token-type parity: invoke the GraphQL query with BOTH a JWT application token (the product default, validated
+  # locally by the gateway) and an OAUTH/opaque application token (a reference token validated via key-manager
+  # introspection — a DISTINCT gateway validation path). Ports the JWT-app + oauth-app invocation of GraphqlTestCase.
+  # Single-tenant (super): token-type validation is server-wide; the ×2-tenant smoke above already covers routing.
+  @cap:gateway @feat:graphql-invocation @rule:token-type @type:regression @dep:publisher @legacy:GraphqlTestCase
+  Scenario Outline: Invoke a GraphQL API with a <tokenType> application token
+    Given The system is ready
+    And I have valid access tokens as "admin"
+    And I put JSON payload from file "artifacts/payloads/create_apim_test_graphql_api.json" in context as "graphQLAPIPayload"
+    And I create a GraphQL API with schema file "artifacts/payloads/graphql_schema.graphql" and additional properties "graphQLAPIPayload" as "graphqlApiId"
+    Then The response status code should be 201
+    When I retrieve the "apis" resource with id "graphqlApiId"
+    And I put the response payload in context as "graphqlRetrievedPayload"
+    And I extract response field "context" and store it as "graphqlApiContext"
+    When I put the following JSON payload in context as "createRevisionPayload"
+    """
+    {"description":"Initial Revision"}
+    """
+    And I make a request to create a revision for "apis" resource "graphqlApiId" with payload "createRevisionPayload"
+    And I deploy revision "revisionId" of "apis" resource "graphqlApiId"
+    Then The response status code should be 201
+    And I wait for deployment of the resource in "graphqlRetrievedPayload"
+    And I publish the "apis" resource with id "graphqlApiId"
+    Then The lifecycle status of API "graphqlApiId" should be "Published"
+    When I have set up a "<tokenType>" token type application with keys, subscribed to API "graphqlApiId" with plan "Unlimited", and obtained access token for "graphqlTokenTypeSubId"
+    Then The response status code should be 200
+    When I put the following JSON payload in context as "graphqlQuery"
+    """
+    {"query": "{languages{code name}}"}
+    """
+    And I invoke the API at gateway context "{{graphqlApiContext}}/1.0.0" with method "POST" using access token "generatedAccessToken" and payload "graphqlQuery" until response status code becomes 200 within 60 seconds
+    Then The response status code should be 200
+
+    Examples:
+      | tokenType |
+      | JWT       |
+      | OAUTH     |

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/features/gateway/graphql_query_limits.feature
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/features/gateway/graphql_query_limits.feature
@@ -1,0 +1,71 @@
+@cleanup
+Feature: Gateway GraphQL Query Limits (HTTP)
+
+  Gateway-plane GraphQL query-analysis limits on an HTTP query (not a subscription): the gateway computes the
+  query's complexity/depth and rejects an over-limit query BEFORE it reaches the backend. This is the documented
+  HTTP variant (enforce-graphql-query-limits) of the complexity/depth limits — the subscription variant returns a
+  graphql-ws 4021/4020 frame, whereas over HTTP the gateway returns a 400 with a "QUERY TOO COMPLEX / TOO DEEP"
+  error. Single-tenant (super) — the limits are API/policy-scoped.
+
+  @cap:gateway @feat:graphql-invocation @rule:query-limits @type:regression @dep:admin @legacy:GraphqlTestCase
+  Scenario: An over-complex HTTP GraphQL query is rejected
+    Given The system is ready
+    And I have valid access tokens as "admin"
+    When I create a subscription throttling policy "${UNIQUE:gqlQComplex1}" with max complexity 1 and max depth 8
+    Then The response status code should be 201
+    And I put JSON payload from file "artifacts/payloads/create_apim_test_graphql_api.json" in context as "gqlQPayload"
+    And I create a GraphQL API with schema file "artifacts/payloads/graphql_schema.graphql" and additional properties "gqlQPayload" as "gqlQApiId"
+    When I retrieve the "apis" resource with id "gqlQApiId"
+    And I put the response payload in context as "gqlQApiPayload"
+    And I extract response field "context" and store it as "gqlQContext"
+    When I update the "apis" resource "gqlQApiId" and "gqlQApiPayload" with configuration type "policies" and value:
+    """
+    ["Unlimited","{{subThrottlePolicyName}}"]
+    """
+    Then The response status code should be 200
+    When I put JSON payload from file "artifacts/payloads/graphql_query_complexity.json" in context as "gqlQComplexityPayload"
+    And I set the GraphQL complexity for API "gqlQApiId" from payload "gqlQComplexityPayload"
+    Then The response status code should be 200
+    And I deploy the API with id "gqlQApiId"
+    When I publish the "apis" resource with id "gqlQApiId"
+    Then The lifecycle status of API "gqlQApiId" should be "Published"
+    When I have set up application with keys, subscribed to API "gqlQApiId" with plan "{{subThrottlePolicyName}}", and obtained access token for "gqlQComplexSubId"
+    Then The response status code should be 200
+    When I put the following JSON payload in context as "gqlComplexQuery"
+    """
+    {"query": "{ languages { code name } }"}
+    """
+    # complexity 3 (languages + code + name) exceeds max complexity 1 → rejected (400, QUERY TOO COMPLEX)
+    And I invoke the API at gateway context "{{gqlQContext}}/1.0.0" with method "POST" using access token "generatedAccessToken" and payload "gqlComplexQuery" until response status code becomes 400 within 60 seconds
+    Then The response status code should be 400
+    And The response should contain "COMPLEX"
+
+  @cap:gateway @feat:graphql-invocation @rule:query-limits @type:regression @dep:admin @legacy:GraphqlTestCase
+  Scenario: An over-deep HTTP GraphQL query is rejected
+    Given The system is ready
+    And I have valid access tokens as "admin"
+    When I create a subscription throttling policy "${UNIQUE:gqlQDepth1}" with max complexity 100 and max depth 1
+    Then The response status code should be 201
+    And I put JSON payload from file "artifacts/payloads/create_apim_test_graphql_api.json" in context as "gqlQPayload2"
+    And I create a GraphQL API with schema file "artifacts/payloads/graphql_schema.graphql" and additional properties "gqlQPayload2" as "gqlQApiId2"
+    When I retrieve the "apis" resource with id "gqlQApiId2"
+    And I put the response payload in context as "gqlQApiPayload2"
+    And I extract response field "context" and store it as "gqlQContext2"
+    When I update the "apis" resource "gqlQApiId2" and "gqlQApiPayload2" with configuration type "policies" and value:
+    """
+    ["Unlimited","{{subThrottlePolicyName}}"]
+    """
+    Then The response status code should be 200
+    And I deploy the API with id "gqlQApiId2"
+    When I publish the "apis" resource with id "gqlQApiId2"
+    Then The lifecycle status of API "gqlQApiId2" should be "Published"
+    When I have set up application with keys, subscribed to API "gqlQApiId2" with plan "{{subThrottlePolicyName}}", and obtained access token for "gqlQDepthSubId"
+    Then The response status code should be 200
+    When I put the following JSON payload in context as "gqlDeepQuery"
+    """
+    {"query": "{ languages { code name } }"}
+    """
+    # depth 2 (languages -> code/name) exceeds max depth 1 → rejected (400, QUERY TOO DEEP)
+    And I invoke the API at gateway context "{{gqlQContext2}}/1.0.0" with method "POST" using access token "generatedAccessToken" and payload "gqlDeepQuery" until response status code becomes 400 within 60 seconds
+    Then The response status code should be 400
+    And The response should contain "DEEP"

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/features/gateway/mcp_invocation.feature
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/features/gateway/mcp_invocation.feature
@@ -1,0 +1,368 @@
+@cleanup
+Feature: MCP tool invocation through the gateway
+
+  Gateway-plane invocation of MCP tools across all three creation types (proxy / from-OpenAPI / from-API): the
+  full stateful MCP JSON-RPC handshake, scope enforcement (200 with scope / 403 without), and subscription
+  throttling (429). Publisher-plane CRUD is in publisher/mcp_servers.feature. Needs the node MCP backend. ×2 tenant.
+
+  # Invocation: publish + subscribe + the full stateful MCP handshake through the gateway.
+  @cap:gateway @feat:mcp-invocation @rule:proxy @type:regression @dep:publisher @legacy:MCPServerTestCase
+  Scenario Outline: Invoke a tool on a proxied MCP server through the gateway as <actor>
+    Given The system is ready
+    And I have valid access tokens as "<actor>"
+    When I create an MCP server proxy to "http://nodebackend:3020/mcp" exposing tools "echo,add,get_pets" as "mcpId"
+    Then The response status code should be 201
+    When I deploy the "mcp-servers" resource with id "mcpId"
+    When I publish the "mcp-servers" resource with id "mcpId"
+    Then The response status code should be 200
+    When I retrieve the "mcp-servers" resource with id "mcpId"
+    And I extract response field "context" and store it as "mcpContext"
+    When I have set up application with keys, subscribed to API "mcpId" with plan "Unlimited", and obtained access token for "mcpSubId"
+    Then The response status code should be 200
+    # Full MCP handshake through the gateway: initialize (session) → notifications/initialized → tools/list
+    # (must advertise echo) → tools/call echo — the stateful round-trip to the real SDK-backed MCP server.
+    When I invoke the MCP tool "echo" with arguments "{\"message\":\"hello mcp\"}" at gateway context "{{mcpContext}}" version "1.0.0" using access token "generatedAccessToken" expecting result containing "hello mcp" within 90 seconds
+    # Value-add 1 — REAL tool execution (legacy asserted only canned echoes): args are forwarded and the real
+    # result is computed/returned by the SDK server (add 2+3=5; get_pets returns actual pet data).
+    When I invoke the MCP tool "add" with arguments "{\"a\":2,\"b\":3}" at gateway context "{{mcpContext}}" version "1.0.0" using access token "generatedAccessToken" expecting result containing "5" within 90 seconds
+    When I invoke the MCP tool "get_pets" with arguments "{}" at gateway context "{{mcpContext}}" version "1.0.0" using access token "generatedAccessToken" expecting result containing "max" within 90 seconds
+    # Value-add 2 — multi-call SESSION CONTINUITY: one initialize, then several tools/call on the SAME
+    # Mcp-Session-Id (proves the gateway persists MCP session state across calls).
+    When I invoke MCP tools in one session at gateway context "{{mcpContext}}" version "1.0.0" using access token "generatedAccessToken" with calls "echo|{\"message\":\"multi\"}|multi ; add|{\"a\":10,\"b\":20}|30" within 90 seconds
+    # Value-add 3 — JSON-RPC error passthrough: a non-exposed tool yields an MCP error through the gateway.
+    When I invoke the MCP tool "nosuchtool" with arguments "{}" at gateway context "{{mcpContext}}" version "1.0.0" using access token "generatedAccessToken" expecting an error within 90 seconds
+    # Value-add 4 — negative auth at the gateway: an invalid token is rejected (401).
+    When I invoke the MCP server at gateway context "{{mcpContext}}" version "1.0.0" with an invalid token expecting status 401 within 60 seconds
+    When I delete the MCP server "mcpId"
+
+    Examples:
+      | actor             |
+      | admin             |
+      | admin@tenant1.com |
+
+  # Enforcement: a scope-gated MCP tool is refused (403) without the scope and allowed (200) with it.
+  @cap:gateway @feat:mcp-invocation @rule:proxy @type:regression @dep:publisher @legacy:MCPServerTestCase
+  Scenario Outline: A scope-gated MCP tool is enforced (200 with the scope, 403 without) as <actor>
+    Given The system is ready
+    And I have valid access tokens as "<actor>"
+    When I create an MCP server proxy to "http://nodebackend:3020/mcp" exposing tools "echo" as "mcpId"
+    Then The response status code should be 201
+    # Gate the echo tool with a scope bound to the tenant admin role.
+    When I gate the MCP server "mcpId" tool "echo" with scope "mcpScopeEnf" bound to role "admin"
+    Then The response status code should be 200
+    When I deploy the "mcp-servers" resource with id "mcpId"
+    When I publish the "mcp-servers" resource with id "mcpId"
+    Then The response status code should be 200
+    When I retrieve the "mcp-servers" resource with id "mcpId"
+    And I extract response field "context" and store it as "mcpContext"
+    # Subscribe an app with client_credentials + password grants (password needed to mint a scoped user token).
+    When I put JSON payload from file "artifacts/payloads/create_apim_test_app.json" in context as "mcpScopeAppPayload"
+    And I create an application with payload "mcpScopeAppPayload"
+    Then The response status code should be 201
+    When I put the following JSON payload in context as "mcpScopeKeysPayload"
+      """
+      {"keyType": "PRODUCTION", "grantTypesToBeSupported": ["client_credentials", "password"]}
+      """
+    And I generate client credentials for application id "createdAppId" with payload "mcpScopeKeysPayload"
+    Then The response status code should be 200
+    When I put the following JSON payload in context as "mcpScopeSubPayload"
+      """
+      {"applicationId": "{{applicationId}}", "apiId": "{{apiId}}", "throttlingPolicy": "Unlimited"}
+      """
+    And I subscribe to API "mcpId" using application "createdAppId" with payload "mcpScopeSubPayload" as "mcpScopeSubId"
+    Then The response status code should be 201
+    # A token WITH the scope calls the gated tool (200).
+    When I request an OAuth access token for the current user using password grant with scope "mcpScopeEnf"
+    Then The response status code should be 200
+    When I invoke the MCP tool "echo" with arguments "{\"message\":\"scoped\"}" at gateway context "{{mcpContext}}" version "1.0.0" using access token "generatedAccessToken" expecting status 200 within 90 seconds
+    # A token WITHOUT the scope is refused at the tool call (403).
+    When I request an OAuth access token for the current user using password grant with scope "openid"
+    Then The response status code should be 200
+    When I invoke the MCP tool "echo" with arguments "{\"message\":\"scoped\"}" at gateway context "{{mcpContext}}" version "1.0.0" using access token "generatedAccessToken" expecting status 403 within 90 seconds
+    When I delete the MCP server "mcpId"
+
+    Examples:
+      | actor             |
+      | admin             |
+      | admin@tenant1.com |
+
+  # Enforcement: a subscription bound to a low request-count policy is throttled (429) once it exceeds the limit.
+  # Doc-advocated (auth+throttling+analytics on MCP servers) though the legacy left it disabled. Uses the robust
+  # cumulative until-429 pattern within the minute window (each /mcp request counts toward the subscription quota).
+  @cap:gateway @feat:mcp-invocation @rule:proxy @type:regression @dep:admin @dep:publisher @legacy:MCPServerTestCase
+  Scenario Outline: A proxied MCP server subscription is throttled with 429 once it exceeds its limit as <actor>
+    Given The system is ready
+    And I have valid access tokens as "<actor>"
+    # A bespoke subscription policy allowing only 10 requests/min (reachable in a test; high enough that a few
+    # full MCP handshakes succeed before the quota trips).
+    When I create a subscription throttling policy "${UNIQUE:mcpSub10perMin}" allowing 10 requests per minute
+    Then The response status code should be 201
+    When I create an MCP server proxy to "http://nodebackend:3020/mcp" exposing tools "echo" as "mcpId"
+    Then The response status code should be 201
+    # The MCP server must OFFER the low tier for a subscription to use it.
+    When I update the MCP server "mcpId" to offer policies "Unlimited,{{subThrottlePolicyName}}"
+    Then The response status code should be 200
+    When I deploy the "mcp-servers" resource with id "mcpId"
+    When I publish the "mcp-servers" resource with id "mcpId"
+    Then The response status code should be 200
+    When I retrieve the "mcp-servers" resource with id "mcpId"
+    And I extract response field "context" and store it as "mcpContext"
+    # An application subscribed on the LOW subscription tier, keyed (password grant for a user token).
+    When I put JSON payload from file "artifacts/payloads/create_apim_test_app.json" in context as "mcpThrottleAppPayload"
+    And I create an application with payload "mcpThrottleAppPayload"
+    Then The response status code should be 201
+    When I put the following JSON payload in context as "mcpThrottleKeysPayload"
+      """
+      {"keyType": "PRODUCTION", "grantTypesToBeSupported": ["client_credentials", "password"]}
+      """
+    And I generate client credentials for application id "createdAppId" with payload "mcpThrottleKeysPayload"
+    Then The response status code should be 200
+    When I put the following JSON payload in context as "mcpThrottleSubPayload"
+      """
+      {"applicationId": "{{applicationId}}", "apiId": "{{apiId}}", "throttlingPolicy": "{{subThrottlePolicyName}}"}
+      """
+    And I subscribe to API "mcpId" using application "createdAppId" with payload "mcpThrottleSubPayload" as "mcpThrottleSubId"
+    Then The response status code should be 201
+    When I request an OAuth access token for the current user using password grant with scope "PRODUCTION"
+    Then The response status code should be 200
+    # Drive past the 10/min subscription limit — the gateway must eventually refuse with 429 (cumulative retry).
+    When I invoke the MCP tool "echo" with arguments "{\"message\":\"t\"}" at gateway context "{{mcpContext}}" version "1.0.0" using access token "generatedAccessToken" expecting status 429 within 90 seconds
+    When I delete the MCP server "mcpId"
+
+    Examples:
+      | actor             |
+      | admin             |
+      | admin@tenant1.com |
+
+  # Invocation + value-adds: the gateway translates tools/call → HTTP to the REST backend and returns real data.
+  @cap:gateway @feat:mcp-invocation @rule:openapi @type:regression @dep:publisher @legacy:MCPServerTestCase
+  Scenario Outline: Invoke OpenAPI-generated MCP tools through the gateway (MCP to HTTP) as <actor>
+    Given The system is ready
+    And I have valid access tokens as "<actor>"
+    When I create an MCP server from openapi "artifacts/payloads/OAS/mcp_petstore_oas3.json" with backend "http://nodebackend:3001/jaxrs_basic/services/customers/customerservice" as "mcpId"
+    Then The response status code should be 201
+    When I deploy the "mcp-servers" resource with id "mcpId"
+    When I publish the "mcp-servers" resource with id "mcpId"
+    Then The response status code should be 200
+    When I retrieve the "mcp-servers" resource with id "mcpId"
+    And I extract response field "context" and store it as "mcpContext"
+    When I have set up application with keys, subscribed to API "mcpId" with plan "Unlimited", and obtained access token for "mcpSubId"
+    Then The response status code should be 200
+    # Value-add — real MCP↔HTTP: tools/call get_pets → gateway calls the REST backend → returns real pet data.
+    When I invoke the MCP tool "get_pets" with arguments "{}" at gateway context "{{mcpContext}}" version "1.0.0" using access token "generatedAccessToken" expecting result containing "max" within 90 seconds
+    # Value-add — path-param tool: get_pets_by_petId {petId:123} → gateway maps to GET /pets/123 on the backend.
+    When I invoke the MCP tool "get_pets_by_petId" with arguments "{\"petId\":\"123\"}" at gateway context "{{mcpContext}}" version "1.0.0" using access token "generatedAccessToken" expecting result containing "max" within 90 seconds
+    # Value-add — error passthrough + negative auth.
+    When I invoke the MCP tool "nosuchtool" with arguments "{}" at gateway context "{{mcpContext}}" version "1.0.0" using access token "generatedAccessToken" expecting an error within 90 seconds
+    # The DirectBackend (OpenAPI) subtype rejects an invalid token at tools/call with 403 (the proxy subtype
+    # returns 401 — a verified per-subtype difference); asserted strictly so a future code change is caught.
+    When I invoke the MCP server at gateway context "{{mcpContext}}" version "1.0.0" with an invalid token expecting status 403 within 60 seconds
+    When I delete the MCP server "mcpId"
+
+    Examples:
+      | actor             |
+      | admin             |
+      | admin@tenant1.com |
+
+  # Enforcement: scope-gated tool invocation on the OpenAPI subtype (legacy tested this only for proxy/existing-api).
+  @cap:gateway @feat:mcp-invocation @rule:openapi @type:regression @dep:publisher @legacy:MCPServerTestCase
+  Scenario Outline: A scope-gated OpenAPI-generated MCP tool is enforced (200 with scope, 403 without) as <actor>
+    Given The system is ready
+    And I have valid access tokens as "<actor>"
+    When I create an MCP server from openapi "artifacts/payloads/OAS/mcp_petstore_oas3.json" with backend "http://nodebackend:3001/jaxrs_basic/services/customers/customerservice" as "mcpId"
+    Then The response status code should be 201
+    When I gate the MCP server "mcpId" tool "get_pets" with scope "mcpOasScopeEnf" bound to role "admin"
+    Then The response status code should be 200
+    When I deploy the "mcp-servers" resource with id "mcpId"
+    When I publish the "mcp-servers" resource with id "mcpId"
+    Then The response status code should be 200
+    When I retrieve the "mcp-servers" resource with id "mcpId"
+    And I extract response field "context" and store it as "mcpContext"
+    When I put JSON payload from file "artifacts/payloads/create_apim_test_app.json" in context as "mcpOasAppPayload"
+    And I create an application with payload "mcpOasAppPayload"
+    Then The response status code should be 201
+    When I put the following JSON payload in context as "mcpOasKeysPayload"
+      """
+      {"keyType": "PRODUCTION", "grantTypesToBeSupported": ["client_credentials", "password"]}
+      """
+    And I generate client credentials for application id "createdAppId" with payload "mcpOasKeysPayload"
+    Then The response status code should be 200
+    When I put the following JSON payload in context as "mcpOasSubPayload"
+      """
+      {"applicationId": "{{applicationId}}", "apiId": "{{apiId}}", "throttlingPolicy": "Unlimited"}
+      """
+    And I subscribe to API "mcpId" using application "createdAppId" with payload "mcpOasSubPayload" as "mcpOasSubId"
+    Then The response status code should be 201
+    When I request an OAuth access token for the current user using password grant with scope "mcpOasScopeEnf"
+    Then The response status code should be 200
+    When I invoke the MCP tool "get_pets" with arguments "{}" at gateway context "{{mcpContext}}" version "1.0.0" using access token "generatedAccessToken" expecting status 200 within 90 seconds
+    When I request an OAuth access token for the current user using password grant with scope "openid"
+    Then The response status code should be 200
+    When I invoke the MCP tool "get_pets" with arguments "{}" at gateway context "{{mcpContext}}" version "1.0.0" using access token "generatedAccessToken" expecting status 403 within 90 seconds
+    When I delete the MCP server "mcpId"
+
+    Examples:
+      | actor             |
+      | admin             |
+      | admin@tenant1.com |
+
+  # Enforcement: subscription throttling on the OpenAPI subtype.
+  @cap:gateway @feat:mcp-invocation @rule:openapi @type:regression @dep:admin @dep:publisher @legacy:MCPServerTestCase
+  Scenario Outline: An OpenAPI-generated MCP subscription is throttled with 429 once it exceeds its limit as <actor>
+    Given The system is ready
+    And I have valid access tokens as "<actor>"
+    When I create a subscription throttling policy "${UNIQUE:mcpOasSub10perMin}" allowing 10 requests per minute
+    Then The response status code should be 201
+    When I create an MCP server from openapi "artifacts/payloads/OAS/mcp_petstore_oas3.json" with backend "http://nodebackend:3001/jaxrs_basic/services/customers/customerservice" as "mcpId"
+    Then The response status code should be 201
+    When I update the MCP server "mcpId" to offer policies "Unlimited,{{subThrottlePolicyName}}"
+    Then The response status code should be 200
+    When I deploy the "mcp-servers" resource with id "mcpId"
+    When I publish the "mcp-servers" resource with id "mcpId"
+    Then The response status code should be 200
+    When I retrieve the "mcp-servers" resource with id "mcpId"
+    And I extract response field "context" and store it as "mcpContext"
+    When I put JSON payload from file "artifacts/payloads/create_apim_test_app.json" in context as "mcpOasThrAppPayload"
+    And I create an application with payload "mcpOasThrAppPayload"
+    Then The response status code should be 201
+    When I put the following JSON payload in context as "mcpOasThrKeysPayload"
+      """
+      {"keyType": "PRODUCTION", "grantTypesToBeSupported": ["client_credentials", "password"]}
+      """
+    And I generate client credentials for application id "createdAppId" with payload "mcpOasThrKeysPayload"
+    Then The response status code should be 200
+    When I put the following JSON payload in context as "mcpOasThrSubPayload"
+      """
+      {"applicationId": "{{applicationId}}", "apiId": "{{apiId}}", "throttlingPolicy": "{{subThrottlePolicyName}}"}
+      """
+    And I subscribe to API "mcpId" using application "createdAppId" with payload "mcpOasThrSubPayload" as "mcpOasThrSubId"
+    Then The response status code should be 201
+    When I request an OAuth access token for the current user using password grant with scope "PRODUCTION"
+    Then The response status code should be 200
+    When I invoke the MCP tool "get_pets" with arguments "{}" at gateway context "{{mcpContext}}" version "1.0.0" using access token "generatedAccessToken" expecting status 429 within 90 seconds
+    When I delete the MCP server "mcpId"
+
+    Examples:
+      | actor             |
+      | admin             |
+      | admin@tenant1.com |
+
+  # Invocation + value-adds: the gateway routes tools/call through the underlying API to its backend.
+  @cap:gateway @feat:mcp-invocation @rule:api @type:regression @dep:publisher @legacy:MCPServerTestCase
+  Scenario Outline: Invoke API-generated MCP tools through the gateway as <actor>
+    Given The system is ready
+    And I have valid access tokens as "<actor>"
+    When I import openapi definition from "artifacts/payloads/OAS/mcp_petstore_oas3.json" with additional properties "artifacts/payloads/mcp_petstore_api_props.json" as "backingApiId"
+    Then The response status code should be 201
+    When I deploy the "apis" resource with id "backingApiId"
+    When I create an MCP server from api "backingApiId" exposing paths "/pets,/pets/{petId}" as "mcpId"
+    Then The response status code should be 201
+    When I deploy the "mcp-servers" resource with id "mcpId"
+    When I publish the "mcp-servers" resource with id "mcpId"
+    Then The response status code should be 200
+    When I retrieve the "mcp-servers" resource with id "mcpId"
+    And I extract response field "context" and store it as "mcpContext"
+    When I have set up application with keys, subscribed to API "mcpId" with plan "Unlimited", and obtained access token for "mcpSubId"
+    Then The response status code should be 200
+    # Value-add — real routing through the underlying API to its backend → real pet data.
+    When I invoke the MCP tool "get_pets" with arguments "{}" at gateway context "{{mcpContext}}" version "1.0.0" using access token "generatedAccessToken" expecting result containing "max" within 90 seconds
+    # Value-add — path-param tool routed to GET /pets/123 through the API.
+    When I invoke the MCP tool "get_pets_by_petId" with arguments "{\"petId\":\"123\"}" at gateway context "{{mcpContext}}" version "1.0.0" using access token "generatedAccessToken" expecting result containing "max" within 90 seconds
+    # Value-add — error passthrough + negative auth.
+    When I invoke the MCP tool "nosuchtool" with arguments "{}" at gateway context "{{mcpContext}}" version "1.0.0" using access token "generatedAccessToken" expecting an error within 90 seconds
+    When I invoke the MCP server at gateway context "{{mcpContext}}" version "1.0.0" with an invalid token expecting status 403 within 60 seconds
+    When I delete the MCP server "mcpId"
+
+    Examples:
+      | actor             |
+      | admin             |
+      | admin@tenant1.com |
+
+  # Enforcement: scope-gated tool invocation on the API subtype.
+  @cap:gateway @feat:mcp-invocation @rule:api @type:regression @dep:publisher @legacy:MCPServerTestCase
+  Scenario Outline: A scope-gated API-generated MCP tool is enforced (200 with scope, 403 without) as <actor>
+    Given The system is ready
+    And I have valid access tokens as "<actor>"
+    When I import openapi definition from "artifacts/payloads/OAS/mcp_petstore_oas3.json" with additional properties "artifacts/payloads/mcp_petstore_api_props.json" as "backingApiId"
+    Then The response status code should be 201
+    When I deploy the "apis" resource with id "backingApiId"
+    When I create an MCP server from api "backingApiId" exposing paths "/pets" as "mcpId"
+    Then The response status code should be 201
+    When I gate the MCP server "mcpId" tool "get_pets" with scope "mcpApiScopeEnf" bound to role "admin"
+    Then The response status code should be 200
+    When I deploy the "mcp-servers" resource with id "mcpId"
+    When I publish the "mcp-servers" resource with id "mcpId"
+    Then The response status code should be 200
+    When I retrieve the "mcp-servers" resource with id "mcpId"
+    And I extract response field "context" and store it as "mcpContext"
+    When I put JSON payload from file "artifacts/payloads/create_apim_test_app.json" in context as "mcpApiAppPayload"
+    And I create an application with payload "mcpApiAppPayload"
+    Then The response status code should be 201
+    When I put the following JSON payload in context as "mcpApiKeysPayload"
+      """
+      {"keyType": "PRODUCTION", "grantTypesToBeSupported": ["client_credentials", "password"]}
+      """
+    And I generate client credentials for application id "createdAppId" with payload "mcpApiKeysPayload"
+    Then The response status code should be 200
+    When I put the following JSON payload in context as "mcpApiSubPayload"
+      """
+      {"applicationId": "{{applicationId}}", "apiId": "{{apiId}}", "throttlingPolicy": "Unlimited"}
+      """
+    And I subscribe to API "mcpId" using application "createdAppId" with payload "mcpApiSubPayload" as "mcpApiSubId"
+    Then The response status code should be 201
+    When I request an OAuth access token for the current user using password grant with scope "mcpApiScopeEnf"
+    Then The response status code should be 200
+    When I invoke the MCP tool "get_pets" with arguments "{}" at gateway context "{{mcpContext}}" version "1.0.0" using access token "generatedAccessToken" expecting status 200 within 90 seconds
+    When I request an OAuth access token for the current user using password grant with scope "openid"
+    Then The response status code should be 200
+    When I invoke the MCP tool "get_pets" with arguments "{}" at gateway context "{{mcpContext}}" version "1.0.0" using access token "generatedAccessToken" expecting status 403 within 90 seconds
+    When I delete the MCP server "mcpId"
+
+    Examples:
+      | actor             |
+      | admin             |
+      | admin@tenant1.com |
+
+  # Enforcement: subscription throttling on the API subtype.
+  @cap:gateway @feat:mcp-invocation @rule:api @type:regression @dep:admin @dep:publisher @legacy:MCPServerTestCase
+  Scenario Outline: An API-generated MCP subscription is throttled with 429 once it exceeds its limit as <actor>
+    Given The system is ready
+    And I have valid access tokens as "<actor>"
+    When I create a subscription throttling policy "${UNIQUE:mcpApiSub10perMin}" allowing 10 requests per minute
+    Then The response status code should be 201
+    When I import openapi definition from "artifacts/payloads/OAS/mcp_petstore_oas3.json" with additional properties "artifacts/payloads/mcp_petstore_api_props.json" as "backingApiId"
+    Then The response status code should be 201
+    When I deploy the "apis" resource with id "backingApiId"
+    When I create an MCP server from api "backingApiId" exposing paths "/pets" as "mcpId"
+    Then The response status code should be 201
+    When I update the MCP server "mcpId" to offer policies "Unlimited,{{subThrottlePolicyName}}"
+    Then The response status code should be 200
+    When I deploy the "mcp-servers" resource with id "mcpId"
+    When I publish the "mcp-servers" resource with id "mcpId"
+    Then The response status code should be 200
+    When I retrieve the "mcp-servers" resource with id "mcpId"
+    And I extract response field "context" and store it as "mcpContext"
+    When I put JSON payload from file "artifacts/payloads/create_apim_test_app.json" in context as "mcpApiThrAppPayload"
+    And I create an application with payload "mcpApiThrAppPayload"
+    Then The response status code should be 201
+    When I put the following JSON payload in context as "mcpApiThrKeysPayload"
+      """
+      {"keyType": "PRODUCTION", "grantTypesToBeSupported": ["client_credentials", "password"]}
+      """
+    And I generate client credentials for application id "createdAppId" with payload "mcpApiThrKeysPayload"
+    Then The response status code should be 200
+    When I put the following JSON payload in context as "mcpApiThrSubPayload"
+      """
+      {"applicationId": "{{applicationId}}", "apiId": "{{apiId}}", "throttlingPolicy": "{{subThrottlePolicyName}}"}
+      """
+    And I subscribe to API "mcpId" using application "createdAppId" with payload "mcpApiThrSubPayload" as "mcpApiThrSubId"
+    Then The response status code should be 201
+    When I request an OAuth access token for the current user using password grant with scope "PRODUCTION"
+    Then The response status code should be 200
+    When I invoke the MCP tool "get_pets" with arguments "{}" at gateway context "{{mcpContext}}" version "1.0.0" using access token "generatedAccessToken" expecting status 429 within 90 seconds
+    When I delete the MCP server "mcpId"
+
+    Examples:
+      | actor             |
+      | admin             |
+      | admin@tenant1.com |

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/features/publisher/api_products.feature
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/features/publisher/api_products.feature
@@ -1,0 +1,231 @@
+@cleanup
+Feature: Publisher API Products
+
+  Ports the core of the legacy APIProductCreationTestCase + APIProductRevisionTestCase: an API Product aggregates
+  selected resources of existing APIs into a new entity with its own context/version, taken through revision and
+  lifecycle. This feature covers the publisher plane — create + verify the aggregation, read the product's
+  swagger definition, reject a malformed context, create a new version (incl. as default), confirm the product
+  tracks its underlying API, and the product revision lifecycle (reusing the generic revision steps with
+  resourceType "api-products"). Gateway invocation of a product is covered by gateway/api_product_invocation.
+  ×2 tenant where the concern is tenant-agnostic. Teardown via @cleanup — the product is deleted before its
+  underlying API (a product references the API).
+
+  @cap:publisher @feat:products @type:smoke @dep:publisher @legacy:APIProductCreationTestCase
+  Scenario Outline: Create an API product aggregating an API and read its definition as <actor>
+    Given The system is ready and I have valid publisher access tokens as "<actor>"
+    And I have created an api from "artifacts/payloads/create_apim_test_api.json" as "prodApiId" and deployed it
+    When I create an API product "${UNIQUE:AggProduct}" with context "${UNIQUE:aggProductCtx}" from API "prodApiId" as "productId"
+    Then The response status code should be 201
+    # The product retrieve echoes the aggregated API id, and its swagger carries the aggregated resource path.
+    When I retrieve the "api-products" resource with id "productId"
+    Then The response status code should be 200
+    And The response should contain "{{prodApiId}}"
+    When I retrieve the API product swagger of "productId"
+    Then The response status code should be 200
+    And The response should contain "/customers/{id}"
+
+    Examples:
+      | actor                     |
+      | publisherUser             |
+      | publisherUser@tenant1.com |
+
+  @cap:publisher @feat:products @type:negative @dep:publisher @legacy:APIProductCreationTestCase
+  Scenario: A malformed API product context is rejected
+    Given The system is ready and I have valid publisher access tokens as "publisherUser"
+    And I have created an api from "artifacts/payloads/create_apim_test_api.json" as "prodApiIdNeg" and deployed it
+    When I attempt to create an API product "${UNIQUE:BadCtxProduct}" with context "invalid context with spaces" from API "prodApiIdNeg"
+    Then The response status code should be 400
+
+  @cap:publisher @feat:products @type:regression @dep:publisher @legacy:APIProductCreationTestCase
+  Scenario Outline: Create a new version of an API product as <actor>
+    Given The system is ready and I have valid publisher access tokens as "<actor>"
+    And I have created an api from "artifacts/payloads/create_apim_test_api.json" as "verApiId" and deployed it
+    When I create an API product "${UNIQUE:VerProduct}" with context "${UNIQUE:verProductCtx}" from API "verApiId" as "verProductId"
+    Then The response status code should be 201
+    When I create a new version "2.0.0" of API product "verProductId" with default version "false" as "verProductV2Id"
+    Then The response status code should be 201
+    When I retrieve the "api-products" resource with id "verProductV2Id"
+    Then The response status code should be 200
+    And The response should contain "2.0.0"
+
+    Examples:
+      | actor                     |
+      | publisherUser             |
+      | publisherUser@tenant1.com |
+
+  @cap:publisher @feat:products @type:regression @dep:publisher @legacy:APIProductCreationTestCase
+  Scenario: A new API product version can be created as the default version
+    Given The system is ready and I have valid publisher access tokens as "publisherUser"
+    And I have created an api from "artifacts/payloads/create_apim_test_api.json" as "defVerApiId" and deployed it
+    When I create an API product "${UNIQUE:DefVerProduct}" with context "${UNIQUE:defVerProductCtx}" from API "defVerApiId" as "defProductId"
+    Then The response status code should be 201
+    When I create a new version "2.0.0" of API product "defProductId" with default version "true" as "defProductV2Id"
+    Then The response status code should be 201
+    # Re-fetch the new version and confirm it is flagged as the default.
+    And The "api-products" resource should reflect the updated "isDefaultVersion" as:
+      """
+      true
+      """
+
+  @cap:publisher @feat:products @type:regression @dep:publisher @legacy:APIProductCreationTestCase
+  Scenario Outline: An API product tracks its underlying API after the API is updated as <actor>
+    Given The system is ready and I have valid publisher access tokens as "<actor>"
+    And I have created an api from "artifacts/payloads/create_apim_test_api.json" as "underApiId" and deployed it
+    When I create an API product "${UNIQUE:TrackProduct}" with context "${UNIQUE:trackProductCtx}" from API "underApiId" as "trackProductId"
+    Then The response status code should be 201
+    # Update the underlying API (description), then confirm the product still references it + its operations.
+    When I retrieve the "apis" resource with id "underApiId"
+    And I put the response payload in context as "underApiPayload"
+    When I update the "apis" resource "underApiId" and "underApiPayload" with configuration type "description" and value:
+      """
+      Updated backing API for product tracking
+      """
+    Then The response status code should be 200
+    When I retrieve the "api-products" resource with id "trackProductId"
+    Then The response status code should be 200
+    And The response should contain "{{underApiId}}"
+    And The response should contain "/customers/{id}"
+
+    Examples:
+      | actor                     |
+      | publisherUser             |
+      | publisherUser@tenant1.com |
+
+  @cap:publisher @feat:products @type:regression @dep:publisher @legacy:APIProductRevisionTestCase
+  Scenario Outline: API product revision lifecycle — create, list, deploy, undeploy, restore, delete as <actor>
+    Given The system is ready and I have valid publisher access tokens as "<actor>"
+    And I have created an api from "artifacts/payloads/create_apim_test_api.json" as "revApiId" and deployed it
+    When I create an API product "${UNIQUE:RevProduct}" with context "${UNIQUE:revProductCtx}" from API "revApiId" as "revProductId"
+    Then The response status code should be 201
+
+    When I put the following JSON payload in context as "prodRevPayload"
+    """
+    {"description":"product revision 1"}
+    """
+    And I make a request to create a revision for "api-products" resource "revProductId" with payload "prodRevPayload"
+    Then The response status code should be 201
+    And I extract response field "id" and store it as "prodRevId"
+    When I retrieve the revisions of "api-products" resource "revProductId"
+    Then The response status code should be 200
+
+    When I deploy revision "prodRevId" of "api-products" resource "revProductId"
+    Then The response status code should be 201
+    And I wait until "api-products" "revProductId" revision is deployed in the gateway
+    When I undeploy revision "prodRevId" of "api-products" resource "revProductId"
+    Then The response status code should be 201
+    When I restore revision "prodRevId" of "api-products" resource "revProductId"
+    Then The response status code should be 201
+    When I delete revision "prodRevId" of "api-products" resource "revProductId"
+    Then The response status code should be 200
+
+    Examples:
+      | actor                     |
+      | publisherUser             |
+      | publisherUser@tenant1.com |
+
+  @cap:publisher @feat:products @type:negative @dep:publisher @legacy:APIProductLifecycleTest
+  Scenario Outline: A published API product with an active subscription cannot be deleted, but can be deprecated as <actor>
+    Given The system is ready
+    And I have valid access tokens as "<actor>"
+    And I have created an api from "artifacts/payloads/create_apim_test_api.json" as "d5ApiId" and deployed it
+    When I create an API product "${UNIQUE:DelSubProduct}" with context "${UNIQUE:delSubProductCtx}" from API "d5ApiId" as "d5ProductId"
+    Then The response status code should be 201
+    When I put the following JSON payload in context as "d5Rev"
+    """
+    {"description":"product revision for delete-with-subscription"}
+    """
+    And I make a request to create a revision for "api-products" resource "d5ProductId" with payload "d5Rev"
+    Then The response status code should be 201
+    When I deploy revision "revisionId" of "api-products" resource "d5ProductId"
+    Then The response status code should be 201
+    When I publish the "api-products" resource with id "d5ProductId"
+    Then The response status code should be 200
+    When I have set up application with keys, subscribed to API "d5ProductId", and obtained access token for "d5SubId"
+    Then The response status code should be 200
+    # Delete is rejected while an active subscription exists.
+    When I delete the "api-products" resource with id "d5ProductId"
+    Then The response status code should be 409
+    And The response should contain "active subscriptions exist"
+    # But the product can still be deprecated.
+    When I change the lifecycle of "api-products" resource "d5ProductId" with action "Deprecate"
+    Then The response status code should be 200
+    When I retrieve the "api-products" resource with id "d5ProductId"
+    Then The response should contain "DEPRECATED"
+
+    Examples:
+      | actor             |
+      | admin             |
+      | admin@tenant1.com |
+
+  @cap:publisher @feat:revisions @type:regression @dep:publisher @legacy:APIProductRevisionTestCase
+  Scenario Outline: Restoring the underlying API to a revision missing resources a product depends on is rejected as <actor>
+    Given The system is ready and I have valid publisher access tokens as "<actor>"
+    And I have created an api from "artifacts/payloads/create_apim_test_api.json" as "d6ApiId" and deployed it
+    # Revision 1 captures the API's original resources (/customers/{id}).
+    When I put the following JSON payload in context as "d6Rev1Payload"
+    """
+    {"description":"revision 1 - original resources"}
+    """
+    And I make a request to create a revision for "apis" resource "d6ApiId" with payload "d6Rev1Payload"
+    Then The response status code should be 201
+    And I extract response field "id" and store it as "d6Rev1Id"
+    # Add new resources to the API, then capture revision 2 with the enlarged resource set.
+    When I retrieve the "apis" resource with id "d6ApiId"
+    And I put the response payload in context as "d6ApiPayload"
+    When I update the "apis" resource "d6ApiId" and "d6ApiPayload" with configuration type "operations" and value:
+      """
+      [{"target":"/customers/{id}","verb":"GET"},{"target":"/customers/{id}","verb":"DELETE"},{"target":"/missing-resource","verb":"GET"},{"target":"/missing-resource","verb":"POST"},{"target":"/missing-resource/{id}","verb":"GET"}]
+      """
+    Then The response status code should be 200
+    When I put the following JSON payload in context as "d6Rev2Payload"
+    """
+    {"description":"revision 2 - with added resources"}
+    """
+    And I make a request to create a revision for "apis" resource "d6ApiId" with payload "d6Rev2Payload"
+    Then The response status code should be 201
+    And I extract response field "id" and store it as "d6Rev2Id"
+    # A product aggregates the API's current (enlarged) resource set, then is deployed.
+    When I create an API product "${UNIQUE:RestoreProduct}" with context "${UNIQUE:restoreProductCtx}" from API "d6ApiId" as "d6ProductId"
+    Then The response status code should be 201
+    When I put the following JSON payload in context as "d6ProdRev"
+    """
+    {"description":"product revision"}
+    """
+    And I make a request to create a revision for "api-products" resource "d6ProductId" with payload "d6ProdRev"
+    Then The response status code should be 201
+    When I deploy revision "revisionId" of "api-products" resource "d6ProductId"
+    Then The response status code should be 201
+    # Restoring the API to revision 2 (which has the product's resources) succeeds.
+    When I restore revision "d6Rev2Id" of "apis" resource "d6ApiId"
+    Then The response status code should be 201
+    # Restoring to revision 1 (which lacks the added resources the product depends on) is rejected.
+    When I restore revision "d6Rev1Id" of "apis" resource "d6ApiId"
+    Then The response status code should be 400
+
+    Examples:
+      | actor                     |
+      | publisherUser             |
+      | publisherUser@tenant1.com |
+
+  @cap:publisher @feat:products @type:regression @dep:publisher @legacy:APIProductLifecycleTest
+  Scenario: An API product moves through its lifecycle and can be deleted when retired
+    Given The system is ready and I have valid publisher access tokens as "publisherUser"
+    And I have created an api from "artifacts/payloads/create_apim_test_api.json" as "lcApiId" and deployed it
+    When I create an API product "${UNIQUE:LcProduct}" with context "${UNIQUE:lcProductCtx}" from API "lcApiId" as "lcProductId"
+    Then The response status code should be 201
+    # Publish → Deprecate → Retire, confirming each transition on the publisher plane.
+    When I publish the "api-products" resource with id "lcProductId"
+    Then The response status code should be 200
+    When I retrieve the "api-products" resource with id "lcProductId"
+    Then The response should contain "PUBLISHED"
+    When I change the lifecycle of "api-products" resource "lcProductId" with action "Deprecate"
+    Then The response status code should be 200
+    When I retrieve the "api-products" resource with id "lcProductId"
+    Then The response should contain "DEPRECATED"
+    When I change the lifecycle of "api-products" resource "lcProductId" with action "Retire"
+    Then The response status code should be 200
+    When I retrieve the "api-products" resource with id "lcProductId"
+    Then The response should contain "RETIRED"
+    # A retired product can be deleted (legacy testDeleteRetiredAPIProducts).
+    When I delete the "api-products" resource with id "lcProductId"
+    Then The response status code should be 200

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/features/publisher/graphql_design_from_url.feature
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/features/publisher/graphql_design_from_url.feature
@@ -1,0 +1,34 @@
+@cleanup
+Feature: Publisher GraphQL API Creation from a URL
+
+  Publisher-plane GraphQL API creation from a URL instead of an uploaded schema file — ports the "create using
+  endpoint" (introspection) and SDL-URL paths of GraphqlTestCase. The gateway derives the schema from the URL:
+  by introspecting a live GraphQL endpoint, or by fetching an SDL served at a URL. Uses the in-network node
+  GraphQL backend (no third-party). Asserts the derived schema contains the expected types.
+
+  @cap:publisher @feat:graphql-design @rule:create-from-url-introspection @type:regression @dep:gateway @legacy:GraphqlTestCase
+  Scenario: Create a GraphQL API by introspecting a live endpoint
+    Given The system is ready
+    And I have valid access tokens as "admin"
+    # Introspect the live node GraphQL endpoint to derive the SDL, then create the API from that schema
+    When I validate the GraphQL schema from endpoint URL "http://nodebackend:3003/graphql-full" with introspection "true" and store schema as "introspectedSchema"
+    Then The response status code should be 200
+    When I put JSON payload from file "artifacts/payloads/create_apim_test_graphql_api.json" in context as "gqlUrlPayload"
+    And I create a GraphQL API with schema "introspectedSchema" and additional properties "gqlUrlPayload" as "gqlUrlApiId"
+    Then The response status code should be 201
+    # The schema was derived from the endpoint via introspection — it must contain the schema's types
+    When I retrieve the GraphQL schema of API "gqlUrlApiId"
+    Then The response status code should be 200
+    And The response should contain "languages"
+
+  @cap:publisher @feat:graphql-design @rule:create-from-url-sdl @type:regression @dep:gateway @legacy:GraphqlTestCase
+  Scenario: Create a GraphQL API by fetching an SDL served at a URL
+    Given The system is ready
+    And I have valid access tokens as "admin"
+    # The node backend serves the raw SDL at /sdl; APIM fetches it and creates the API (useIntrospection=false path)
+    When I put JSON payload from file "artifacts/payloads/create_apim_test_graphql_api.json" in context as "gqlSdlPayload"
+    And I create a GraphQL API from endpoint URL "http://nodebackend:3003/sdl" with additional properties "gqlSdlPayload" as "gqlSdlApiId"
+    Then The response status code should be 201
+    When I retrieve the GraphQL schema of API "gqlSdlApiId"
+    Then The response status code should be 200
+    And The response should contain "languages"

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/features/publisher/mcp_servers.feature
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/features/publisher/mcp_servers.feature
@@ -1,0 +1,183 @@
+@cleanup
+Feature: MCP Server authoring (publisher plane)
+
+  Publisher-plane CRUD of MCP servers across all three creation types — proxy (to a third-party MCP server),
+  from-OpenAPI (DirectBackend), and from-API (ExistingApi) — plus backend-endpoint management. Gateway
+  invocation is in gateway/mcp_invocation.feature. Needs the node MCP backend (proxy create-validation). ×2 tenant.
+
+  # CRUD: create exposing a subset of the backend's tools, read them back, update the exposed set, delete.
+  @cap:publisher @feat:mcp-servers @rule:proxy @type:regression @dep:publisher @legacy:MCPServerTestCase
+  Scenario Outline: Full CRUD lifecycle of a proxied MCP server as <actor>
+    Given The system is ready
+    And I have valid access tokens as "<actor>"
+    # CREATE — expose only echo + add (of the backend's echo/add/get_pets); assert the discovered tools persist
+    When I create an MCP server proxy to "http://nodebackend:3020/mcp" exposing tools "echo,add" as "mcpId"
+    Then The response status code should be 201
+    And The response should contain "echo"
+    And The response should contain "add"
+    # Least-privilege: the backend also offers get_pets, but it was NOT selected — so it must not be exposed.
+    And The response should not contain "get_pets"
+    # READ — retrieve returns the server with its operations (still the selected subset only)
+    When I retrieve the "mcp-servers" resource with id "mcpId"
+    Then The response status code should be 200
+    And The response should contain "echo"
+    And The response should contain "add"
+    And The response should not contain "get_pets"
+    # UPDATE (ADD) — expand the exposed set to add get_pets; the persisted operations reflect it
+    When I update the MCP server "mcpId" to expose tools "echo,add,get_pets"
+    Then The response status code should be 200
+    And The response should contain "get_pets"
+    # READ-BACK — the add persisted
+    When I retrieve the "mcp-servers" resource with id "mcpId"
+    Then The response should contain "get_pets"
+    # UPDATE (REMOVE) — narrow back to echo,add; get_pets is dropped
+    When I update the MCP server "mcpId" to expose tools "echo,add"
+    Then The response status code should be 200
+    When I retrieve the "mcp-servers" resource with id "mcpId"
+    Then The response should contain "echo"
+    And The response should not contain "get_pets"
+    # DELETE — removed; a subsequent retrieve 404s
+    When I delete the MCP server "mcpId"
+    Then The response status code should be 200
+    When I retrieve the "mcp-servers" resource with id "mcpId"
+    Then The response status code should be 404
+
+    Examples:
+      | actor             |
+      | admin             |
+      | admin@tenant1.com |
+
+  # Backend-endpoint management for a PROXY MCP server. A correct update PUTs the backend back in full, INCLUDING
+  # its `definition` (MCP-tools JSON, not an OpenAPI spec). carbon-apimgt < 9.33.147 wrongly re-validated that
+  # definition as OpenAPI on update, failing a correct PUT with 900754 "Error while parsing OpenAPI definition —
+  # attribute tools is unexpected" (HTTP 400) — a product regression. It is fixed in carbon-apimgt 9.33.147, the
+  # version this branch now builds, so the scenario is enabled. Do NOT work around any recurrence by stripping the
+  # definition (that would hide a regression).
+  @cap:publisher @feat:mcp-servers @rule:proxy @type:regression @dep:publisher @legacy:MCPServerTestCase
+  Scenario Outline: Manage the backend endpoint of a proxied MCP server as <actor>
+    Given The system is ready
+    And I have valid access tokens as "<actor>"
+    When I create an MCP server proxy to "http://nodebackend:3020/mcp" exposing tools "echo,add" as "mcpId"
+    Then The response status code should be 201
+    # LIST the server's backend endpoints and capture the (single) backend's id
+    When I retrieve the backends of MCP server "mcpId" and store the first backend id as "mcpBackendId"
+    Then The response status code should be 200
+    # GET the backend by id and capture it for a round-trip update
+    When I retrieve backend "mcpBackendId" of MCP server "mcpId"
+    Then The response status code should be 200
+    And I put the response payload in context as "mcpBackendPayload"
+    # endpointConfig is a stringified JSON blob (escaped \/), so edit the endpoint URL at text level (its port
+    # has no slashes). The definition is sent back unchanged (a correct update includes it).
+    When I replace "nodebackend:3020" with "nodebackend:3021" in the payload "mcpBackendPayload"
+    And I update backend "mcpBackendId" of MCP server "mcpId" with payload "mcpBackendPayload"
+    Then The response status code should be 200
+    When I retrieve backend "mcpBackendId" of MCP server "mcpId"
+    Then The response status code should be 200
+    And The response should contain "nodebackend:3021"
+    When I delete the MCP server "mcpId"
+
+    Examples:
+      | actor             |
+      | admin             |
+      | admin@tenant1.com |
+
+  # CRUD: create from OAS (both tools generated), read, narrow to a subset (remove a tool), delete.
+  @cap:publisher @feat:mcp-servers @rule:openapi @type:regression @dep:publisher @legacy:MCPServerTestCase
+  Scenario Outline: Full CRUD lifecycle of an OpenAPI-generated MCP server as <actor>
+    Given The system is ready
+    And I have valid access tokens as "<actor>"
+    When I create an MCP server from openapi "artifacts/payloads/OAS/mcp_petstore_oas3.json" with backend "http://nodebackend:3001/jaxrs_basic/services/customers/customerservice" as "mcpId"
+    Then The response status code should be 201
+    And The response should contain "get_pets"
+    And The response should contain "get_pets_by_petId"
+    When I retrieve the "mcp-servers" resource with id "mcpId"
+    Then The response status code should be 200
+    And The response should contain "get_pets"
+    And The response should contain "get_pets_by_petId"
+    # UPDATE (REMOVE) — narrow the exposed tools to just get_pets (docs "select tools to import" / least-privilege).
+    When I update the MCP server "mcpId" removing tool "get_pets_by_petId"
+    Then The response status code should be 200
+    When I retrieve the "mcp-servers" resource with id "mcpId"
+    Then The response should contain "get_pets"
+    And The response should not contain "get_pets_by_petId"
+    # UPDATE (ADD) — re-add the removed tool (inverse of remove); it comes back
+    When I re-add the removed tool to the MCP server "mcpId"
+    Then The response status code should be 200
+    When I retrieve the "mcp-servers" resource with id "mcpId"
+    Then The response should contain "get_pets_by_petId"
+    When I delete the MCP server "mcpId"
+    Then The response status code should be 200
+    When I retrieve the "mcp-servers" resource with id "mcpId"
+    Then The response status code should be 404
+
+    Examples:
+      | actor             |
+      | admin             |
+      | admin@tenant1.com |
+
+  # Backend-endpoint management: an OpenAPI-generated MCP server has its OWN backend (the REST endpoint the
+  # generated tools call). List it, get it by id, update its URL, and read the update back. (list/get/update
+  # only — the backend is created implicitly with the server and has no separate add/delete.)
+  @cap:publisher @feat:mcp-servers @rule:openapi @type:regression @dep:publisher @legacy:MCPServerTestCase
+  Scenario Outline: Manage the backend endpoint of an OpenAPI-generated MCP server as <actor>
+    Given The system is ready
+    And I have valid access tokens as "<actor>"
+    When I create an MCP server from openapi "artifacts/payloads/OAS/mcp_petstore_oas3.json" with backend "http://nodebackend:3001/jaxrs_basic/services/customers/customerservice" as "mcpId"
+    Then The response status code should be 201
+    When I retrieve the backends of MCP server "mcpId" and store the first backend id as "mcpBackendId"
+    Then The response status code should be 200
+    When I retrieve backend "mcpBackendId" of MCP server "mcpId"
+    Then The response status code should be 200
+    And I put the response payload in context as "mcpBackendPayload"
+    # A correct update sends the backend back in full (INCLUDING its definition — an OpenAPI spec here, which the
+    # server validates cleanly). endpointConfig is a stringified JSON blob (escaped \/), so edit the endpoint URL
+    # at text level using a slash-free segment ("customerservice") to avoid the blob's escaped slashes.
+    When I replace "customerservice" with "customerservice_updated" in the payload "mcpBackendPayload"
+    And I update backend "mcpBackendId" of MCP server "mcpId" with payload "mcpBackendPayload"
+    Then The response status code should be 200
+    When I retrieve backend "mcpBackendId" of MCP server "mcpId"
+    Then The response status code should be 200
+    And The response should contain "customerservice_updated"
+    When I delete the MCP server "mcpId"
+
+    Examples:
+      | actor             |
+      | admin             |
+      | admin@tenant1.com |
+
+  # CRUD: import+deploy an API, generate an MCP server from it, read, narrow the tools, delete.
+  @cap:publisher @feat:mcp-servers @rule:api @type:regression @dep:publisher @legacy:MCPServerTestCase
+  Scenario Outline: Full CRUD lifecycle of an API-generated MCP server as <actor>
+    Given The system is ready
+    And I have valid access tokens as "<actor>"
+    When I import openapi definition from "artifacts/payloads/OAS/mcp_petstore_oas3.json" with additional properties "artifacts/payloads/mcp_petstore_api_props.json" as "backingApiId"
+    Then The response status code should be 201
+    When I deploy the "apis" resource with id "backingApiId"
+    When I create an MCP server from api "backingApiId" exposing paths "/pets,/pets/{petId}" as "mcpId"
+    Then The response status code should be 201
+    And The response should contain "get_pets"
+    And The response should contain "get_pets_by_petId"
+    When I retrieve the "mcp-servers" resource with id "mcpId"
+    Then The response status code should be 200
+    And The response should contain "get_pets"
+    And The response should contain "get_pets_by_petId"
+    # UPDATE (REMOVE) — narrow the exposed tools (least-privilege).
+    When I update the MCP server "mcpId" removing tool "get_pets_by_petId"
+    Then The response status code should be 200
+    When I retrieve the "mcp-servers" resource with id "mcpId"
+    Then The response should contain "get_pets"
+    And The response should not contain "get_pets_by_petId"
+    # UPDATE (ADD) — re-add the removed tool (inverse of remove); it comes back
+    When I re-add the removed tool to the MCP server "mcpId"
+    Then The response status code should be 200
+    When I retrieve the "mcp-servers" resource with id "mcpId"
+    Then The response should contain "get_pets_by_petId"
+    When I delete the MCP server "mcpId"
+    Then The response status code should be 200
+    When I retrieve the "mcp-servers" resource with id "mcpId"
+    Then The response status code should be 404
+
+    Examples:
+      | actor             |
+      | admin             |
+      | admin@tenant1.com |

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/testng-v2.xml
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/testng-v2.xml
@@ -35,6 +35,7 @@
             <class name="org.wso2.am.integration.cucumbertests.runners.block.PublisherStreamingDesignRunner"/>
             <class name="org.wso2.am.integration.cucumbertests.runners.block.PublisherSoapDesignRunner"/>
             <class name="org.wso2.am.integration.cucumbertests.runners.block.PublisherAPIRevisionsRunner"/>
+            <class name="org.wso2.am.integration.cucumbertests.runners.block.PublisherApiProductsRunner"/>
         </classes>
     </test>
     <!-- DevPortal features share their own container (separate capability, consumer-plane actors). -->
@@ -62,6 +63,22 @@
             <class name="org.wso2.am.integration.cucumbertests.runners.block.GatewayGraphQLScopeEnforcementRunner"/>
             <class name="org.wso2.am.integration.cucumbertests.runners.block.GatewayDefaultVersionRoutingRunner"/>
             <class name="org.wso2.am.integration.cucumbertests.runners.block.GatewayLifecycleStageInvocationRunner"/>
+            <class name="org.wso2.am.integration.cucumbertests.runners.block.GatewayApiProductInvocationRunner"/>
+            <class name="org.wso2.am.integration.cucumbertests.runners.block.GatewayGraphqlQueryLimitsRunner"/>
+            <class name="org.wso2.am.integration.cucumbertests.runners.block.GatewayGraphqlEndpointSecurityRunner"/>
+            <class name="org.wso2.am.integration.cucumbertests.runners.block.PublisherGraphqlFromUrlRunner"/>
+            <class name="org.wso2.am.integration.cucumbertests.runners.block.GatewayAiApiInvocationRunner"/>
+        </classes>
+    </test>
+    <!-- MCP servers span planes (publisher-plane CRUD + gateway-plane invocation) but share one backend-enabled
+         container: proxy create-validation and tool invocation both call the node mcp-server backend. -->
+    <test name="IntegrationV2-MCP" parallel="classes" thread-count="2">
+        <parameter name="blockLabel" value="mcp"/>
+        <parameter name="initTenantUsers" value="true"/>
+        <parameter name="initBackend" value="true"/>
+        <classes>
+            <class name="org.wso2.am.integration.cucumbertests.runners.block.PublisherMcpServersRunner"/>
+            <class name="org.wso2.am.integration.cucumbertests.runners.block.GatewayMcpInvocationRunner"/>
         </classes>
     </test>
     <!-- Key-manager features (token/key issuance). initBackend for the refresh/sandbox gateway invocations. -->
@@ -90,6 +107,20 @@
             <class name="org.wso2.am.integration.cucumbertests.runners.block.DevPortalApplicationSharingRunner"/>
         </classes>
     </test>
+    <!-- Custom application attributes: needs a feature-specific overlay (backend JWT generation + a declared
+         application attribute) and a backend (the header-reflecting /reflect-headers route) so the attribute
+         can be verified both stored and surfaced in the X-JWT-Assertion backend JWT claim. Its own block
+         because the overlay ([apim.jwt] enable, application_attributes required=true) is not orthogonal to
+         other blocks' config. -->
+    <test name="IntegrationV2-ApplicationAttributes" parallel="classes" thread-count="1">
+        <parameter name="blockLabel" value="application-attributes"/>
+        <parameter name="initTenantUsers" value="true"/>
+        <parameter name="initBackend" value="true"/>
+        <parameter name="tomlExtraOverlayPath" value="src/test/resources/artifacts/configFiles/applicationAttributes/deployment.toml"/>
+        <classes>
+            <class name="org.wso2.am.integration.cucumbertests.runners.block.DevPortalApplicationAttributesRunner"/>
+        </classes>
+    </test>
     <!-- Admin-plane governance/policy tests (default config, no gateway backend). Concurrent block. -->
     <test name="IntegrationV2-Admin" parallel="classes" thread-count="2">
         <parameter name="blockLabel" value="admin"/>
@@ -110,6 +141,16 @@
         <classes>
             <class name="org.wso2.am.integration.cucumbertests.runners.block.ServerRestartTokenPersistenceRunner"/>
             <class name="org.wso2.am.integration.cucumbertests.runners.block.ServerRestartSharedScopeRunner"/>
+        </classes>
+    </test>
+    <!-- Remote server logging (RemoteLoggingAppenderTest). MUST run sequentially (thread-count=1): it mutates
+         the shared server's log4j2.properties via the RemoteLoggingConfig admin service, so no sibling class may
+         share this container. A host mock sink receives the streamed logs via host.docker.internal. -->
+    <test name="IntegrationV2-RemoteLogging" parallel="classes" thread-count="1">
+        <parameter name="blockLabel" value="remote-logging"/>
+        <parameter name="initTenantUsers" value="true"/>
+        <classes>
+            <class name="org.wso2.am.integration.cucumbertests.runners.block.RemoteLoggingRunner"/>
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
## Description

This pull request introduces several enhancements and new capabilities to the integration test utilities and test containers for the APIM project, focusing on improved support for WebSocket and GraphQL testing, expanded capability mapping, and the addition of a mock MCP server for protocol testing. The main changes are organized below by theme.

**Capability Map & Test Coverage Expansion:**

* Added new features to the `capability-map.yml`, including MCP server authoring, schema validation, governance as a top-level capability, and enhanced DevPortal and Key Manager features. Also, clarified and expanded several feature descriptions. [[1]](diffhunk://#diff-2c58d78280c7745fb5bcccae3bd24bdfa86569609c3576eab7e0d60e9fd0332fL15-R15) [[2]](diffhunk://#diff-2c58d78280c7745fb5bcccae3bd24bdfa86569609c3576eab7e0d60e9fd0332fR29-R36) [[3]](diffhunk://#diff-2c58d78280c7745fb5bcccae3bd24bdfa86569609c3576eab7e0d60e9fd0332fR58-R88) [[4]](diffhunk://#diff-2c58d78280c7745fb5bcccae3bd24bdfa86569609c3576eab7e0d60e9fd0332fR99)

**WebSocket & GraphQL Test Support:**

* Added constants and container port exposure for WebSocket (`ws://`) and secure WebSocket (`wss://`) gateway ports, with corresponding utility methods in `DynamicApimContainer` to retrieve their URLs and the gateway client IP for testing. [[1]](diffhunk://#diff-8be31966cd5c3c7bba2695c3d28a03a039265c4c98c7012e82906674be501343R55-R58) [[2]](diffhunk://#diff-38b09ddd0948908f2aa2a201df4301fee4b84c82fa05189502d46b75633df8b7R57-R61) [[3]](diffhunk://#diff-38b09ddd0948908f2aa2a201df4301fee4b84c82fa05189502d46b75633df8b7R183-R231)
* Enhanced the GraphQL sample server to support introspection, SDL serving, secured endpoints, and GraphQL subscriptions via the `subscriptions-transport-ws` protocol, enabling more comprehensive gateway GraphQL API and subscription testing. [[1]](diffhunk://#diff-5708ecf47a9f84a2a3faba086fa5d238e18ce8d38779cc2b10872b4c4870b70fL10-R14) [[2]](diffhunk://#diff-5e28a5c03bdb5798b7daf2ce42db7043575f87b7d1cd388e0e348dcd78556f60R19-R22) [[3]](diffhunk://#diff-5e28a5c03bdb5798b7daf2ce42db7043575f87b7d1cd388e0e348dcd78556f60L28-R99)

**Mock MCP Server Integration:**

* Added a new `mcp-server` Node.js app (using the official `@modelcontextprotocol/sdk`) with Dockerfile and PM2 ecosystem integration for use in gateway MCP proxy tests. [[1]](diffhunk://#diff-fe6aa8dd4ae1c62d32ab1bd7fae58a5cb93f5bc30dc8572b7a1644c25e0aae79R30-R38) [[2]](diffhunk://#diff-fe6aa8dd4ae1c62d32ab1bd7fae58a5cb93f5bc30dc8572b7a1644c25e0aae79R65) [[3]](diffhunk://#diff-1dffc1c39ecb42db30da4b9d7104255fa3522844c40010017608480833902686R162-R169) [[4]](diffhunk://#diff-013fbc958d97c08fb747f1aba69f889368ed6bfcc6450e7fc32ebc9557e2b936R1-R11)

**Test Utility Improvements:**

* Introduced constants for new API product, environment, governance, and key manager ID tracking in `Constants.java`, and added the default governance API path. [[1]](diffhunk://#diff-8be31966cd5c3c7bba2695c3d28a03a039265c4c98c7012e82906674be501343R102) [[2]](diffhunk://#diff-8be31966cd5c3c7bba2695c3d28a03a039265c4c98c7012e82906674be501343R142-R147)

These changes collectively improve the test infrastructure to cover new APIM features, better simulate real-world scenarios (especially for GraphQL and MCP), and provide a more maintainable and extensible testbed for future development.