### PR TITLE
Add tests for token generation using authcode grant without requested scopes

### DIFF
--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/ApplicationBaseSteps.java
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/ApplicationBaseSteps.java
@@ -1460,6 +1460,135 @@ public class ApplicationBaseSteps {
         return java.net.URLEncoder.encode(value, java.nio.charset.StandardCharsets.UTF_8);
     }
 
+    @When("I request an OAuth access token via authorization code grant with scope {string}")
+    public void iRequestOAuthAccessTokenViaAuthCodeGrantWithScope(String scope) throws Exception {
+        performAuthCodeGrant(scope);
+    }
+
+    @When("I request an OAuth access token via authorization code grant without requesting any scopes")
+    public void iRequestOAuthAccessTokenViaAuthCodeGrantWithoutScope() throws Exception {
+        performAuthCodeGrant(null);
+    }
+
+    /**
+     * Executes the authorization-code flow and exchanges the code for a token.
+     *
+     * Handles both consent and no-consent flows by checking the login redirect:
+     * approves consent when {@code sessionDataKeyConsent} is present, or uses the code
+     * directly when returned. Fails on OAuth errors and stores the token response for
+     * further assertions.
+     *
+     * @param scope OAuth scope to include, or {@code null} to omit
+     */
+    private void performAuthCodeGrant(String scope) throws Exception {
+
+        String consumerKey = TestContext.resolve("consumerKey").toString();
+        String consumerSecret = TestContext.resolve("consumerSecret").toString();
+        User actor = Identity.actingActor();
+        String callbackUrl = "http://localhost:8490/callback";
+        String authorizeUrl = getBaseUrl() + "oauth2/authorize";
+
+        // Step 1: Initiate — get sessionDataKey and session cookie.
+        String initUrl = authorizeUrl + "?response_type=code"
+                + "&client_id=" + urlEncode(consumerKey)
+                + (scope != null ? "&scope=" + urlEncode(scope) : "")
+                + "&redirect_uri=" + urlEncode(callbackUrl);
+        System.out.println("initUrl: " + initUrl);
+        HttpResponse initResponse = SimpleHTTPClient.getInstance().doGet(initUrl, new HashMap<>());
+        System.out.println("initResponse: " + initResponse);
+
+        Assert.assertEquals(initResponse.getResponseCode(), 302,
+                "Expected 302 from authorize on initiation, got: " + initResponse.getResponseCode());
+        String locationHeader = initResponse.getHeaders().get("Location");
+        Assert.assertNotNull(locationHeader, "Location header missing on authorize initiation");
+        String sessionNonceCookie = initResponse.getHeaders().get("Set-Cookie");
+        Assert.assertNotNull(sessionNonceCookie, "Set-Cookie header missing on authorize initiation");
+        String sessionDataKey = extractQueryParam(locationHeader, "sessionDataKey");
+        Assert.assertNotNull(sessionDataKey,
+                "sessionDataKey not found in Location header: " + locationHeader);
+
+        // Step 2: Authenticate.
+        Map<String, String> loginHeaders = new HashMap<>();
+        loginHeaders.put("Cookie", sessionNonceCookie);
+        String loginBody = "username=" + urlEncode(actor.getUserName())
+                + "&password=" + urlEncode(actor.getPassword())
+                + "&tocommonauth=true"
+                + "&sessionDataKey=" + urlEncode(sessionDataKey);
+        HttpResponse loginResponse = SimpleHTTPClient.getInstance().doPost(
+                authorizeUrl, loginHeaders, loginBody,
+                Constants.CONTENT_TYPES.APPLICATION_X_WWW_FORM_URLENCODED);
+        Assert.assertEquals(loginResponse.getResponseCode(), 302,
+                "Expected 302 after login, got: " + loginResponse.getResponseCode());
+        locationHeader = loginResponse.getHeaders().get("Location");
+        System.out.println("location header: " + locationHeader);
+        Assert.assertNotNull(locationHeader, "Location header missing after login");
+
+        String oauthError = extractQueryParam(locationHeader, "error");
+        Assert.assertNull(oauthError,
+                "Authorization failed with error '" + oauthError + "': "
+                        + extractQueryParam(locationHeader, "error_description")
+                        + " — " + locationHeader);
+
+        // Step 3: approve consent when redirected to the consent page.
+        // When no scope is requested, consent page is skipped and code is available directly in the callback.
+        String authCode = extractQueryParam(locationHeader, "code");
+        System.out.println("authcode: " + authCode);
+
+        if (authCode == null) {
+            String sessionDataKeyConsent = extractQueryParam(locationHeader, "sessionDataKeyConsent");
+            Assert.assertNotNull(sessionDataKeyConsent,
+                    "Expected 'code' or 'sessionDataKeyConsent' in Location after login: "
+                            + locationHeader);
+
+            Map<String, String> consentHeaders = new HashMap<>();
+            consentHeaders.put("Cookie", sessionNonceCookie);
+            String consentBody = "consent=approve"
+                    + "&hasApprovedAlways=false"
+                    + "&sessionDataKeyConsent=" + urlEncode(sessionDataKeyConsent);
+            HttpResponse consentResponse = SimpleHTTPClient.getInstance().doPost(
+                    authorizeUrl, consentHeaders, consentBody,
+                    Constants.CONTENT_TYPES.APPLICATION_X_WWW_FORM_URLENCODED);
+            Assert.assertEquals(consentResponse.getResponseCode(), 302,
+                    "Expected 302 after consent approval, got: " + consentResponse.getResponseCode());
+            locationHeader = consentResponse.getHeaders().get("Location");
+            Assert.assertNotNull(locationHeader, "Location header missing after consent approval");
+            authCode = extractQueryParam(locationHeader, "code");
+            Assert.assertNotNull(authCode,
+                    "Auth code not found in Location after consent approval: " + locationHeader);
+        }
+
+        // Step 4: Exchange auth code for token.
+        String tokenBody = "grant_type=authorization_code"
+                + "&code=" + urlEncode(authCode)
+                + "&redirect_uri=" + urlEncode(callbackUrl)
+                + "&client_id=" + urlEncode(consumerKey)
+                + "&client_secret=" + urlEncode(consumerSecret);
+        HttpResponse tokenResponse = Requests.post(Utils.getAPIMTokenEndpointURL(getBaseUrl()),
+                new HashMap<>(), tokenBody, Constants.CONTENT_TYPES.APPLICATION_X_WWW_FORM_URLENCODED);
+        captureTokens(tokenResponse);
+    }
+
+    private static String extractQueryParam(String url, String paramName) {
+
+        try {
+            String query = new java.net.URI(url).getQuery();
+            if (query == null) {
+                return null;
+            }
+            for (String param : query.split("&")) {
+                int eq = param.indexOf('=');
+                if (eq >= 0) {
+                    String key = java.net.URLDecoder.decode(param.substring(0, eq), StandardCharsets.UTF_8);
+                    if (paramName.equals(key)) {
+                        return java.net.URLDecoder.decode(param.substring(eq + 1), StandardCharsets.UTF_8);
+                    }
+                }
+            }
+        } catch (Exception ignored) {
+        }
+        return null;
+    }
+
     /**
      * Revokes the given OAuth access token via the revocation endpoint, authenticated with the
      * application's client credentials. Stores the response in context.

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/ApplicationBaseSteps.java
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/stepdefinitions/ApplicationBaseSteps.java
@@ -1482,6 +1482,7 @@ public class ApplicationBaseSteps {
      */
     private void performAuthCodeGrant(String scope) throws Exception {
 
+        TestContext.remove("httpResponse");
         String consumerKey = TestContext.resolve("consumerKey").toString();
         String consumerSecret = TestContext.resolve("consumerSecret").toString();
         User actor = Identity.actingActor();

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/utils/clients/SimpleHTTPClient.java
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/java/org/wso2/am/integration/cucumbertests/utils/clients/SimpleHTTPClient.java
@@ -638,7 +638,12 @@ public class SimpleHTTPClient {
         Header[] headers = response.getAllHeaders();
         Map<String, String> heads = new HashMap<>();
         for (Header header : headers) {
-            heads.put(header.getName(), header.getValue());
+            String existing = heads.get(header.getName());
+            if (existing != null) {
+                heads.put(header.getName(), existing + "; " + header.getValue());
+            } else {
+                heads.put(header.getName(), header.getValue());
+            }
         }
         return new org.wso2.carbon.automation.test.utils.http.client.HttpResponse(
                 body, code, heads);

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/features/key-manager/token_issuance.feature
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/features/key-manager/token_issuance.feature
@@ -121,6 +121,54 @@ Feature: Key Manager Token Issuance
       | admin             |
       | admin@tenant1.com |
 
+  @cap:key-manager @feat:token-issuance @rule:authcode @type:regression @legacy:GrantTypeTokenGenerateTestCase
+  Scenario Outline: Generate an access token via authorization code grant as <actor>
+    Given The system is ready
+    And I have valid access tokens as "<actor>"
+    When I put JSON payload from file "artifacts/payloads/create_apim_test_app.json" in context as "createAppPayload"
+    And I create an application with payload "createAppPayload"
+    Then The response status code should be 201
+    When I put the following JSON payload in context as "authCodeKeysPayload"
+      """
+      {"keyType": "PRODUCTION", "grantTypesToBeSupported": ["client_credentials", "password", "authorization_code"], "callbackUrl": "http://localhost:8490/callback", "scopes": ["openid", "am_application_scope", "default"]}
+      """
+    And I generate client credentials for application id "createdAppId" with payload "authCodeKeysPayload"
+    Then The response status code should be 200
+    When I request an OAuth access token via authorization code grant with scope "PRODUCTION"
+    Then The response status code should be 200
+    And The generated access token should be in JWT format
+
+    Examples:
+      | actor             |
+      | admin             |
+      | admin@tenant1.com |
+
+  @cap:key-manager @feat:token-issuance @rule:authcode-default-scope @type:regression @legacy:JWTTestCase
+  Scenario Outline: Auth code grant without scope issues token with 'default' scope as <actor>
+    Given The system is ready
+    And I have valid access tokens as "<actor>"
+    When I put JSON payload from file "artifacts/payloads/create_apim_test_app.json" in context as "createAppPayload"
+    And I create an application with payload "createAppPayload"
+    Then The response status code should be 201
+    When I put the following JSON payload in context as "authCodeKeysPayload"
+      """
+      {"keyType": "PRODUCTION", "grantTypesToBeSupported": ["client_credentials", "password", "authorization_code"], "callbackUrl": "http://localhost:8490/callback", "scopes": ["default"]}
+      """
+    And I generate client credentials for application id "createdAppId" with payload "authCodeKeysPayload"
+    Then The response status code should be 200
+    When I request an OAuth access token via authorization code grant without requesting any scopes
+    Then The response status code should be 200
+    And I extract response field "scope" and store it as "tokenScope"
+    And the actual value of "tokenScope" should match the expected value:
+      """
+      default
+      """
+
+    Examples:
+      | actor             |
+      | admin             |
+      | admin@tenant1.com |
+
   @cap:key-manager @feat:token-issuance @rule:scope-in-token @type:regression @legacy:TokenEncryptionScopeTestCase
   Scenario Outline: A requested shared scope is granted in the issued token as <actor>
     Given The system is ready and I have valid publisher access tokens as "<actor>"


### PR DESCRIPTION
### Purpose

Adds testAuthCodeGrantWithoutScopeHasDefaultScope to JWTTestCase to verify that when an authorization code grant token request is made without requesting any scopes, the token is successfully generated with the internally assigned scope 'default'.

Since no scopes are requested, the Identity Server skips the consent page and redirects directly with the auth code after login.

Related to: https://github.com/wso2/api-manager/issues/5051