### PR TITLE
Add ServerCertificateAlias config

### DIFF
--- a/all-in-one-apim/modules/distribution/product/src/main/resources/conf/templates/repository/resources/security/listenerprofiles.xml.j2
+++ b/all-in-one-apim/modules/distribution/product/src/main/resources/conf/templates/repository/resources/security/listenerprofiles.xml.j2
@@ -25,6 +25,9 @@
             <Type>{{keystore.tls.type}}</Type>
             <Password>{{keystore.tls.password}}</Password>
             <KeyPassword>{{keystore.tls.key_password}}</KeyPassword>
+            {% if keystore.tls.server_certificate_alias is defined %}
+            <ServerCertificateAlias>{{keystore.tls.server_certificate_alias}}</ServerCertificateAlias>
+            {% endif %}
         </KeyStore>
         <TrustStore>
             <Location>repository/resources/security/{{truststore.file_name}}</Location>

--- a/api-control-plane/modules/distribution/product/src/main/resources/conf/templates/repository/resources/security/listenerprofiles.xml.j2
+++ b/api-control-plane/modules/distribution/product/src/main/resources/conf/templates/repository/resources/security/listenerprofiles.xml.j2
@@ -25,6 +25,9 @@
             <Type>{{keystore.tls.type}}</Type>
             <Password>{{keystore.tls.password}}</Password>
             <KeyPassword>{{keystore.tls.key_password}}</KeyPassword>
+            {% if keystore.tls.server_certificate_alias is defined %}
+            <ServerCertificateAlias>{{keystore.tls.server_certificate_alias}}</ServerCertificateAlias>
+            {% endif %}
         </KeyStore>
         <TrustStore>
             <Location>repository/resources/security/{{truststore.file_name}}</Location>

--- a/gateway/modules/distribution/product/src/main/resources/conf/templates/repository/resources/security/listenerprofiles.xml.j2
+++ b/gateway/modules/distribution/product/src/main/resources/conf/templates/repository/resources/security/listenerprofiles.xml.j2
@@ -25,6 +25,9 @@
             <Type>{{keystore.tls.type}}</Type>
             <Password>{{keystore.tls.password}}</Password>
             <KeyPassword>{{keystore.tls.key_password}}</KeyPassword>
+            {% if keystore.tls.server_certificate_alias is defined %}
+            <ServerCertificateAlias>{{keystore.tls.server_certificate_alias}}</ServerCertificateAlias>
+            {% endif %}
         </KeyStore>
         <TrustStore>
             <Location>repository/resources/security/{{truststore.file_name}}</Location>

--- a/traffic-manager/modules/distribution/product/src/main/resources/conf/templates/repository/resources/security/listenerprofiles.xml.j2
+++ b/traffic-manager/modules/distribution/product/src/main/resources/conf/templates/repository/resources/security/listenerprofiles.xml.j2
@@ -25,6 +25,9 @@
             <Type>{{keystore.tls.type}}</Type>
             <Password>{{keystore.tls.password}}</Password>
             <KeyPassword>{{keystore.tls.key_password}}</KeyPassword>
+            {% if keystore.tls.server_certificate_alias is defined %}
+            <ServerCertificateAlias>{{keystore.tls.server_certificate_alias}}</ServerCertificateAlias>
+            {% endif %}
         </KeyStore>
         <TrustStore>
             <Location>repository/resources/security/{{truststore.file_name}}</Location>


### PR DESCRIPTION
- Adds j2 support for below config

    ```
    [keystore.tls]
    server_certificate_alias =  "wso2carbon"
    ```

- Related synapse PR : https://github.com/wso2/wso2-synapse/pull/2429