### PR TITLE
Update TenantDomainValidationTestCase to assert 404 response and message

### DIFF
--- a/all-in-one-apim/modules/distribution/product/src/main/assembly/filter.properties
+++ b/all-in-one-apim/modules/distribution/product/src/main/assembly/filter.properties
@@ -3,7 +3,7 @@ product.key=AM
 product.version=4.7.0
 product.wum.name=wso2am
 
-carbon.version=4.11.18
+carbon.version=4.11.20
 am.version=4.7.0
 default.server.role=APIManager
 bundle.creators=org.wso2.carbon.mediator.bridge.MediatorBundleCreator

--- a/all-in-one-apim/modules/integration-v2/docs/devs/coverage-tree.md
+++ b/all-in-one-apim/modules/integration-v2/docs/devs/coverage-tree.md
@@ -410,7 +410,7 @@ integration-v2 product tests
 │   │   ├── [load-balance] A load-balanced endpoint distributes requests across all backends as <actor>  (gateway/rest_invocation.feature:1065)
 │   │   ├── [load-balance] A load-balanced SANDBOX endpoint group round-robins across all sandbox members as <actor>  (gateway/rest_invocation.feature:1101)
 │   │   ├── [status-line] The gateway relays a backend's non-standard status reason phrase as <actor>  (gateway/rest_invocation.feature:1192)
-│   │   ├── [tenant-domain] A mis-cased tenant domain in the gateway path is rejected and leaves the tenant's routing intact  (gateway/rest_invocation.feature:1260)
+│   │   ├── [tenant-domain] A mis-cased tenant domain in the gateway path is rejected and leaves the tenant's routing intact  (gateway/rest_invocation.feature:1261)
 │   │   ├── [sandbox-gateway] A sandbox-only gateway accepts a sandbox token and rejects a production token as <actor>  (gateway/sandbox_gateway.feature:12)
 │   │   ├── [sandbox-gateway] An unsecured resource on a both-endpoints API serves the sandbox endpoint for either token on the sandbox gateway as <actor>  (gateway/sandbox_gateway.feature:77)
 │   │   ├── [sandbox-gateway] An unsecured resource on a sandbox-only API serves the sandbox endpoint for either token on the sandbox gateway as <actor>  (gateway/sandbox_gateway.feature:175)

--- a/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/features/gateway/rest_invocation.feature
+++ b/all-in-one-apim/modules/integration-v2/tests-integration/cucumber-tests/src/test/resources/features/gateway/rest_invocation.feature
@@ -1249,10 +1249,11 @@ Feature: Gateway REST API Invocation
       | admin@tenant1.com |
 
   # A tenant API is addressed at the gateway as /t/<domain>/<context>, and the domain is matched EXACTLY — so a
-  # mis-cased variant ("/t/Tenant1.com/") resolves to no tenant and the gateway rejects the call with a 500.
+  # mis-cased variant ("/t/Tenant1.com/") is rejected by the gateway with a 404 and a generic message, so that a
+  # probe cannot tell an existing tenant from a non-existent one.
   # The third leg is the actual subject: a failed tenant resolution must not poison tenant routing, so the
   # correctly-cased path must still serve the backend afterwards. Legs 1 and 2 are the control and the trigger.
-  # Ports TenantDomainValidationTestCase#testAPIInvokeWithTenants (valid 200, mis-cased 500, valid 200 again).
+  # Ports TenantDomainValidationTestCase#testAPIInvokeWithTenants (valid 200, mis-cased 404, valid 200 again).
   # Tenant-only, so a plain Scenario rather than the actor outline used above: a super-tenant API's context
   # carries no /t/ segment at all, so there is nothing to mis-case in the carbon.super row.
   # Subscribed on Unlimited (as the legacy did) so the three back-to-back invocations cannot hit a tier limit.
@@ -1279,8 +1280,9 @@ Feature: Gateway REST API Invocation
     # copied first so the correctly-cased value survives for leg 3 (the replace step rewrites in place).
     When I copy context value "tdvContext" to "tdvMisCasedContext"
     And I replace "/t/tenant1.com/" with "/t/Tenant1.com/" in context "tdvMisCasedContext"
-    And I invoke the API at gateway context "{{tdvMisCasedContext}}/1.0.0/customers/123/" with method "GET" using access token "generatedAccessToken" and payload "" until response status code becomes 500 within 60 seconds
-    Then The response status code should be 500
+    And I invoke the API at gateway context "{{tdvMisCasedContext}}/1.0.0/customers/123/" with method "GET" using access token "generatedAccessToken" and payload "" until response status code becomes 404 within 60 seconds
+    Then The response status code should be 404
+    And The response should contain "The requested resource is not available"
 
     # Leg 3 (the point) — the correctly-cased path still reaches the backend, so tenant routing was not poisoned
     When I invoke the API at gateway context "{{tdvContext}}/1.0.0/customers/123/" with method "GET" using access token "generatedAccessToken" and payload "" until response status code becomes 200 within 60 seconds

--- a/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/TenantDomainValidationTestCase.java
+++ b/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/TenantDomainValidationTestCase.java
@@ -84,13 +84,19 @@ public class TenantDomainValidationTestCase extends APIManagerLifecycleBaseTest 
             invalidTenantDomainCreated = true;
             fail("Tenant creation was expected to be rejected for the invalid domain " + INVALID_TENANT_DOMAIN
                     + ", but it succeeded.");
-        } catch (TenantMgtAdminServiceExceptionException e) {
-            // The generated stub instantiates this exception through its no-arg constructor, so getMessage() only
-            // ever returns the exception class name. The server's detail is carried in the fault message bean.
-            assertNotNull(e.getFaultMessage(), "Tenant creation fault carried no fault message.");
-            assertNotNull(e.getFaultMessage().getTenantMgtAdminServiceException(),
-                    "Tenant creation fault carried no exception detail.");
-            String faultMessage = e.getFaultMessage().getTenantMgtAdminServiceException().getMessage();
+        } catch (Exception e) {
+            // The rejection can surface two ways. When the stub maps the fault it throws the typed exception,
+            // built through its no-arg constructor, so getMessage() is only the class name and the server's text
+            // lives in the fault bean. Otherwise the fault travels as an AxisFault/RemoteException whose message
+            // IS the fault reason. Read whichever carries the detail rather than assuming one shape.
+            String faultMessage = e.getMessage();
+            if (e instanceof TenantMgtAdminServiceExceptionException) {
+                TenantMgtAdminServiceExceptionException fault = (TenantMgtAdminServiceExceptionException) e;
+                if (fault.getFaultMessage() != null
+                        && fault.getFaultMessage().getTenantMgtAdminServiceException() != null) {
+                    faultMessage = fault.getFaultMessage().getTenantMgtAdminServiceException().getMessage();
+                }
+            }
             assertTrue(faultMessage != null && faultMessage.contains(ILLEGAL_TENANT_DOMAIN_MESSAGE),
                     "Expected the message '" + ILLEGAL_TENANT_DOMAIN_MESSAGE + "' when creating a tenant with an "
                             + "invalid domain but received : " + faultMessage);

--- a/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/TenantDomainValidationTestCase.java
+++ b/all-in-one-apim/modules/integration/tests-integration/tests-backend/src/test/java/org/wso2/am/integration/tests/other/TenantDomainValidationTestCase.java
@@ -30,6 +30,7 @@ import org.wso2.am.integration.test.utils.bean.APIRequest;
 import org.wso2.am.integration.test.utils.base.APIManagerLifecycleBaseTest;
 import org.wso2.carbon.automation.test.utils.http.client.HttpRequestUtil;
 import org.wso2.carbon.automation.test.utils.http.client.HttpResponse;
+import org.wso2.carbon.tenant.mgt.stub.TenantMgtAdminServiceExceptionException;
 
 import java.net.URL;
 import java.util.ArrayList;
@@ -38,6 +39,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
@@ -52,11 +54,16 @@ public class TenantDomainValidationTestCase extends APIManagerLifecycleBaseTest 
     private final String TENANT_ADMIN_USER = TENANT_ADMIN_USERNAME + "@" + TENANT_DOMAIN;
     private final String API_CONTEXT = "testABC_API";
     private final String INVALID_TENANT_DOMAIN = "Abc.com";
+    private final String RESOURCE_NOT_AVAILABLE_MESSAGE = "The requested resource is not available";
+    private final String ILLEGAL_TENANT_DOMAIN_MESSAGE = "The tenant domain " + INVALID_TENANT_DOMAIN
+            + " contains one or more illegal characters. The valid characters are lowercase letters, "
+            + "numbers, '.', '-' and '_'.";
     private final String API_END_POINT_POSTFIX_URL = "jaxrs_basic/services/customers/customerservice/";
     private String apiProductionEndPointUrl;
     private String apiID;
     private String appID;
     private boolean invalidTenantDomainCreated;
+    private boolean tenantDomainCreated;
 
     @BeforeClass(alwaysRun = true)
     public void setEnvironment() throws Exception {
@@ -77,9 +84,16 @@ public class TenantDomainValidationTestCase extends APIManagerLifecycleBaseTest 
             invalidTenantDomainCreated = true;
             fail("Tenant creation was expected to be rejected for the invalid domain " + INVALID_TENANT_DOMAIN
                     + ", but it succeeded.");
-        } catch (Exception e) {
-            assertTrue(e.getMessage().contains("The tenant domain " + INVALID_TENANT_DOMAIN + " contains one or more illegal " +
-                            "characters. The valid characters are lowercase letters, numbers, '.', '-' and '_'."));
+        } catch (TenantMgtAdminServiceExceptionException e) {
+            // The generated stub instantiates this exception through its no-arg constructor, so getMessage() only
+            // ever returns the exception class name. The server's detail is carried in the fault message bean.
+            assertNotNull(e.getFaultMessage(), "Tenant creation fault carried no fault message.");
+            assertNotNull(e.getFaultMessage().getTenantMgtAdminServiceException(),
+                    "Tenant creation fault carried no exception detail.");
+            String faultMessage = e.getFaultMessage().getTenantMgtAdminServiceException().getMessage();
+            assertTrue(faultMessage != null && faultMessage.contains(ILLEGAL_TENANT_DOMAIN_MESSAGE),
+                    "Expected the message '" + ILLEGAL_TENANT_DOMAIN_MESSAGE + "' when creating a tenant with an "
+                            + "invalid domain but received : " + faultMessage);
         }
     }
 
@@ -89,6 +103,7 @@ public class TenantDomainValidationTestCase extends APIManagerLifecycleBaseTest 
 
         // Add a new tenant
         tenantManagementServiceClient.addTenant(TENANT_DOMAIN, TENANT_ADMIN_PASSWORD, TENANT_ADMIN_USERNAME, "demo");
+        tenantDomainCreated = true;
 
         restAPIPublisher = new RestAPIPublisherImpl(TENANT_ADMIN_USERNAME, TENANT_ADMIN_PASSWORD, TENANT_DOMAIN,
                 publisherURLHttps);
@@ -98,7 +113,7 @@ public class TenantDomainValidationTestCase extends APIManagerLifecycleBaseTest 
 
         //Create the Application and the API
         HttpResponse applicationResponse = restAPIStore.createApplication(APP_NAME,
-                "Test Application RevokeOneTimeToken", APIMIntegrationConstants.APPLICATION_TIER.UNLIMITED,
+                "Application to test tenant domain validation", APIMIntegrationConstants.APPLICATION_TIER.UNLIMITED,
                 ApplicationDTO.TokenTypeEnum.JWT);
         appID = applicationResponse.getData();
 
@@ -122,12 +137,11 @@ public class TenantDomainValidationTestCase extends APIManagerLifecycleBaseTest 
         List<String> grantTypes = new ArrayList<>();
         grantTypes.add("client_credentials");
         ArrayList<String> scopes = new ArrayList<>();
-        scopes.add("OTT");
 
         ApplicationKeyDTO applicationKeyDTO = restAPIStore
                 .generateKeys(appID, "3600", null,
                         ApplicationKeyGenerateRequestDTO.KeyTypeEnum.PRODUCTION, scopes, grantTypes);
-        assert applicationKeyDTO.getToken() != null;
+        assertNotNull(applicationKeyDTO.getToken(), "No token was issued for application " + APP_NAME);
         String accessToken = applicationKeyDTO.getToken().getAccessToken();
 
         // Invoke the API with a valid tenant domain
@@ -141,9 +155,12 @@ public class TenantDomainValidationTestCase extends APIManagerLifecycleBaseTest 
         gatewayUrl = gatewayUrlsWrk.getWebAppURLNhttp() + "t/" + INVALID_TENANT_DOMAIN + "/";
         response = invokeAPI(accessToken, gatewayUrl);
 
-        assertEquals(response.getResponseCode(), 500,
-                "Expected response code 500 but received " + response.getResponseCode() + " when invoking API with " +
+        assertEquals(response.getResponseCode(), 404,
+                "Expected response code 404 but received " + response.getResponseCode() + " when invoking API with " +
                         "invalid tenant domain");
+        assertTrue(response.getData().contains(RESOURCE_NOT_AVAILABLE_MESSAGE),
+                "Expected the message '" + RESOURCE_NOT_AVAILABLE_MESSAGE + "' when invoking API with invalid tenant " +
+                        "domain but received : " + response.getData());
 
         // Invoke the API with a valid tenant domain again to check nothing have broken
         gatewayUrl = gatewayUrlsWrk.getWebAppURLNhttp() + "t/" + TENANT_DOMAIN + "/";
@@ -175,7 +192,9 @@ public class TenantDomainValidationTestCase extends APIManagerLifecycleBaseTest 
         if (apiID != null) {
             restAPIPublisher.deleteAPI(apiID);
         }
-        tenantManagementServiceClient.deleteTenant(TENANT_DOMAIN);
+        if (tenantDomainCreated) {
+            tenantManagementServiceClient.deleteTenant(TENANT_DOMAIN);
+        }
         // Last, so a failure here cannot skip the cleanup above. Only reachable if domain validation regressed.
         if (invalidTenantDomainCreated) {
             tenantManagementServiceClient.deleteTenant(INVALID_TENANT_DOMAIN);

--- a/all-in-one-apim/modules/p2-profile/product/carbon.product
+++ b/all-in-one-apim/modules/p2-profile/product/carbon.product
@@ -2,7 +2,7 @@
 <?pde version="3.5"?>
 
 <product name="Carbon Product" uid="carbon.product.id" id="carbon.product" application="carbon.application"
-version="4.11.18" useFeatures="true" includeLaunchers="true">
+version="4.11.20" useFeatures="true" includeLaunchers="true">
 
    <configIni use="default">
    </configIni>
@@ -14,7 +14,7 @@ version="4.11.18" useFeatures="true" includeLaunchers="true">
    </plugins>
 
    <features>
-      <feature id="org.wso2.carbon.core.runtime" version="4.11.18"/>
+      <feature id="org.wso2.carbon.core.runtime" version="4.11.20"/>
    </features>
 
   <configurations>

--- a/all-in-one-apim/pom.xml
+++ b/all-in-one-apim/pom.xml
@@ -1324,7 +1324,7 @@
         <carbon.governance.version>4.9.7</carbon.governance.version>
 
         <!--carbon versions-->
-        <carbon.kernel.version>4.11.18</carbon.kernel.version>
+        <carbon.kernel.version>4.11.20</carbon.kernel.version>
 
         <cipher.tool.version>1.1.30</cipher.tool.version>
 

--- a/api-control-plane/modules/distribution/product/src/main/assembly/filter.properties
+++ b/api-control-plane/modules/distribution/product/src/main/assembly/filter.properties
@@ -3,7 +3,7 @@ product.key=ACP
 product.version=4.7.0
 product.wum.name=wso2am-acp
 
-carbon.version=4.11.18
+carbon.version=4.11.20
 am.version=4.7.0
 default.server.role=APIManager
 bundle.creators=org.wso2.carbon.mediator.bridge.MediatorBundleCreator

--- a/api-control-plane/modules/p2-profile/product/carbon.product
+++ b/api-control-plane/modules/p2-profile/product/carbon.product
@@ -2,7 +2,7 @@
 <?pde version="3.5"?>
 
 <product name="Carbon Product" uid="carbon.product.id" id="carbon.product" application="carbon.application"
-version="4.11.18" useFeatures="true" includeLaunchers="true">
+version="4.11.20" useFeatures="true" includeLaunchers="true">
 
    <configIni use="default">
    </configIni>
@@ -14,7 +14,7 @@ version="4.11.18" useFeatures="true" includeLaunchers="true">
    </plugins>
 
    <features>
-      <feature id="org.wso2.carbon.core.runtime" version="4.11.18"/>
+      <feature id="org.wso2.carbon.core.runtime" version="4.11.20"/>
    </features>
 
   <configurations>

--- a/api-control-plane/pom.xml
+++ b/api-control-plane/pom.xml
@@ -1298,7 +1298,7 @@
         <carbon.governance.version>4.9.7</carbon.governance.version>
 
         <!--carbon versions-->
-        <carbon.kernel.version>4.11.18</carbon.kernel.version>
+        <carbon.kernel.version>4.11.20</carbon.kernel.version>
 
         <cipher.tool.version>1.1.30</cipher.tool.version>
 

--- a/gateway/modules/distribution/product/src/main/assembly/filter.properties
+++ b/gateway/modules/distribution/product/src/main/assembly/filter.properties
@@ -3,7 +3,7 @@ product.key=APIM-GW
 product.version=4.7.0
 product.wum.name=wso2am-universal-gw
 
-carbon.version=4.11.18
+carbon.version=4.11.20
 am.version=4.7.0
 default.server.role=APIManager Gateway
 bundle.creators=org.wso2.carbon.mediator.bridge.MediatorBundleCreator

--- a/gateway/modules/p2-profile/product/carbon.product
+++ b/gateway/modules/p2-profile/product/carbon.product
@@ -2,7 +2,7 @@
 <?pde version="3.5"?>
 
 <product name="Carbon Product" uid="carbon.product.id" id="carbon.product" application="carbon.application"
-version="4.11.18" useFeatures="true" includeLaunchers="true">
+version="4.11.20" useFeatures="true" includeLaunchers="true">
 
    <configIni use="default">
    </configIni>
@@ -14,7 +14,7 @@ version="4.11.18" useFeatures="true" includeLaunchers="true">
    </plugins>
 
    <features>
-      <feature id="org.wso2.carbon.core.runtime" version="4.11.18"/>
+      <feature id="org.wso2.carbon.core.runtime" version="4.11.20"/>
    </features>
 
   <configurations>

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -1298,7 +1298,7 @@
         <carbon.governance.version>4.9.7</carbon.governance.version>
 
         <!--carbon versions-->
-        <carbon.kernel.version>4.11.18</carbon.kernel.version>
+        <carbon.kernel.version>4.11.20</carbon.kernel.version>
 
         <cipher.tool.version>1.1.30</cipher.tool.version>
 

--- a/traffic-manager/modules/distribution/product/src/main/assembly/filter.properties
+++ b/traffic-manager/modules/distribution/product/src/main/assembly/filter.properties
@@ -3,7 +3,7 @@ product.key=APIM-TM
 product.version=4.7.0
 product.wum.name=wso2am-tm
 
-carbon.version=4.11.18
+carbon.version=4.11.20
 am.version=4.7.0
 default.server.role=APIManager Traffic Manager
 bundle.creators=org.wso2.carbon.mediator.bridge.MediatorBundleCreator

--- a/traffic-manager/modules/p2-profile/product/carbon.product
+++ b/traffic-manager/modules/p2-profile/product/carbon.product
@@ -2,7 +2,7 @@
 <?pde version="3.5"?>
 
 <product name="Carbon Product" uid="carbon.product.id" id="carbon.product" application="carbon.application"
-version="4.11.18" useFeatures="true" includeLaunchers="true">
+version="4.11.20" useFeatures="true" includeLaunchers="true">
 
    <configIni use="default">
    </configIni>
@@ -14,7 +14,7 @@ version="4.11.18" useFeatures="true" includeLaunchers="true">
    </plugins>
 
    <features>
-      <feature id="org.wso2.carbon.core.runtime" version="4.11.18"/>
+      <feature id="org.wso2.carbon.core.runtime" version="4.11.20"/>
    </features>
 
   <configurations>

--- a/traffic-manager/pom.xml
+++ b/traffic-manager/pom.xml
@@ -1300,7 +1300,7 @@
         <carbon.governance.version>4.9.7</carbon.governance.version>
 
         <!--carbon versions-->
-        <carbon.kernel.version>4.11.18</carbon.kernel.version>
+        <carbon.kernel.version>4.11.20</carbon.kernel.version>
 
         <cipher.tool.version>1.1.30</cipher.tool.version>
 


### PR DESCRIPTION
### Purpose
Add test case for tenant domain validation for API requests
Upgraded the kernel version since the fix is available at kernel v4.11.20

### Related Fix
https://github.com/wso2/carbon-kernel/pull/4622