### PR TITLE
BROKEN LINKS: update legacy security documentation links

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,8 +8,8 @@
 
 ## Reporting Vulnerabilities
 
-WSO2 takes security issues very seriously. If you have any concerns regarding our product security or have uncovered a security vulnerability, we strongly encourage you to report that to our private and highly confidential security mailing list: security@wso2.com first, without disclosing them in any forums, sites or other groups - public or private. To protect the end-user security, these issues could be disclosed in other places only after WSO2 completes its [Vulnerability Management Process](https://docs.wso2.com/display/Security/WSO2+Security+Vulnerability+Management+Process).
+WSO2 takes security issues very seriously. If you have any concerns regarding our product security or have uncovered a security vulnerability, we strongly encourage you to report that to our private and highly confidential security mailing list: security@wso2.com first, without disclosing them in any forums, sites or other groups - public or private. To protect the end-user security, these issues could be disclosed in other places only after WSO2 completes its [Vulnerability Management Process](https://security.docs.wso2.com/en/latest/security-reporting/vulnerability-management-process/).
 
 **Warning** : Please do not create GitHub issues for security vulnerabilities.
 
-[WSO2 guidelines for reporting a security vulnerability](https://docs.wso2.com/display/Security/WSO2+Security+Vulnerability+Reporting+Guidelines) page describes how to report a Security Vulnerability and includes a public key if you wish to send secure messages to security@wso2.com
+[WSO2 guidelines for reporting a security vulnerability](https://security.docs.wso2.com/en/latest/security-reporting/vulnerability-reporting-guidelines/) page describes how to report a Security Vulnerability and includes a public key if you wish to send secure messages to security@wso2.com


### PR DESCRIPTION
### Purpose
Updates the legacy Confluence-based documentation links in `SECURITY.md` to point to the new WSO2 static documentation portal (`security.docs.wso2.com`). Previously, the old links redirected to a generic Atlassian login/spaces page. 
### Issues
N/A
### Release note
Update outdated security reporting documentation links in `SECURITY.md`.
### Documentation
No documentation impact. Current documentation covers the changes.
### Security checks
 - Followed [secure coding standards](http://wso2.com/technical-reports/wso2-secure-engineering-guidelines)? N/A (Docs only)
 - Verified `FindSecurityBugs` report? N/A
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? Yes