### PR TITLE
Bump carbon.apimgt.version to 9.33.171 and align proxy MCP schema assertions

### DIFF
--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/features/publisher/mcp_servers.feature
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/features/publisher/mcp_servers.feature
@@ -41,12 +41,12 @@ Feature: MCP Server authoring (publisher plane)
     # schema would advertise a contract its own backend rejects, and the presence checks above would not notice.
     Then the MCP server "mcpId" tool "echo" should have schema definition:
       """
-      {"type":"object","properties":{"message":{"type":"string"}},"required":["message"]}
+      {"inputSchema":{"type":"object","properties":{"message":{"type":"string"}},"required":["message"]}}
       """
     And the MCP server "mcpId" tool "echo" should have description "Echoes the provided message"
     And the MCP server "mcpId" tool "add" should have schema definition:
       """
-      {"type":"object","properties":{"a":{"type":"number"},"b":{"type":"number"}},"required":["a","b"]}
+      {"inputSchema":{"type":"object","properties":{"a":{"type":"number"},"b":{"type":"number"}},"required":["a","b"]}}
       """
     And the MCP server "mcpId" tool "add" should have description "Adds two numbers"
     # UPDATE (REMOVE) — narrow back to echo,add; get_pets is dropped

--- a/all-in-one-apim/pom.xml
+++ b/all-in-one-apim/pom.xml
@@ -1311,7 +1311,7 @@
         <carbon.apimgt.ui.version>9.3.194</carbon.apimgt.ui.version>
 
         <!-- APIM Component Version -->
-        <carbon.apimgt.version>9.33.168</carbon.apimgt.version>
+        <carbon.apimgt.version>9.33.171</carbon.apimgt.version>
 
         <carbon.apimgt.imp.pkg.version>[9.0.0, 10.0.0)</carbon.apimgt.imp.pkg.version>
 


### PR DESCRIPTION
Bumps carbon.apimgt.version from 9.33.168 to 9.33.171 and updates the proxy MCP server CRUD test's expected tool schema to the wrapped form now returned by the runtime.