### PR TITLE
Add Configurations for Websocket Proxy Support

### DIFF
--- a/all-in-one-apim/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/axis2.xml.j2
+++ b/all-in-one-apim/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/axis2.xml.j2
@@ -471,6 +471,26 @@
              {% for name,value in transport.ws.sender.parameters.items() %}
                      <parameter name="{{name}}" locked="false">{{value}}</parameter>
               {% endfor %}
+        {% if transport.ws.proxy_profile is defined %}
+        <parameter name="ws.proxyProfiles">
+        {% for profile in transport.ws.proxy_profile %}
+            <profile>
+                <targetHosts>{% for hostitem in profile.target_hosts.toList() %}{{hostitem}}{% if loop.index < profile.target_hosts.toList()|length %},{% endif %}{% endfor %}</targetHosts>
+                <proxyHost>{{profile.proxy_host}}</proxyHost>
+                <proxyPort>{{profile.proxy_port}}</proxyPort>
+                {% if profile.proxy_username is defined %}
+                <proxyUserName>{{profile.proxy_username}}</proxyUserName>
+                {% endif %}
+                {% if profile.proxy_password is defined %}
+                <proxyPassword>{{profile.proxy_password}}</proxyPassword>
+                {% endif %}
+                {% if profile.bypass_hosts is defined %}
+                <bypass>{% for bypassitem in profile.bypass_hosts.toList() %}{{bypassitem}}{% if loop.index < profile.bypass_hosts.toList()|length %},{% endif %}{% endfor %}</bypass>
+                {% endif %}
+            </profile>
+        {% endfor %}
+        </parameter>
+        {% endif %}
     </transportSender>
 {%endif%}
 {%if transport.wss.sender.enable %}
@@ -482,6 +502,26 @@
             <ws.trust.store.location>{{transport.wss.sender.trust_store.location}}</ws.trust.store.location>
             <ws.trust.store.Password>{{transport.wss.sender.trust_store.password}}</ws.trust.store.Password>
         </parameter>
+        {% if transport.wss.proxy_profile is defined %}
+        <parameter name="ws.proxyProfiles">
+        {% for profile in transport.wss.proxy_profile %}
+            <profile>
+                <targetHosts>{% for hostitem in profile.target_hosts.toList() %}{{hostitem}}{% if loop.index < profile.target_hosts.toList()|length %},{% endif %}{% endfor %}</targetHosts>
+                <proxyHost>{{profile.proxy_host}}</proxyHost>
+                <proxyPort>{{profile.proxy_port}}</proxyPort>
+                {% if profile.proxy_username is defined %}
+                <proxyUserName>{{profile.proxy_username}}</proxyUserName>
+                {% endif %}
+                {% if profile.proxy_password is defined %}
+                <proxyPassword>{{profile.proxy_password}}</proxyPassword>
+                {% endif %}
+                {% if profile.bypass_hosts is defined %}
+                <bypass>{% for bypassitem in profile.bypass_hosts.toList() %}{{bypassitem}}{% if loop.index < profile.bypass_hosts.toList()|length %},{% endif %}{% endfor %}</bypass>
+                {% endif %}
+            </profile>
+        {% endfor %}
+        </parameter>
+        {% endif %}
     </transportSender>
 {%endif%}
 

--- a/gateway/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/axis2.xml.j2
+++ b/gateway/modules/distribution/product/src/main/resources/conf/templates/repository/conf/axis2/axis2.xml.j2
@@ -471,6 +471,26 @@
              {% for name,value in transport.ws.sender.parameters.items() %}
                      <parameter name="{{name}}" locked="false">{{value}}</parameter>
               {% endfor %}
+        {% if transport.ws.proxy_profile is defined %}
+        <parameter name="ws.proxyProfiles">
+        {% for profile in transport.ws.proxy_profile %}
+            <profile>
+                <targetHosts>{% for hostitem in profile.target_hosts.toList() %}{{hostitem}}{% if loop.index < profile.target_hosts.toList()|length %},{% endif %}{% endfor %}</targetHosts>
+                <proxyHost>{{profile.proxy_host}}</proxyHost>
+                <proxyPort>{{profile.proxy_port}}</proxyPort>
+                {% if profile.proxy_username is defined %}
+                <proxyUserName>{{profile.proxy_username}}</proxyUserName>
+                {% endif %}
+                {% if profile.proxy_password is defined %}
+                <proxyPassword>{{profile.proxy_password}}</proxyPassword>
+                {% endif %}
+                {% if profile.bypass_hosts is defined %}
+                <bypass>{% for bypassitem in profile.bypass_hosts.toList() %}{{bypassitem}}{% if loop.index < profile.bypass_hosts.toList()|length %},{% endif %}{% endfor %}</bypass>
+                {% endif %}
+            </profile>
+        {% endfor %}
+        </parameter>
+        {% endif %}
     </transportSender>
 {%endif%}
 {%if transport.wss.sender.enable %}
@@ -482,6 +502,26 @@
             <ws.trust.store.location>{{transport.wss.sender.trust_store.location}}</ws.trust.store.location>
             <ws.trust.store.Password>{{transport.wss.sender.trust_store.password}}</ws.trust.store.Password>
         </parameter>
+        {% if transport.wss.proxy_profile is defined %}
+        <parameter name="ws.proxyProfiles">
+        {% for profile in transport.wss.proxy_profile %}
+            <profile>
+                <targetHosts>{% for hostitem in profile.target_hosts.toList() %}{{hostitem}}{% if loop.index < profile.target_hosts.toList()|length %},{% endif %}{% endfor %}</targetHosts>
+                <proxyHost>{{profile.proxy_host}}</proxyHost>
+                <proxyPort>{{profile.proxy_port}}</proxyPort>
+                {% if profile.proxy_username is defined %}
+                <proxyUserName>{{profile.proxy_username}}</proxyUserName>
+                {% endif %}
+                {% if profile.proxy_password is defined %}
+                <proxyPassword>{{profile.proxy_password}}</proxyPassword>
+                {% endif %}
+                {% if profile.bypass_hosts is defined %}
+                <bypass>{% for bypassitem in profile.bypass_hosts.toList() %}{{bypassitem}}{% if loop.index < profile.bypass_hosts.toList()|length %},{% endif %}{% endfor %}</bypass>
+                {% endif %}
+            </profile>
+        {% endfor %}
+        </parameter>
+        {% endif %}
     </transportSender>
 {%endif%}
 


### PR DESCRIPTION
### Purpose
- Support for websocket proxy was provided via [1][2]. This PR adds the relevant configurations to the axis2.xml.j2 files
- Public Issue: https://github.com/wso2/api-manager/issues/5115

[1] https://github.com/wso2/carbon-mediation/pull/1833
[2] https://github.com/wso2/carbon-mediation/pull/1836