### PR TITLE
Add oauth.opaque.renew_token_without_revoking_existing to identity.xml.j2- #3879

### DIFF
--- a/all-in-one-apim/modules/distribution/product/src/main/resources/conf/templates/repository/conf/identity/identity.xml.j2
+++ b/all-in-one-apim/modules/distribution/product/src/main/resources/conf/templates/repository/conf/identity/identity.xml.j2
@@ -982,6 +982,22 @@
             </RenewTokenWithoutRevokingExisting>
         </JWT>
         {% endif %}
+
+        {% if oauth.opaque.renew_token_without_revoking_existing is defined %}
+        <Opaque>
+            <RenewTokenWithoutRevokingExisting>
+                <Enable>{{oauth.opaque.renew_token_without_revoking_existing.enable}}</Enable>
+                {% if oauth.opaque.renew_token_without_revoking_existing.allowed_grant_types is defined %}
+                <AllowedGrantTypes>
+                    {% for allowed_grant_type in oauth.opaque.renew_token_without_revoking_existing.allowed_grant_types %}
+                    <AllowedGrantType>{{allowed_grant_type}}</AllowedGrantType>
+                    {% endfor %}
+                </AllowedGrantTypes>
+                {% endif %}
+            </RenewTokenWithoutRevokingExisting>
+        </Opaque>
+        {% endif %}
+        
         <!--
             Disable this property to use the updated session-bound token behavior for OAuth tokens.
             Default value : true

--- a/api-control-plane/modules/distribution/product/src/main/resources/conf/templates/repository/conf/identity/identity.xml.j2
+++ b/api-control-plane/modules/distribution/product/src/main/resources/conf/templates/repository/conf/identity/identity.xml.j2
@@ -982,6 +982,22 @@
             </RenewTokenWithoutRevokingExisting>
         </JWT>
         {% endif %}
+
+        {% if oauth.opaque.renew_token_without_revoking_existing is defined %}
+        <Opaque>
+            <RenewTokenWithoutRevokingExisting>
+                <Enable>{{oauth.opaque.renew_token_without_revoking_existing.enable}}</Enable>
+                {% if oauth.opaque.renew_token_without_revoking_existing.allowed_grant_types is defined %}
+                <AllowedGrantTypes>
+                    {% for allowed_grant_type in oauth.opaque.renew_token_without_revoking_existing.allowed_grant_types %}
+                    <AllowedGrantType>{{allowed_grant_type}}</AllowedGrantType>
+                    {% endfor %}
+                </AllowedGrantTypes>
+                {% endif %}
+            </RenewTokenWithoutRevokingExisting>
+        </Opaque>
+        {% endif %}
+        
         <!--
             Disable this property to use the updated session-bound token behavior for OAuth tokens.
             Default value : true

--- a/gateway/modules/distribution/product/src/main/resources/conf/templates/repository/conf/identity/identity.xml.j2
+++ b/gateway/modules/distribution/product/src/main/resources/conf/templates/repository/conf/identity/identity.xml.j2
@@ -982,6 +982,22 @@
             </RenewTokenWithoutRevokingExisting>
         </JWT>
         {% endif %}
+
+                {% if oauth.opaque.renew_token_without_revoking_existing is defined %}
+        <Opaque>
+            <RenewTokenWithoutRevokingExisting>
+                <Enable>{{oauth.opaque.renew_token_without_revoking_existing.enable}}</Enable>
+                {% if oauth.opaque.renew_token_without_revoking_existing.allowed_grant_types is defined %}
+                <AllowedGrantTypes>
+                    {% for allowed_grant_type in oauth.opaque.renew_token_without_revoking_existing.allowed_grant_types %}
+                    <AllowedGrantType>{{allowed_grant_type}}</AllowedGrantType>
+                    {% endfor %}
+                </AllowedGrantTypes>
+                {% endif %}
+            </RenewTokenWithoutRevokingExisting>
+        </Opaque>
+        {% endif %}
+        
         <!--
             Disable this property to use the updated session-bound token behavior for OAuth tokens.
             Default value : true

--- a/traffic-manager/modules/distribution/product/src/main/resources/conf/templates/repository/conf/identity/identity.xml.j2
+++ b/traffic-manager/modules/distribution/product/src/main/resources/conf/templates/repository/conf/identity/identity.xml.j2
@@ -982,6 +982,22 @@
             </RenewTokenWithoutRevokingExisting>
         </JWT>
         {% endif %}
+
+                {% if oauth.opaque.renew_token_without_revoking_existing is defined %}
+        <Opaque>
+            <RenewTokenWithoutRevokingExisting>
+                <Enable>{{oauth.opaque.renew_token_without_revoking_existing.enable}}</Enable>
+                {% if oauth.opaque.renew_token_without_revoking_existing.allowed_grant_types is defined %}
+                <AllowedGrantTypes>
+                    {% for allowed_grant_type in oauth.opaque.renew_token_without_revoking_existing.allowed_grant_types %}
+                    <AllowedGrantType>{{allowed_grant_type}}</AllowedGrantType>
+                    {% endfor %}
+                </AllowedGrantTypes>
+                {% endif %}
+            </RenewTokenWithoutRevokingExisting>
+        </Opaque>
+        {% endif %}
+        
         <!--
             Disable this property to use the updated session-bound token behavior for OAuth tokens.
             Default value : true


### PR DESCRIPTION
Adds the block so that opaque token renewal without revoking existing tokens can be enabled via deployment.toml, with an optional allowed grant type list.

Resolves: https://github.com/wso2/api-manager/issues/5171