### PR TITLE
Adding Cucumber test for empty body requests with Content aware mediation

### DIFF
--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/runners/block/GatewayMediationPoliciesRunner.java
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/runners/block/GatewayMediationPoliciesRunner.java
@@ -21,8 +21,8 @@ import io.cucumber.testng.CucumberOptions;
 
 /**
  * Runner for gateway-plane mediation / operation-policy runtime behaviour (the port of the attach-and-invoke
- * slice of OperationPolicyTestCase, JWTClaimBasedAccessValidatorPolicyTestCase, ESBJAVA3380 jsonToXML and
- * ScriptMediatorTestCase). Runs in the backend-enabled IntegrationV2-Gateway block, which starts the header/body
+ * slice of OperationPolicyTestCase, JWTClaimBasedAccessValidatorPolicyTestCase, ESBJAVA3380 jsonToXML,
+ * ScriptMediatorTestCase and ContentAwareMediationPolicyEmptyBodyTestCase). Runs in the backend-enabled IntegrationV2-Gateway block, which starts the header/body
  * reflecting node backend; the per-scenario cleanup hook tears down the API/app/common-policy.
  */
 @CucumberOptions(

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/APIInvocationSteps.java
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/APIInvocationSteps.java
@@ -319,7 +319,7 @@ public class APIInvocationSteps {
             try {
                 String actualAccessToken = TestContext.resolve(accessToken).toString();
                 String actualPayload = (payload == null || payload.isEmpty())
-                        ? "" : TestContext.resolve(payload).toString();
+                        ? null : TestContext.resolve(payload).toString();
                 String endpointUrl = getBaseGatewayUrl()
                         + (resolvedContext.startsWith("/") ? "" : "/") + resolvedContext;
                 Map<String, String> headers = new HashMap<>();

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/artifacts/payloads/create_content_aware_empty_body_api.json
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/artifacts/payloads/create_content_aware_empty_body_api.json
@@ -1,0 +1,112 @@
+{
+  "name": "${UNIQUE:ContentAwareEmptyBody}",
+  "context": "${UNIQUE:contentAwareEmptyBody}",
+  "version": "1.0.0",
+  "endpointConfig": {
+    "endpoint_type": "http",
+    "production_endpoints": {
+      "template_not_supported": false,
+      "config": null,
+      "url": "http://nodebackend:3001/jaxrs_basic/services/customers/customerservice/"
+    },
+    "sandbox_endpoints": {
+      "url": "http://nodebackend:3001/jaxrs_basic/services/customers/customerservice/",
+      "config": null,
+      "template_not_supported": false
+    }
+  },
+  "description": "API for content-aware mediation empty-body regression — all verbs on /reflect-body",
+  "tags": [
+    "mediation"
+  ],
+  "policies": [
+    "Gold",
+    "Bronze",
+    "Unlimited"
+  ],
+  "operations": [
+    {
+      "verb": "GET",
+      "target": "/reflect-body",
+      "scopes": [],
+      "operationPolicies": {
+        "request": [
+          {
+            "policyName": "contentAwarePropertyPolicy",
+            "policyVersion": "v1",
+            "parameters": {}
+          }
+        ],
+        "response": [],
+        "fault": []
+      }
+    },
+    {
+      "verb": "POST",
+      "target": "/reflect-body",
+      "scopes": [],
+      "operationPolicies": {
+        "request": [
+          {
+            "policyName": "contentAwarePropertyPolicy",
+            "policyVersion": "v1",
+            "parameters": {}
+          }
+        ],
+        "response": [],
+        "fault": []
+      }
+    },
+    {
+      "verb": "PUT",
+      "target": "/reflect-body",
+      "scopes": [],
+      "operationPolicies": {
+        "request": [
+          {
+            "policyName": "contentAwarePropertyPolicy",
+            "policyVersion": "v1",
+            "parameters": {}
+          }
+        ],
+        "response": [],
+        "fault": []
+      }
+    },
+    {
+      "verb": "PATCH",
+      "target": "/reflect-body",
+      "scopes": [],
+      "operationPolicies": {
+        "request": [
+          {
+            "policyName": "contentAwarePropertyPolicy",
+            "policyVersion": "v1",
+            "parameters": {}
+          }
+        ],
+        "response": [],
+        "fault": []
+      }
+    },
+    {
+      "verb": "DELETE",
+      "target": "/reflect-body",
+      "scopes": [],
+      "operationPolicies": {
+        "request": [
+          {
+            "policyName": "contentAwarePropertyPolicy",
+            "policyVersion": "v1",
+            "parameters": {}
+          }
+        ],
+        "response": [],
+        "fault": []
+      }
+    }
+  ],
+  "isDefaultVersion": true,
+  "additionalProperties": [],
+  "additionalPropertiesMap": {}
+}

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/artifacts/payloads/policySpecFiles/content_aware_property_policy.j2
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/artifacts/payloads/policySpecFiles/content_aware_property_policy.j2
@@ -1,0 +1,3 @@
+<sequence xmlns="http://ws.apache.org/ns/synapse" name="contentAwarePropertyPolicy">
+    <property expression="json-eval($.password)" name="password" scope="default" type="STRING"/>
+</sequence>

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/artifacts/payloads/policySpecFiles/content_aware_property_policy.yaml
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/artifacts/payloads/policySpecFiles/content_aware_property_policy.yaml
@@ -1,0 +1,15 @@
+type: operation_policy_specification
+version: v4.5.0
+data:
+  category: Mediation
+  name: contentAwarePropertyPolicy
+  version: v1
+  displayName: Content Aware Property Policy
+  description: Adds a content-aware property using json-eval. Verifies that empty JSON body requests do not cause gateway errors when a content-aware mediator is applied.
+  applicableFlows:
+    - request
+  supportedGateways:
+    - Synapse
+  supportedApiTypes:
+    - HTTP
+  policyAttributes: []

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/features/gateway/mediation_policies.feature
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/features/gateway/mediation_policies.feature
@@ -362,3 +362,39 @@ Feature: Gateway Mediation Policies
       | actor             |
       | admin             |
       | admin@tenant1.com |
+
+  # Content-aware json-eval mediation: a request-flow operation policy that reads the JSON body must not produce a
+  # "Could not write JSON stream" gateway error when invoked with Content-Type: application/json and an empty
+  # request body (no entity) on GET, POST, PUT, PATCH, and DELETE. The /reflect-body backend echoes the request
+  # body so a gateway-side failure is observable in the response. Ports ContentAwareMediationPolicyEmptyBodyTestCase.
+  @cap:gateway @feat:mediation-policies @rule:content-aware-empty-body @type:regression @dep:publisher @legacy:ContentAwareMediationPolicyEmptyBodyTestCase
+  Scenario Outline: A content-aware json-eval policy does not error on empty-body <method> as <actor>
+    Given The system is ready
+    And I have valid access tokens as "<actor>"
+    And I create a new common policy with spec "artifacts/payloads/policySpecFiles/content_aware_property_policy.j2" and "artifacts/payloads/policySpecFiles/content_aware_property_policy.yaml" as "caPolicyId"
+    And I have created an api from "artifacts/payloads/create_content_aware_empty_body_api.json" as "caApiId" and deployed it
+    When I publish the "apis" resource with id "caApiId"
+    Then The lifecycle status of API "caApiId" should be "Published"
+    When I retrieve the "apis" resource with id "caApiId"
+    And I extract response field "context" and store it as "caContext"
+    When I have set up application with keys, subscribed to API "caApiId", and obtained access token for "caSubId"
+    Then The response status code should be 200
+
+    # Content-Type: application/json + empty body (no entity) — matches ContentAwareMediationPolicyEmptyBodyTestCase
+    When I invoke the API at gateway context "{{caContext}}/1.0.0/reflect-body" with method "<method>" using access token "generatedAccessToken" and payload "" with request header "Content-Type" set to "application/json" until response status code becomes 200 within 60 seconds
+    Then The response status code should be 200
+    And The response should not contain "Could not write JSON stream"
+    And The response should not contain "Runtime Error"
+
+    Examples:
+      | actor             | method |
+      | admin             | GET    |
+      | admin             | POST   |
+      | admin             | PUT    |
+      | admin             | PATCH  |
+      | admin             | DELETE |
+      | admin@tenant1.com | GET    |
+      | admin@tenant1.com | POST   |
+      | admin@tenant1.com | PUT    |
+      | admin@tenant1.com | PATCH  |
+      | admin@tenant1.com | DELETE |


### PR DESCRIPTION
## Purpose

This PR adds a cucumber test for POST/PUT/PATCH/GET/DELETE requests to validate that API invocation do not fail when requests contain:

- Content-Type: application/json
- an empty request body
- a content-aware Synapse mediator using json-eval(...)

## Related issues

- https://github.com/wso2/api-manager/issues/4826

## Related fix

- https://github.com/wso2/wso2-synapse/pull/2542